### PR TITLE
[no-release-notes] Rename SortField(s) to SortCondition(s)

### DIFF
--- a/memory/table.go
+++ b/memory/table.go
@@ -564,7 +564,7 @@ func (t *Table) PartitionRows(ctx *sql.Context, partition sql.Partition) (sql.Ro
 		// Assume only one partition for now
 		rows := data.partitions[string(data.partitionKeys[0])]
 
-		sf := sql.SortFields{
+		sc := sql.SortConditions{
 			{Expr: vectorPartition.OrderBy, Order: sql.Ascending},
 		}
 
@@ -573,10 +573,10 @@ func (t *Table) PartitionRows(ctx *sql.Context, partition sql.Partition) (sql.Ro
 			if err != nil {
 				return nil, err
 			}
-			return iters.NewTopRowsIter(sf, limit, vectorPartition.CalcFoundRows, sql.RowsToRowIter(rows...), 0), nil
+			return iters.NewTopRowsIter(sc, limit, vectorPartition.CalcFoundRows, sql.RowsToRowIter(rows...)), nil
 		}
 
-		return iters.NewSortIter(sf, sql.RowsToRowIter(rows...)), nil
+		return iters.NewSortIter(sc, sql.RowsToRowIter(rows...)), nil
 	}
 
 	rows, ok := data.partitions[string(partition.Key())]
@@ -1748,28 +1748,28 @@ func (t *IndexedTable) PartitionRows(ctx *sql.Context, partition sql.Partition) 
 
 	if t.Lookup.Index != nil {
 		idx := t.Lookup.Index.(*Index)
-		sf := make(sql.SortFields, len(idx.Exprs))
+		sc := make(sql.SortConditions, len(idx.Exprs))
 		for i, e := range idx.Exprs {
-			sf[i] = sql.SortCondition{Expr: e}
+			sc[i] = sql.SortCondition{Expr: e}
 			if t.Lookup.IsReverse {
-				sf[i].Order = sql.Descending
+				sc[i].Order = sql.Descending
 				// TODO: null ordering?
 			}
 		}
 		var sorter *expression.Sorter
 		if i, ok := iter.(*tableIter); ok {
 			sorter = &expression.Sorter{
-				SortFields: sf,
-				Rows:       i.rows,
-				LastError:  nil,
-				Ctx:        ctx,
+				SortConditions: sc,
+				Rows:           i.rows,
+				LastError:      nil,
+				Ctx:            ctx,
 			}
 		} else if i, ok := iter.(*spatialTableIter); ok {
 			sorter = &expression.Sorter{
-				SortFields: sf,
-				Rows:       i.rows,
-				LastError:  nil,
-				Ctx:        ctx,
+				SortConditions: sc,
+				Rows:           i.rows,
+				LastError:      nil,
+				Ctx:            ctx,
 			}
 		}
 

--- a/memory/table.go
+++ b/memory/table.go
@@ -565,7 +565,7 @@ func (t *Table) PartitionRows(ctx *sql.Context, partition sql.Partition) (sql.Ro
 		rows := data.partitions[string(data.partitionKeys[0])]
 
 		sf := sql.SortFields{
-			{Column: vectorPartition.OrderBy, Order: sql.Ascending},
+			{Expr: vectorPartition.OrderBy, Order: sql.Ascending},
 		}
 
 		if vectorPartition.Limit != nil {
@@ -1750,7 +1750,7 @@ func (t *IndexedTable) PartitionRows(ctx *sql.Context, partition sql.Partition) 
 		idx := t.Lookup.Index.(*Index)
 		sf := make(sql.SortFields, len(idx.Exprs))
 		for i, e := range idx.Exprs {
-			sf[i] = sql.SortCondition{Column: e}
+			sf[i] = sql.SortCondition{Expr: e}
 			if t.Lookup.IsReverse {
 				sf[i].Order = sql.Descending
 				// TODO: null ordering?

--- a/memory/table.go
+++ b/memory/table.go
@@ -1750,7 +1750,7 @@ func (t *IndexedTable) PartitionRows(ctx *sql.Context, partition sql.Partition) 
 		idx := t.Lookup.Index.(*Index)
 		sf := make(sql.SortFields, len(idx.Exprs))
 		for i, e := range idx.Exprs {
-			sf[i] = sql.SortField{Column: e}
+			sf[i] = sql.SortCondition{Column: e}
 			if t.Lookup.IsReverse {
 				sf[i].Order = sql.Descending
 				// TODO: null ordering?

--- a/sql/analyzer/replace_order_by_distance.go
+++ b/sql/analyzer/replace_order_by_distance.go
@@ -51,38 +51,38 @@ func replaceIdxOrderByDistanceHelper(ctx *sql.Context, scope *plan.Scope, node s
 		// We can safely do this because an expression that references other tables won't pass `isSortFieldsValidPrefix` below.
 		sortNode = offsetAssignIndexes(ctx, sortNode).(plan.Sortable)
 
-		sfExprs := normalizeExpressions(ctx, tableAliases, nil, sortNode.GetSortFields().ToExpressions()...)
-		sfAliases := aliasedExpressionsInNode(sortNode)
+		sortExprs := normalizeExpressions(ctx, tableAliases, nil, sortNode.GetSortConditions().ToExpressions()...)
+		sortAliases := aliasedExpressionsInNode(sortNode)
 
 		// TODO: Instead of checking both sides of the expression,
 		// use a previous pass to normalize distance functions so
 		// that the literal is always on the same side.
-		if len(sfExprs) != 1 {
+		if len(sortExprs) != 1 {
 			return n, transform.SameTree, nil
 		}
-		distance, isDistance := sfExprs[0].(*vector.Distance)
+		distance, isDistance := sortExprs[0].(*vector.Distance)
 		if !isDistance {
 			return n, transform.SameTree, nil
 		}
 
 		// We currently require that the query vector to the distance function is a constant value that does not
 		// depend on the row. Right now that can be a Literal or a UserVar.
-		isLiteral := func(expr sql.Expression) bool {
-			switch expr.(type) {
+		isLiteral := func(e sql.Expression) bool {
+			switch e.(type) {
 			case *expression.Literal, *expression.UserVar:
 				return true
 			}
 			return false
 		}
 
-		var column sql.Expression
+		var expr sql.Expression
 		var literal sql.Expression
 		if isLiteral(distance.LeftChild) {
-			column = distance.RightChild
+			expr = distance.RightChild
 			literal = distance.LeftChild
 		} else {
 			if isLiteral(distance.RightChild) {
-				column = distance.LeftChild
+				expr = distance.LeftChild
 				literal = distance.RightChild
 			} else {
 				return n, transform.SameTree, nil
@@ -96,7 +96,7 @@ func replaceIdxOrderByDistanceHelper(ctx *sql.Context, scope *plan.Scope, node s
 			if !idxCandidate.CanSupportOrderBy(distance) {
 				continue
 			}
-			if isSortFieldsValidPrefix([]sql.Expression{column}, sfAliases, idxCandidate.Expressions()) {
+			if sortExprsMatchIdxColExprs([]sql.Expression{expr}, sortAliases, idxCandidate.Expressions()) {
 				idx = idxCandidate
 				break
 			}

--- a/sql/analyzer/replace_sort.go
+++ b/sql/analyzer/replace_sort.go
@@ -421,8 +421,9 @@ func replaceAgg(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.Scope,
 			return nil, transform.SameTree, err
 		}
 
-		// TODO: A Limit wrapping a Sort gets transformed into a TopN node. This can likely be refactored into a TopN
-		//  node
+		// TODO: The analyzer rule insertTopNNodes replaces Limit nodes wrapping a Sort into TopN nodes. This rule
+		//  wouldn't be applied here since it's a Limit wrapping a Project wrapping a Sort, but this node could likely
+		//  be rewritten here to instead be a TopN node.
 		newProj := plan.NewProject(ctx, newProjs, plan.NewSort(sql.SortConditions{sortBy}, gb.Child))
 		limit := plan.NewLimit(expression.NewLiteral(1, types.Int64), newProj)
 		return limit, transform.NewTree, nil

--- a/sql/analyzer/replace_sort.go
+++ b/sql/analyzer/replace_sort.go
@@ -177,8 +177,8 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 			}
 			sortConditions := make(sql.SortFields, len(sortNode.SortFields))
 			sameSortConditions := true
-			for i, sortField := range sortNode.SortFields {
-				col, sameExpr, _ := transform.Expr(ctx, sortField.Column, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+			for i, sortCondition := range sortNode.SortFields {
+				col, sameExpr, _ := transform.Expr(ctx, sortCondition.Expr, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 					if gt, ok := e.(*expression.GetField); ok {
 						if gf, ok := c.ScopeMapping[gt.Id()]; ok {
 							return gf, transform.NewTree, nil
@@ -187,15 +187,15 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 					return e, transform.SameTree, nil
 				})
 				if sameExpr {
-					sortConditions[i] = sortField
+					sortConditions[i] = sortCondition
 				} else {
 					sameSortConditions = false
 					valCol, _ := col.(sql.ValueExpression)
 					sortConditions[i] = sql.SortCondition{
-						Column:          col,
+						Expr:            col,
 						ValueExprColumn: valCol,
-						NullOrdering:    sortField.NullOrdering,
-						Order:           sortField.Order,
+						NullOrdering:    sortCondition.NullOrdering,
+						Order:           sortCondition.Order,
 					}
 				}
 			}
@@ -388,8 +388,8 @@ func replaceAgg(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.Scope,
 				return n, transform.SameTree, nil
 			}
 			sortBy = sql.SortCondition{
-				Column: gf,
-				Order:  sql.Descending,
+				Expr:  gf,
+				Order: sql.Descending,
 			}
 		case *aggregation.Min:
 			gf, ok := agg.Child.(*expression.GetField)
@@ -397,8 +397,8 @@ func replaceAgg(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.Scope,
 				return n, transform.SameTree, nil
 			}
 			sortBy = sql.SortCondition{
-				Column: gf,
-				Order:  sql.Ascending,
+				Expr:  gf,
+				Order: sql.Ascending,
 			}
 		default:
 			return n, transform.SameTree, nil
@@ -407,7 +407,7 @@ func replaceAgg(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.Scope,
 		// since we're only supporting one aggregation, it must be on the first column of the primary key
 		if pkCols := pkIdx.Expressions(); len(pkCols) < 1 {
 			return n, transform.SameTree, nil
-		} else if !strings.EqualFold(pkCols[0], sortBy.Column.String()) {
+		} else if !strings.EqualFold(pkCols[0], sortBy.Expr.String()) {
 			return n, transform.SameTree, nil
 		}
 
@@ -415,7 +415,7 @@ func replaceAgg(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.Scope,
 		name := gb.SelectDeps[0].String()
 		newProjs, _, err := transform.Exprs(ctx, proj.Projections, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			if strings.EqualFold(e.String(), name) {
-				return sortBy.Column, transform.NewTree, nil
+				return sortBy.Expr, transform.NewTree, nil
 			}
 			return e, transform.SameTree, nil
 		})

--- a/sql/analyzer/replace_sort.go
+++ b/sql/analyzer/replace_sort.go
@@ -175,8 +175,8 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 			if sortNode == nil {
 				continue
 			}
-			sortFields := make([]sql.SortField, len(sortNode.SortFields))
-			sameSortFields := true
+			sortConditions := make(sql.SortFields, len(sortNode.SortFields))
+			sameSortConditions := true
 			for i, sortField := range sortNode.SortFields {
 				col, sameExpr, _ := transform.Expr(ctx, sortField.Column, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 					if gt, ok := e.(*expression.GetField); ok {
@@ -187,11 +187,11 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 					return e, transform.SameTree, nil
 				})
 				if sameExpr {
-					sortFields[i] = sortField
+					sortConditions[i] = sortField
 				} else {
-					sameSortFields = false
+					sameSortConditions = false
 					valCol, _ := col.(sql.ValueExpression)
-					sortFields[i] = sql.SortField{
+					sortConditions[i] = sql.SortCondition{
 						Column:          col,
 						ValueExprColumn: valCol,
 						NullOrdering:    sortField.NullOrdering,
@@ -199,10 +199,10 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 					}
 				}
 			}
-			if !sameSortFields {
+			if !sameSortConditions {
 				// The Sort node is used to find table aliases, but table aliases can't be found inside SubqueryAlias
 				// nodes, so we need to construct a new Sort node with the SubqueryAlias's child
-				newSort := plan.NewSort(sortFields, c.Child)
+				newSort := plan.NewSort(sortConditions, c.Child)
 				newChildren[i], same, err = replaceIdxSortHelper(ctx, scope, child, newSort)
 			}
 		case *plan.JoinNode:
@@ -379,15 +379,15 @@ func replaceAgg(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.Scope,
 			return n, transform.SameTree, nil
 		}
 
-		// generate sort fields from aggregations
-		var sf sql.SortField
+		// generate sort condition from aggregations
+		var sortBy sql.SortCondition
 		switch agg := gb.SelectDeps[0].(type) {
 		case *aggregation.Max:
 			gf, ok := agg.Child.(*expression.GetField)
 			if !ok {
 				return n, transform.SameTree, nil
 			}
-			sf = sql.SortField{
+			sortBy = sql.SortCondition{
 				Column: gf,
 				Order:  sql.Descending,
 			}
@@ -396,7 +396,7 @@ func replaceAgg(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.Scope,
 			if !ok {
 				return n, transform.SameTree, nil
 			}
-			sf = sql.SortField{
+			sortBy = sql.SortCondition{
 				Column: gf,
 				Order:  sql.Ascending,
 			}
@@ -407,7 +407,7 @@ func replaceAgg(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.Scope,
 		// since we're only supporting one aggregation, it must be on the first column of the primary key
 		if pkCols := pkIdx.Expressions(); len(pkCols) < 1 {
 			return n, transform.SameTree, nil
-		} else if !strings.EqualFold(pkCols[0], sf.Column.String()) {
+		} else if !strings.EqualFold(pkCols[0], sortBy.Column.String()) {
 			return n, transform.SameTree, nil
 		}
 
@@ -415,14 +415,17 @@ func replaceAgg(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.Scope,
 		name := gb.SelectDeps[0].String()
 		newProjs, _, err := transform.Exprs(ctx, proj.Projections, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			if strings.EqualFold(e.String(), name) {
-				return sf.Column, transform.NewTree, nil
+				return sortBy.Column, transform.NewTree, nil
 			}
 			return e, transform.SameTree, nil
 		})
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
-		newProj := plan.NewProject(ctx, newProjs, plan.NewSort(sql.SortFields{sf}, gb.Child))
+
+		// TODO: A Limit wrapping a Sort gets transformed into a TopN node. This can likely be refactored into a TopN
+		//  node
+		newProj := plan.NewProject(ctx, newProjs, plan.NewSort(sql.SortFields{sortBy}, gb.Child))
 		limit := plan.NewLimit(expression.NewLiteral(1, types.Int64), newProj)
 		return limit, transform.NewTree, nil
 	})

--- a/sql/analyzer/replace_sort.go
+++ b/sql/analyzer/replace_sort.go
@@ -20,7 +20,7 @@ func replaceIdxSort(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scope
 func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, sortNode *plan.Sort) (sql.Node, transform.TreeIdentity, error) {
 	switch n := node.(type) {
 	case *plan.Sort:
-		if isValidSortFieldOrder(n.SortFields) {
+		if isValidSortOrder(n.SortConditions) {
 			sortNode = n // lowest parent sort node
 		}
 	case *plan.IndexedTableAccess:
@@ -43,9 +43,9 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 		if err != nil {
 			return n, transform.SameTree, nil
 		}
-		sfExprs := normalizeExpressions(ctx, tableAliases, nil, sortNode.SortFields.ToExpressions()...)
-		sfAliases := aliasedExpressionsInNode(sortNode)
-		if !isSortFieldsValidPrefix(sfExprs, sfAliases, lookup.Index.Expressions()) {
+		sortExprs := normalizeExpressions(ctx, tableAliases, nil, sortNode.SortConditions.ToExpressions()...)
+		sortAliases := aliasedExpressionsInNode(sortNode)
+		if !sortExprsMatchIdxColExprs(sortExprs, sortAliases, lookup.Index.Expressions()) {
 			return n, transform.SameTree, nil
 		}
 		mysqlRanges, ok := lookup.Ranges.(sql.MySQLRangeCollection)
@@ -54,7 +54,7 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 		}
 		// if the resulting ranges are overlapping, we cannot drop the sort node
 		// it is possible we end up with blocks of rows that intersect
-		if hasOverlapping(ctx, sfExprs, mysqlRanges) {
+		if hasOverlapping(ctx, sortExprs, mysqlRanges) {
 			return n, transform.SameTree, nil
 		}
 
@@ -63,7 +63,7 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 			return n, transform.SameTree, nil
 		}
 
-		isReverse := sortNode.SortFields[0].Order == sql.Descending
+		isReverse := sortNode.SortConditions[0].Order == sql.Descending
 
 		// If the lookup does not need any reversing, use it and drop the sort node.
 		// Note that |NewTree| triggers replacement of the sort node captured above by the IndexedTableAccess in the
@@ -113,8 +113,8 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
-		sfExprs := normalizeExpressions(ctx, tableAliases, nil, sortNode.SortFields.ToExpressions()...)
-		sfAliases := aliasedExpressionsInNode(sortNode)
+		sortExprs := normalizeExpressions(ctx, tableAliases, nil, sortNode.SortConditions.ToExpressions()...)
+		sortAliases := aliasedExpressionsInNode(sortNode)
 		for _, idxCandidate := range idxs {
 			if idxCandidate.IsSpatial() {
 				continue
@@ -123,7 +123,7 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 				// TODO: It's possible that we may be able to use vector indexes for point lookups, but not range lookups
 				continue
 			}
-			if isSortFieldsValidPrefix(sfExprs, sfAliases, idxCandidate.Expressions()) {
+			if sortExprsMatchIdxColExprs(sortExprs, sortAliases, idxCandidate.Expressions()) {
 				idx = idxCandidate
 				break
 			}
@@ -137,7 +137,7 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
-		if sortNode.SortFields[0].Order == sql.Descending {
+		if sortNode.SortConditions[0].Order == sql.Descending {
 			lookup = sql.NewIndexLookup(
 				lookup.Index,
 				lookup.Ranges.(sql.MySQLRangeCollection),
@@ -175,9 +175,9 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 			if sortNode == nil {
 				continue
 			}
-			sortConditions := make(sql.SortFields, len(sortNode.SortFields))
+			sortConditions := make(sql.SortConditions, len(sortNode.SortConditions))
 			sameSortConditions := true
-			for i, sortCondition := range sortNode.SortFields {
+			for i, sortCondition := range sortNode.SortConditions {
 				expr, sameExpr, _ := transform.Expr(ctx, sortCondition.Expr, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 					if gt, ok := e.(*expression.GetField); ok {
 						if gf, ok := c.ScopeMapping[gt.Id()]; ok {
@@ -227,8 +227,8 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 			if !leftIsSorted && !rightIsSorted {
 				continue
 			}
-			// No need to check all SortField orders because of isValidSortFieldOrder
-			isReversed := sortNode.SortFields[0].Order == sql.Descending
+			// No need to check all SortCondition orders because of isValidSortOrder
+			isReversed := sortNode.SortConditions[0].Order == sql.Descending
 			// If both left and right have been replaced, no need to manually reverse any indexes as they both should be
 			// replaced already
 			if leftIsSorted && rightIsSorted {
@@ -423,40 +423,40 @@ func replaceAgg(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.Scope,
 
 		// TODO: A Limit wrapping a Sort gets transformed into a TopN node. This can likely be refactored into a TopN
 		//  node
-		newProj := plan.NewProject(ctx, newProjs, plan.NewSort(sql.SortFields{sortBy}, gb.Child))
+		newProj := plan.NewProject(ctx, newProjs, plan.NewSort(sql.SortConditions{sortBy}, gb.Child))
 		limit := plan.NewLimit(expression.NewLiteral(1, types.Int64), newProj)
 		return limit, transform.NewTree, nil
 	})
 }
 
-// isSortFieldsValidPrefix checks if the SortFields in sortNode are a valid prefix of the index columns
-func isSortFieldsValidPrefix(sfExprs []sql.Expression, sfAliases map[string]string, idxColExprs []string) bool {
-	if len(sfExprs) > len(idxColExprs) {
+// sortExprsMatchIdxColExprs checks if the SortCondition expressions in a Sort node match the index column expressions
+func sortExprsMatchIdxColExprs(sortExprs []sql.Expression, sortAliases map[string]string, idxColExprs []string) bool {
+	if len(sortExprs) > len(idxColExprs) {
 		return false
 	}
-	for i, fieldExpr := range sfExprs {
-		var fieldName string
-		if alias, ok := fieldExpr.(*expression.Alias); ok {
-			fieldName = alias.Child.String()
+	for i, sortExpr := range sortExprs {
+		var exprName string
+		if alias, ok := sortExpr.(*expression.Alias); ok {
+			exprName = alias.Child.String()
 		} else {
-			fieldName = fieldExpr.String()
+			exprName = sortExpr.String()
 		}
-		if alias, ok := sfAliases[strings.ToLower(idxColExprs[i])]; ok && alias == fieldName {
+		if alias, ok := sortAliases[strings.ToLower(idxColExprs[i])]; ok && alias == exprName {
 			continue
 		}
-		if !strings.EqualFold(idxColExprs[i], fieldName) {
+		if !strings.EqualFold(idxColExprs[i], exprName) {
 			return false
 		}
 	}
 	return true
 }
 
-// isValidSortFieldOrder checks if all the sortFields are in the same order
-func isValidSortFieldOrder(sfs sql.SortFields) bool {
-	for _, sf := range sfs {
+// isValidSortOrder checks if all the sortConditions are same order type
+func isValidSortOrder(scs sql.SortConditions) bool {
+	for _, sc := range scs {
 		// TODO: could generalize this to more monotonic expressions.
 		//   For example, order by x+1 is ok, but order by mod(x) is not
-		if sfs[0].Order != sf.Order {
+		if scs[0].Order != sc.Order {
 			return false
 		}
 	}

--- a/sql/analyzer/replace_sort.go
+++ b/sql/analyzer/replace_sort.go
@@ -178,7 +178,7 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 			sortConditions := make(sql.SortFields, len(sortNode.SortFields))
 			sameSortConditions := true
 			for i, sortCondition := range sortNode.SortFields {
-				col, sameExpr, _ := transform.Expr(ctx, sortCondition.Expr, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+				expr, sameExpr, _ := transform.Expr(ctx, sortCondition.Expr, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 					if gt, ok := e.(*expression.GetField); ok {
 						if gf, ok := c.ScopeMapping[gt.Id()]; ok {
 							return gf, transform.NewTree, nil
@@ -190,12 +190,10 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 					sortConditions[i] = sortCondition
 				} else {
 					sameSortConditions = false
-					valCol, _ := col.(sql.ValueExpression)
 					sortConditions[i] = sql.SortCondition{
-						Expr:            col,
-						ValueExprColumn: valCol,
-						NullOrdering:    sortCondition.NullOrdering,
-						Order:           sortCondition.Order,
+						Expr:         expr,
+						NullOrdering: sortCondition.NullOrdering,
+						Order:        sortCondition.Order,
 					}
 				}
 			}

--- a/sql/analyzer/topn.go
+++ b/sql/analyzer/topn.go
@@ -46,13 +46,13 @@ func insertTopNNodes(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 		var newNode sql.Node
 		var err error
 		if offset != nil {
-			newNode = plan.NewTopN(sort.SortFields, expression.NewPlus(limit.Limit, offset.Offset), sort.Child).WithCalcFoundRows(limit.CalcFoundRows)
+			newNode = plan.NewTopN(sort.SortConditions, expression.NewPlus(limit.Limit, offset.Offset), sort.Child).WithCalcFoundRows(limit.CalcFoundRows)
 			newNode, err = offset.WithChildren(ctx, newNode)
 			if err != nil {
 				return nil, transform.SameTree, err
 			}
 		} else {
-			newNode = plan.NewTopN(sort.SortFields, limit.Limit, sort.Child).WithCalcFoundRows(limit.CalcFoundRows)
+			newNode = plan.NewTopN(sort.SortConditions, limit.Limit, sort.Child).WithCalcFoundRows(limit.CalcFoundRows)
 		}
 		if proj != nil {
 			newNode, err = proj.WithChildren(ctx, newNode)

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -134,8 +134,8 @@ func validateOrderBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 
 	switch n := n.(type) {
 	case *plan.Sort:
-		for _, field := range n.SortFields {
-			switch field.Expr.(type) {
+		for _, cond := range n.SortConditions {
+			switch cond.Expr.(type) {
 			case sql.Aggregation:
 				return nil, transform.SameTree, analyzererrors.ErrValidationOrderBy.New()
 			}

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -127,6 +127,7 @@ func unresolvedError(ctx *sql.Context, n sql.Node) error {
 	return analyzererrors.ErrValidationResolved.New(n)
 }
 
+// TODO: why is this rule necessary? https://github.com/dolthub/dolt/issues/11309
 func validateOrderBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scope, sel RuleSelector, qFlags *sql.QueryFlags) (sql.Node, transform.TreeIdentity, error) {
 	span, ctx := ctx.Span("validate_order_by")
 	defer span.End()
@@ -134,7 +135,7 @@ func validateOrderBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 	switch n := n.(type) {
 	case *plan.Sort:
 		for _, field := range n.SortFields {
-			switch field.Column.(type) {
+			switch field.Expr.(type) {
 			case sql.Aggregation:
 				return nil, transform.SameTree, analyzererrors.ErrValidationOrderBy.New()
 			}

--- a/sql/analyzer/validation_rules_test.go
+++ b/sql/analyzer/validation_rules_test.go
@@ -53,7 +53,7 @@ func TestValidateOrderBy(t *testing.T) {
 	require.NoError(err)
 
 	_, _, err = vr.Apply(sql.NewEmptyContext(), nil, plan.NewSort(
-		[]sql.SortField{{Column: aggregation.NewCount(nil), Order: sql.Descending}},
+		[]sql.SortCondition{{Expr: aggregation.NewCount(nil), Order: sql.Descending}},
 		nil,
 	), nil, DefaultRuleSelector, nil)
 	require.Error(err)

--- a/sql/analyzer/vector_index_test.go
+++ b/sql/analyzer/vector_index_test.go
@@ -50,8 +50,8 @@ func vectorIndexTestCases(t *testing.T, db *memory.Database, table sql.IndexedTa
 		{
 			name: "without limit",
 			inputPlan: plan.NewSort(
-				sql.SortFields{
-					{Column: vector.NewDistance(sql.NewEmptyContext(), vector.DistanceL2Squared{}, jsonExpression(t, "[0.0, 0.0]"), expression.NewGetFieldWithTable(2, 1, types.JSON, "", "test-table", "v", false)), Order: sql.Ascending},
+				sql.SortConditions{
+					{Expr: vector.NewDistance(sql.NewEmptyContext(), vector.DistanceL2Squared{}, jsonExpression(t, "[0.0, 0.0]"), expression.NewGetFieldWithTable(2, 1, types.JSON, "", "test-table", "v", false)), Order: sql.Ascending},
 				}, plan.NewResolvedTable(table, db, nil)),
 			usesVectorIndex: false,
 			expectedRows: []sql.Row{
@@ -63,8 +63,8 @@ func vectorIndexTestCases(t *testing.T, db *memory.Database, table sql.IndexedTa
 		{
 			name: "with limit",
 			inputPlan: plan.NewTopN(
-				sql.SortFields{
-					{Column: vector.NewDistance(sql.NewEmptyContext(), vector.DistanceL2Squared{}, jsonExpression(t, "[0.0, 0.0]"), expression.NewGetFieldWithTable(2, 1, types.JSON, "", "test-table", "v", false)), Order: sql.Ascending},
+				sql.SortConditions{
+					{Expr: vector.NewDistance(sql.NewEmptyContext(), vector.DistanceL2Squared{}, jsonExpression(t, "[0.0, 0.0]"), expression.NewGetFieldWithTable(2, 1, types.JSON, "", "test-table", "v", false)), Order: sql.Ascending},
 				}, expression.NewLiteral(1, types.Int64), plan.NewResolvedTable(table, db, nil)),
 			usesVectorIndex: true,
 			expectedPlan: `

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -27,14 +27,14 @@ import (
 )
 
 type GroupConcat struct {
-	returnType  sql.Type
-	window      *sql.WindowDefinition
-	distinct    string
-	separator   string
-	selectExprs []sql.Expression
-	sf          sql.SortFields
-	maxLen      int
-	id          sql.ColumnId
+	returnType     sql.Type
+	window         *sql.WindowDefinition
+	distinct       string
+	separator      string
+	selectExprs    []sql.Expression
+	sortConditions sql.SortConditions
+	maxLen         int
+	id             sql.ColumnId
 }
 
 var _ sql.FunctionExpression = &GroupConcat{}
@@ -56,8 +56,13 @@ func (g *GroupConcat) Description() string {
 	return "returns a string result with the concatenated non-NULL values from a group."
 }
 
-func NewGroupConcat(distinct string, orderBy sql.SortFields, separator string, selectExprs []sql.Expression, maxLen int) *GroupConcat {
-	return &GroupConcat{distinct: distinct, sf: orderBy, separator: separator, selectExprs: selectExprs, maxLen: maxLen}
+func NewGroupConcat(distinct string, orderBy sql.SortConditions, separator string, selectExprs []sql.Expression, maxLen int) *GroupConcat {
+	return &GroupConcat{
+		distinct:       distinct,
+		sortConditions: orderBy,
+		separator:      separator,
+		selectExprs:    selectExprs,
+		maxLen:         maxLen}
 }
 
 // Id implements the Aggregation interface
@@ -113,10 +118,10 @@ func (g *GroupConcat) Resolved() bool {
 		}
 	}
 
-	sfs := g.sf.ToExpressions()
+	scs := g.sortConditions.ToExpressions()
 
-	for _, sf := range sfs {
-		if !sf.Resolved() {
+	for _, sc := range scs {
+		if !sc.Resolved() {
 			return false
 		}
 	}
@@ -140,9 +145,9 @@ func (g *GroupConcat) String() string {
 		sb.WriteString(strings.Join(exprs, ", "))
 	}
 
-	if len(g.sf) > 0 {
+	if len(g.sortConditions) > 0 {
 		sb.WriteString(" order by ")
-		for i, ob := range g.sf {
+		for i, ob := range g.sortConditions {
 			if i > 0 {
 				sb.WriteString(", ")
 			}
@@ -174,9 +179,9 @@ func (g *GroupConcat) DebugString(ctx *sql.Context) string {
 		sb.WriteString(strings.Join(exprs, ", "))
 	}
 
-	if len(g.sf) > 0 {
+	if len(g.sortConditions) > 0 {
 		sb.WriteString(" order by ")
-		for i, ob := range g.sf {
+		for i, ob := range g.sortConditions {
 			if i > 0 {
 				sb.WriteString(", ")
 			}
@@ -223,7 +228,7 @@ func (g *GroupConcat) IsNullable(ctx *sql.Context) bool {
 
 // Children implements the Expression interface.
 func (g *GroupConcat) Children() []sql.Expression {
-	return append(g.sf.ToExpressions(), g.selectExprs...)
+	return append(g.sortConditions.ToExpressions(), g.selectExprs...)
 }
 
 // WithChildren implements the Expression interface.
@@ -233,10 +238,10 @@ func (g *GroupConcat) WithChildren(ctx *sql.Context, children ...sql.Expression)
 	}
 
 	// Get the order by expression using the length of the sort fields.
-	sortFieldMarker := len(g.sf)
-	orderByExpr := children[:len(g.sf)]
+	sortFieldMarker := len(g.sortConditions)
+	orderByExpr := children[:len(g.sortConditions)]
 
-	return NewGroupConcat(g.distinct, g.sf.FromExpressions(ctx, orderByExpr...), g.separator, children[sortFieldMarker:], g.maxLen), nil
+	return NewGroupConcat(g.distinct, g.sortConditions.FromExpressions(ctx, orderByExpr...), g.separator, children[sortFieldMarker:], g.maxLen), nil
 }
 
 // OutputExpressions implements the OrderedAggregation interface.
@@ -332,11 +337,11 @@ func (g *groupConcatBuffer) Eval(ctx *sql.Context) (interface{}, error) {
 	}
 
 	// Execute the order operation if it exists.
-	if g.gc.sf != nil {
+	if g.gc.sortConditions != nil {
 		sorter := &expression.Sorter{
-			SortFields: g.gc.sf,
-			Rows:       rows,
-			Ctx:        ctx,
+			SortConditions: g.gc.sortConditions,
+			Rows:           rows,
+			Ctx:            ctx,
 		}
 
 		sort.Stable(sorter)

--- a/sql/expression/function/aggregation/group_concat_test.go
+++ b/sql/expression/function/aggregation/group_concat_test.go
@@ -36,12 +36,12 @@ func TestGroupConcat_FunctionName(t *testing.T) {
 
 	assert.Equal("group_concat(distinct field separator '-')", m.String())
 
-	sf := sql.SortFields{
-		{Column: expression.NewUnresolvedColumn("field"), Order: sql.Ascending},
-		{Column: expression.NewUnresolvedColumn("field2"), Order: sql.Descending},
+	sc := sql.SortConditions{
+		{Expr: expression.NewUnresolvedColumn("field"), Order: sql.Ascending},
+		{Expr: expression.NewUnresolvedColumn("field2"), Order: sql.Descending},
 	}
 
-	m = NewGroupConcat("field", sf, "-", nil, 1024)
+	m = NewGroupConcat("field", sc, "-", nil, 1024)
 
 	assert.Equal("group_concat(distinct field order by field ASC, field2 DESC separator '-')", m.String())
 }

--- a/sql/expression/function/aggregation/window_framer_test.go
+++ b/sql/expression/function/aggregation/window_framer_test.go
@@ -272,7 +272,7 @@ func TestWindowRangeFramers(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			ctx := sql.NewEmptyContext()
 			frameDef := dummyFrame{}
-			w := &sql.WindowDefinition{OrderBy: sql.SortFields{{Column: expr, Order: 1}}}
+			w := &sql.WindowDefinition{OrderBy: sql.SortConditions{{Expr: expr, Order: sql.Ascending}}}
 			framer, err := tt.Framer(frameDef, w)
 			require.NoError(t, err)
 

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -900,11 +900,11 @@ func (a *GroupConcatAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, 
 	}
 
 	// Execute the order operation if it exists.
-	if a.gc.sf != nil {
+	if a.gc.sortConditions != nil {
 		sorter := &expression.Sorter{
-			SortFields: a.gc.sf,
-			Rows:       rows,
-			Ctx:        ctx,
+			SortConditions: a.gc.sortConditions,
+			Rows:           rows,
+			Ctx:            ctx,
 		}
 
 		sort.Stable(sorter)

--- a/sql/expression/function/aggregation/window_iter_test.go
+++ b/sql/expression/function/aggregation/window_iter_test.go
@@ -30,13 +30,13 @@ var (
 	partitionByX = []sql.Expression{
 		expression.NewGetFieldWithTable(1, 0, types.Text, "mydb", "a", "x", false),
 	}
-	sortByW = sql.SortFields{{
-		Column: expression.NewGetFieldWithTable(0, 0, types.Int64, "mydb", "a", "w", false),
+	sortByW = sql.SortConditions{{
+		Expr: expression.NewGetFieldWithTable(0, 0, types.Int64, "mydb", "a", "w", false),
 	}}
-	sortByWDesc = sql.SortFields{
+	sortByWDesc = sql.SortConditions{
 		{
-			Column: expression.NewGetFieldWithTable(0, 0, types.Int64, "mydb", "a", "w", false),
-			Order:  sql.Descending,
+			Expr:  expression.NewGetFieldWithTable(0, 0, types.Int64, "mydb", "a", "w", false),
+			Order: sql.Descending,
 		},
 	}
 	lastX  = NewLastAgg(expression.NewGetField(1, types.Text, "x", true))

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -342,7 +342,7 @@ func (i *WindowPartitionIter) nextPartition(ctx *sql.Context) error {
 func partitionsToSortFields(partitionExprs []sql.Expression) sql.SortFields {
 	sfs := make(sql.SortFields, len(partitionExprs))
 	for i, expr := range partitionExprs {
-		sfs[i] = sql.SortField{
+		sfs[i] = sql.SortCondition{
 			Column: expr,
 			Order:  sql.Ascending,
 		}

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -57,11 +57,11 @@ func (a *Aggregation) startPartition(ctx *sql.Context, interval sql.WindowInterv
 // A WindowPartitionIter is used to evaluate a WindowPartition with a specific sql.RowIter.
 type WindowPartition struct {
 	PartitionBy []sql.Expression
-	SortBy      sql.SortFields
+	SortBy      sql.SortConditions
 	Aggs        []*Aggregation
 }
 
-func NewWindowPartition(partitionBy []sql.Expression, sortBy sql.SortFields, aggs []*Aggregation) *WindowPartition {
+func NewWindowPartition(partitionBy []sql.Expression, sortBy sql.SortConditions, aggs []*Aggregation) *WindowPartition {
 	return &WindowPartition{
 		PartitionBy: partitionBy,
 		SortBy:      sortBy,
@@ -179,9 +179,9 @@ func (i *WindowPartitionIter) materializeInput(ctx *sql.Context) (sql.WindowBuff
 
 	// sort all rows by partition
 	sorter := &expression.Sorter{
-		SortFields: append(partitionsToSortFields(i.w.PartitionBy), i.w.SortBy...),
-		Rows:       input,
-		Ctx:        ctx,
+		SortConditions: append(partitionsToSortConditions(i.w.PartitionBy), i.w.SortBy...),
+		Rows:           input,
+		Ctx:            ctx,
 	}
 	sort.Stable(sorter)
 
@@ -339,15 +339,15 @@ func (i *WindowPartitionIter) nextPartition(ctx *sql.Context) error {
 	return nil
 }
 
-func partitionsToSortFields(partitionExprs []sql.Expression) sql.SortFields {
-	sfs := make(sql.SortFields, len(partitionExprs))
+func partitionsToSortConditions(partitionExprs []sql.Expression) sql.SortConditions {
+	scs := make(sql.SortConditions, len(partitionExprs))
 	for i, expr := range partitionExprs {
-		sfs[i] = sql.SortCondition{
+		scs[i] = sql.SortCondition{
 			Expr:  expr,
 			Order: sql.Ascending,
 		}
 	}
-	return sfs
+	return scs
 }
 
 func isNewPartition(ctx *sql.Context, partitionBy []sql.Expression, last sql.Row, row sql.Row) (bool, error) {

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -343,8 +343,8 @@ func partitionsToSortFields(partitionExprs []sql.Expression) sql.SortFields {
 	sfs := make(sql.SortFields, len(partitionExprs))
 	for i, expr := range partitionExprs {
 		sfs[i] = sql.SortCondition{
-			Column: expr,
-			Order:  sql.Ascending,
+			Expr:  expr,
+			Order: sql.Ascending,
 		}
 	}
 	return sfs

--- a/sql/expression/sort.go
+++ b/sql/expression/sort.go
@@ -21,10 +21,10 @@ import (
 // Sorter is a sorter implementation for Row slices using SortFields for the comparison
 // TODO: Rename to RowSorter since this is used specifically for sorting Rows and is not a generic sorter.
 type Sorter struct {
-	LastError  error
-	Ctx        *sql.Context
-	SortFields sql.SortFields
-	Rows       []sql.Row
+	LastError      error
+	Ctx            *sql.Context
+	SortConditions sql.SortConditions
+	Rows           []sql.Row
 }
 
 // Len implements sort.Interface
@@ -39,29 +39,29 @@ func (s *Sorter) Swap(i, j int) {
 
 // CompareRows compares rows a and b based on s.SortFields
 func (s *Sorter) CompareRows(a, b sql.Row) int {
-	for _, sf := range s.SortFields {
-		typ := sf.Expr.Type(s.Ctx)
+	for _, sc := range s.SortConditions {
+		typ := sc.Expr.Type(s.Ctx)
 		// TODO: For complex SortFields, like Subqueries, recalculating the value may be costly. We should find some way
 		//  to cache it.
-		av, err := sf.Expr.Eval(s.Ctx, a)
+		av, err := sc.Expr.Eval(s.Ctx, a)
 		if err != nil {
 			s.LastError = sql.ErrUnableSort.Wrap(err)
 			return 0
 		}
-		bv, err := sf.Expr.Eval(s.Ctx, b)
+		bv, err := sc.Expr.Eval(s.Ctx, b)
 		if err != nil {
 			s.LastError = sql.ErrUnableSort.Wrap(err)
 			return 0
 		}
 
-		if sf.Order == sql.Descending {
+		if sc.Order == sql.Descending {
 			av, bv = bv, av
 		}
 
 		if av == nil && bv == nil {
 			continue
 		}
-		if sf.NullOrdering == sql.NullsFirst {
+		if sc.NullOrdering == sql.NullsFirst {
 			if av == nil {
 				return -1
 			}

--- a/sql/expression/sort.go
+++ b/sql/expression/sort.go
@@ -40,15 +40,15 @@ func (s *Sorter) Swap(i, j int) {
 // CompareRows compares rows a and b based on s.SortFields
 func (s *Sorter) CompareRows(a, b sql.Row) int {
 	for _, sf := range s.SortFields {
-		typ := sf.Column.Type(s.Ctx)
+		typ := sf.Expr.Type(s.Ctx)
 		// TODO: For complex SortFields, like Subqueries, recalculating the value may be costly. We should find some way
 		//  to cache it.
-		av, err := sf.Column.Eval(s.Ctx, a)
+		av, err := sf.Expr.Eval(s.Ctx, a)
 		if err != nil {
 			s.LastError = sql.ErrUnableSort.Wrap(err)
 			return 0
 		}
-		bv, err := sf.Column.Eval(s.Ctx, b)
+		bv, err := sf.Expr.Eval(s.Ctx, b)
 		if err != nil {
 			s.LastError = sql.ErrUnableSort.Wrap(err)
 			return 0

--- a/sql/expression/sort.go
+++ b/sql/expression/sort.go
@@ -23,7 +23,7 @@ import (
 type Sorter struct {
 	LastError  error
 	Ctx        *sql.Context
-	SortFields []sql.SortField
+	SortFields sql.SortFields
 	Rows       []sql.Row
 }
 

--- a/sql/iters/rel_iters.go
+++ b/sql/iters/rel_iters.go
@@ -390,19 +390,19 @@ func (li *LimitIter) Close(ctx *sql.Context) error {
 }
 
 type sortIter struct {
-	sortFields sql.SortFields
-	childIter  sql.RowIter
-	sortedRows []sql.Row
-	idx        int
+	sortConditions sql.SortConditions
+	childIter      sql.RowIter
+	sortedRows     []sql.Row
+	idx            int
 }
 
 var _ sql.RowIter = (*sortIter)(nil)
 
-func NewSortIter(s sql.SortFields, child sql.RowIter) *sortIter {
+func NewSortIter(s sql.SortConditions, child sql.RowIter) *sortIter {
 	return &sortIter{
-		sortFields: s,
-		childIter:  child,
-		idx:        -1,
+		sortConditions: s,
+		childIter:      child,
+		idx:            -1,
 	}
 }
 
@@ -449,10 +449,10 @@ func (i *sortIter) computeSortedRows(ctx *sql.Context) error {
 
 	rows := cache.Get()
 	sorter := &expression.Sorter{
-		SortFields: i.sortFields,
-		Rows:       rows,
-		LastError:  nil,
-		Ctx:        ctx,
+		SortConditions: i.sortConditions,
+		Rows:           rows,
+		LastError:      nil,
+		Ctx:            ctx,
 	}
 	sort.Stable(sorter)
 	if sorter.LastError != nil {

--- a/sql/iters/top_rows_iters.go
+++ b/sql/iters/top_rows_iters.go
@@ -25,24 +25,24 @@ import (
 // topRowsIter is defined by the topN node. It uses a heap to sort the rows of the child iterator and returns the top N
 // (defined by limit) rows
 type topRowsIter struct {
-	childIter     sql.RowIter
-	sortFields    sql.SortFields
-	topRows       []sql.Row
-	idx           int
-	limit         int64
-	numFoundRows  int64
-	calcFoundRows bool
+	childIter      sql.RowIter
+	sortConditions sql.SortConditions
+	topRows        []sql.Row
+	idx            int
+	limit          int64
+	numFoundRows   int64
+	calcFoundRows  bool
 }
 
 var _ sql.RowIter = (*topRowsIter)(nil)
 
-func NewTopRowsIter(s sql.SortFields, limit int64, calcFoundRows bool, child sql.RowIter, childSchemaLen int) *topRowsIter {
+func NewTopRowsIter(s sql.SortConditions, limit int64, calcFoundRows bool, child sql.RowIter) *topRowsIter {
 	return &topRowsIter{
-		sortFields:    s,
-		limit:         limit,
-		calcFoundRows: calcFoundRows,
-		childIter:     child,
-		idx:           -1,
+		sortConditions: s,
+		limit:          limit,
+		calcFoundRows:  calcFoundRows,
+		childIter:      child,
+		idx:            -1,
 	}
 }
 
@@ -75,10 +75,10 @@ func (i *topRowsIter) Close(ctx *sql.Context) error {
 func (i *topRowsIter) computeTopRows(ctx *sql.Context) error {
 	rowsHeap := &topRowsHeap{
 		Sorter: expression.Sorter{
-			SortFields: i.sortFields,
-			Rows:       make([]sql.Row, 0, i.limit+1),
-			LastError:  nil,
-			Ctx:        ctx,
+			SortConditions: i.sortConditions,
+			Rows:           make([]sql.Row, 0, i.limit+1),
+			LastError:      nil,
+			Ctx:            ctx,
 		},
 		order: make([]int64, 0, i.limit+1),
 	}
@@ -163,21 +163,21 @@ func (h *topRowsHeap) Pop() interface{} {
 // topRowIter is a special case of topRowsIter for when the limit is 1. Rather than using a heap to sort the rows of the
 // child iterator, it scans the rows for the first row.
 type topRowIter struct {
-	childIter     sql.RowIter
-	sortFields    sql.SortFields
-	topRow        sql.Row
-	numFoundRows  int64
-	calcFoundRows bool
-	once          bool
+	childIter      sql.RowIter
+	sortConditions sql.SortConditions
+	topRow         sql.Row
+	numFoundRows   int64
+	calcFoundRows  bool
+	once           bool
 }
 
 var _ sql.RowIter = (*topRowIter)(nil)
 
-func NewTopRowIter(s sql.SortFields, calcFoundRows bool, child sql.RowIter) *topRowIter {
+func NewTopRowIter(s sql.SortConditions, calcFoundRows bool, child sql.RowIter) *topRowIter {
 	return &topRowIter{
-		childIter:     child,
-		sortFields:    s,
-		calcFoundRows: calcFoundRows,
+		childIter:      child,
+		sortConditions: s,
+		calcFoundRows:  calcFoundRows,
 	}
 }
 
@@ -192,8 +192,8 @@ func (i *topRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 		return nil, err
 	}
 	sorter := expression.Sorter{
-		Ctx:        ctx,
-		SortFields: i.sortFields,
+		Ctx:            ctx,
+		SortConditions: i.sortConditions,
 	}
 	for {
 		var row sql.Row

--- a/sql/memo/exec_builder.go
+++ b/sql/memo/exec_builder.go
@@ -99,12 +99,12 @@ func (b *ExecBuilder) buildRangeHeap(ctx *sql.Context, sr *RangeHeap, children .
 			if err != nil {
 				return nil, err
 			}
-			sf := []sql.SortCondition{{
-				Column:       sortExpr,
+			sc := sql.SortFields{{
+				Expr:         sortExpr,
 				Order:        sql.Ascending,
 				NullOrdering: sql.NullsFirst,
 			}}
-			childNode = plan.NewSort(sf, n)
+			childNode = plan.NewSort(sc, n)
 		}
 
 		if err != nil {
@@ -134,12 +134,12 @@ func (b *ExecBuilder) buildRangeHeapJoin(ctx *sql.Context, j *RangeHeapJoin, chi
 		}
 	} else {
 		sortExpr := j.RangeHeap.ValueExpr
-		sf := []sql.SortCondition{{
-			Column:       sortExpr,
+		sc := sql.SortFields{{
+			Expr:         sortExpr,
 			Order:        sql.Ascending,
 			NullOrdering: sql.NullsFirst,
 		}}
-		left = plan.NewSort(sf, children[0])
+		left = plan.NewSort(sc, children[0])
 	}
 
 	right, err := b.buildRangeHeap(ctx, j.RangeHeap, children[1])

--- a/sql/memo/exec_builder.go
+++ b/sql/memo/exec_builder.go
@@ -99,7 +99,7 @@ func (b *ExecBuilder) buildRangeHeap(ctx *sql.Context, sr *RangeHeap, children .
 			if err != nil {
 				return nil, err
 			}
-			sf := []sql.SortField{{
+			sf := []sql.SortCondition{{
 				Column:       sortExpr,
 				Order:        sql.Ascending,
 				NullOrdering: sql.NullsFirst,
@@ -134,7 +134,7 @@ func (b *ExecBuilder) buildRangeHeapJoin(ctx *sql.Context, j *RangeHeapJoin, chi
 		}
 	} else {
 		sortExpr := j.RangeHeap.ValueExpr
-		sf := []sql.SortField{{
+		sf := []sql.SortCondition{{
 			Column:       sortExpr,
 			Order:        sql.Ascending,
 			NullOrdering: sql.NullsFirst,

--- a/sql/memo/exec_builder.go
+++ b/sql/memo/exec_builder.go
@@ -89,7 +89,7 @@ func (b *ExecBuilder) buildRangeHeap(ctx *sql.Context, sr *RangeHeap, children .
 		ret = plan.NewLimit(n.Limit, ret)
 	case *plan.Sort:
 		ret, err = b.buildRangeHeap(ctx, sr, n.Child)
-		ret = plan.NewSort(n.SortFields, ret)
+		ret = plan.NewSort(n.SortConditions, ret)
 	default:
 		var childNode sql.Node
 		if sr.MinIndex != nil {
@@ -99,7 +99,7 @@ func (b *ExecBuilder) buildRangeHeap(ctx *sql.Context, sr *RangeHeap, children .
 			if err != nil {
 				return nil, err
 			}
-			sc := sql.SortFields{{
+			sc := sql.SortConditions{{
 				Expr:         sortExpr,
 				Order:        sql.Ascending,
 				NullOrdering: sql.NullsFirst,
@@ -134,7 +134,7 @@ func (b *ExecBuilder) buildRangeHeapJoin(ctx *sql.Context, j *RangeHeapJoin, chi
 		}
 	} else {
 		sortExpr := j.RangeHeap.ValueExpr
-		sc := sql.SortFields{{
+		sc := sql.SortConditions{{
 			Expr:         sortExpr,
 			Order:        sql.Ascending,
 			NullOrdering: sql.NullsFirst,
@@ -249,7 +249,7 @@ func (b *ExecBuilder) buildIndexScan(ctx *sql.Context, i *IndexScan, children ..
 		ret = plan.NewLimit(n.Limit, ret)
 	case *plan.Sort:
 		ret, err = b.buildIndexScan(ctx, i, n.Child)
-		ret = plan.NewSort(n.SortFields, ret)
+		ret = plan.NewSort(n.SortConditions, ret)
 	default:
 		return nil, fmt.Errorf("unexpected *indexScan child: %T", n)
 	}

--- a/sql/memo/join_order_builder.go
+++ b/sql/memo/join_order_builder.go
@@ -218,7 +218,7 @@ func (j *joinOrderBuilder) populateSubgraph(ctx *sql.Context, n sql.Node) (verte
 		return j.buildProject(ctx, n)
 	case *plan.Sort:
 		_, _, group = j.populateSubgraph(ctx, n.Child)
-		group.RelProps.sort = n.SortFields
+		group.RelProps.sort = n.SortConditions
 	case *plan.Distinct:
 		_, _, group = j.populateSubgraph(ctx, n.Child)
 		group.RelProps.Distinct = HashDistinctOp

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -41,7 +41,7 @@ type relProps struct {
 	grp          *ExprGroup
 	fds          *sql.FuncDepSet
 	tableNodes   []plan.TableIdNode
-	sort         sql.SortFields
+	sort         sql.SortConditions
 	Distinct     distinctOp
 	DistinctOn   []sql.Expression
 }

--- a/sql/plan/recursive_cte.go
+++ b/sql/plan/recursive_cte.go
@@ -62,15 +62,15 @@ var _ sql.Expressioner = (*RecursiveCte)(nil)
 var _ sql.CollationCoercible = (*RecursiveCte)(nil)
 var _ TableIdNode = (*RecursiveCte)(nil)
 
-func NewRecursiveCte(initial, recursive sql.Node, name string, outputCols []string, deduplicate bool, l sql.Expression, sf sql.SortFields) *RecursiveCte {
+func NewRecursiveCte(initial, recursive sql.Node, name string, outputCols []string, deduplicate bool, l sql.Expression, sc sql.SortConditions) *RecursiveCte {
 	return &RecursiveCte{
 		ColumnNames: outputCols,
 		union: &SetOp{
-			SetOpType:  UnionType,
-			BinaryNode: BinaryNode{left: initial, right: recursive},
-			Distinct:   deduplicate,
-			Limit:      l,
-			SortFields: sf,
+			SetOpType:      UnionType,
+			BinaryNode:     BinaryNode{left: initial, right: recursive},
+			Distinct:       deduplicate,
+			Limit:          l,
+			SortConditions: sc,
 		},
 		name: name,
 	}

--- a/sql/plan/set_op.go
+++ b/sql/plan/set_op.go
@@ -124,7 +124,7 @@ func (s *SetOp) Resolved() bool {
 		res = res && s.Offset.Resolved()
 	}
 	for _, sf := range s.SortFields {
-		res = res && sf.Column.Resolved()
+		res = res && sf.Expr.Resolved()
 	}
 	return res
 }

--- a/sql/plan/set_op.go
+++ b/sql/plan/set_op.go
@@ -31,14 +31,14 @@ const (
 // SetOp is a node that returns everything in Left and then everything in Right
 type SetOp struct {
 	BinaryNode
-	Limit      sql.Expression
-	Offset     sql.Expression
-	cols       sql.ColSet
-	SortFields sql.SortFields
-	dispose    []sql.DisposeFunc
-	SetOpType  int
-	id         sql.TableId
-	Distinct   bool
+	Limit          sql.Expression
+	Offset         sql.Expression
+	cols           sql.ColSet
+	SortConditions sql.SortConditions
+	dispose        []sql.DisposeFunc
+	SetOpType      int
+	id             sql.TableId
+	Distinct       bool
 }
 
 var _ sql.Node = (*SetOp)(nil)
@@ -50,14 +50,14 @@ var _ sql.CollationCoercible = (*SetOp)(nil)
 var _ TableIdNode = (*SetOp)(nil)
 
 // NewSetOp creates a new SetOp node with the given children.
-func NewSetOp(setOpType int, left, right sql.Node, distinct bool, limit, offset sql.Expression, sortFields sql.SortFields) *SetOp {
+func NewSetOp(setOpType int, left, right sql.Node, distinct bool, limit, offset sql.Expression, sortConditions sql.SortConditions) *SetOp {
 	return &SetOp{
-		BinaryNode: BinaryNode{left: left, right: right},
-		Distinct:   distinct,
-		Limit:      limit,
-		Offset:     offset,
-		SortFields: sortFields,
-		SetOpType:  setOpType,
+		BinaryNode:     BinaryNode{left: left, right: right},
+		Distinct:       distinct,
+		Limit:          limit,
+		Offset:         offset,
+		SortConditions: sortConditions,
+		SetOpType:      setOpType,
 	}
 }
 
@@ -123,8 +123,8 @@ func (s *SetOp) Resolved() bool {
 	if s.Offset != nil {
 		res = res && s.Offset.Resolved()
 	}
-	for _, sf := range s.SortFields {
-		res = res && sf.Expr.Resolved()
+	for _, sc := range s.SortConditions {
+		res = res && sc.Expr.Resolved()
 	}
 	return res
 }
@@ -155,8 +155,8 @@ func (s *SetOp) Expressions() []sql.Expression {
 	if s.Offset != nil {
 		exprs = append(exprs, s.Offset)
 	}
-	if len(s.SortFields) > 0 {
-		exprs = append(exprs, s.SortFields.ToExpressions()...)
+	if len(s.SortConditions) > 0 {
+		exprs = append(exprs, s.SortConditions.ToExpressions()...)
 	}
 	return exprs
 }
@@ -169,7 +169,7 @@ func (s *SetOp) WithExpressions(ctx *sql.Context, exprs ...sql.Expression) (sql.
 	if s.Offset != nil {
 		expOff = 1
 	}
-	expSort = len(s.SortFields)
+	expSort = len(s.SortConditions)
 
 	if len(exprs) != expLim+expOff+expSort {
 		return nil, fmt.Errorf("expected %d limit and %d sort fields", expLim, expSort)
@@ -186,7 +186,7 @@ func (s *SetOp) WithExpressions(ctx *sql.Context, exprs ...sql.Expression) (sql.
 		ret.Offset = exprs[0]
 		exprs = exprs[1:]
 	}
-	ret.SortFields = s.SortFields.FromExpressions(ctx, exprs...)
+	ret.SortConditions = s.SortConditions.FromExpressions(ctx, exprs...)
 	return &ret, nil
 }
 
@@ -230,8 +230,8 @@ func (s *SetOp) String() string {
 		_ = pr.WriteNode("Except %s", distinct)
 	}
 	var children []string
-	if len(s.SortFields) > 0 {
-		children = append(children, fmt.Sprintf("sortFields: %s", s.SortFields.ToExpressions()))
+	if len(s.SortConditions) > 0 {
+		children = append(children, fmt.Sprintf("sortFields: %s", s.SortConditions.ToExpressions()))
 	}
 	if s.Limit != nil {
 		children = append(children, fmt.Sprintf("limit: %s", s.Limit))
@@ -265,9 +265,9 @@ func (s *SetOp) DebugString(ctx *sql.Context) string {
 		_ = pr.WriteNode("Except %s", distinct)
 	}
 	var children []string
-	if len(s.SortFields) > 0 {
-		sFields := make([]string, len(s.SortFields))
-		for i, e := range s.SortFields.ToExpressions() {
+	if len(s.SortConditions) > 0 {
+		sFields := make([]string, len(s.SortConditions))
+		for i, e := range s.SortConditions.ToExpressions() {
 			sFields[i] = sql.DebugString(ctx, e)
 		}
 		children = append(children, fmt.Sprintf("sortFields: %s", strings.Join(sFields, ", ")))

--- a/sql/plan/sort.go
+++ b/sql/plan/sort.go
@@ -23,20 +23,20 @@ import (
 
 type Sortable interface {
 	sql.Node
-	GetSortFields() sql.SortFields
+	GetSortConditions() sql.SortConditions
 }
 
 // Sort is the sort node.
 type Sort struct {
 	UnaryNode
-	SortFields sql.SortFields
+	SortConditions sql.SortConditions
 }
 
 // NewSort creates a new Sort node.
-func NewSort(sortFields sql.SortFields, child sql.Node) *Sort {
+func NewSort(sortConditions sql.SortConditions, child sql.Node) *Sort {
 	return &Sort{
-		UnaryNode:  UnaryNode{child},
-		SortFields: sortFields,
+		UnaryNode:      UnaryNode{child},
+		SortConditions: sortConditions,
 	}
 }
 
@@ -48,7 +48,7 @@ var _ sql.Describable = (*Sort)(nil)
 
 // Resolved implements the Resolvable interface.
 func (s *Sort) Resolved() bool {
-	for _, f := range s.SortFields {
+	for _, f := range s.SortConditions {
 		if !f.Expr.Resolved() {
 			return false
 		}
@@ -62,11 +62,11 @@ func (s *Sort) IsReadOnly() bool {
 
 func (s *Sort) String() string {
 	pr := sql.NewTreePrinter()
-	var fields = make([]string, len(s.SortFields))
-	for i, f := range s.SortFields {
-		fields[i] = fmt.Sprintf("%s %s", f.Expr, f.Order)
+	var conds = make([]string, len(s.SortConditions))
+	for i, c := range s.SortConditions {
+		conds[i] = fmt.Sprintf("%s %s", c.Expr, c.Order)
 	}
-	_ = pr.WriteNode("Sort(%s)", strings.Join(fields, ", "))
+	_ = pr.WriteNode("Sort(%s)", strings.Join(conds, ", "))
 	_ = pr.WriteChildren(s.Child.String())
 	return pr.String()
 }
@@ -74,22 +74,22 @@ func (s *Sort) String() string {
 // Describe implements the sql.Describable interface
 func (s *Sort) Describe(ctx *sql.Context, options sql.DescribeOptions) string {
 	pr := sql.NewTreePrinter()
-	var fields = make([]string, len(s.SortFields))
-	for i, f := range s.SortFields {
-		fields[i] = sql.Describe(ctx, f, options)
+	var conds = make([]string, len(s.SortConditions))
+	for i, c := range s.SortConditions {
+		conds[i] = sql.Describe(ctx, c, options)
 	}
-	_ = pr.WriteNode("Sort(%s)", strings.Join(fields, ", "))
+	_ = pr.WriteNode("Sort(%s)", strings.Join(conds, ", "))
 	_ = pr.WriteChildren(sql.Describe(ctx, s.Child, options))
 	return pr.String()
 }
 
 func (s *Sort) DebugString(ctx *sql.Context) string {
 	pr := sql.NewTreePrinter()
-	var fields = make([]string, len(s.SortFields))
-	for i, f := range s.SortFields {
-		fields[i] = sql.DebugString(ctx, f)
+	var conds = make([]string, len(s.SortConditions))
+	for i, f := range s.SortConditions {
+		conds[i] = sql.DebugString(ctx, f)
 	}
-	_ = pr.WriteNode("Sort(%s)", strings.Join(fields, ", "))
+	_ = pr.WriteNode("Sort(%s)", strings.Join(conds, ", "))
 	_ = pr.WriteChildren(sql.DebugString(ctx, s.Child))
 	return pr.String()
 }
@@ -97,11 +97,7 @@ func (s *Sort) DebugString(ctx *sql.Context) string {
 // Expressions implements the Expressioner interface.
 func (s *Sort) Expressions() []sql.Expression {
 	// TODO: use shared method
-	var exprs = make([]sql.Expression, len(s.SortFields))
-	for i, f := range s.SortFields {
-		exprs[i] = f.Expr
-	}
-	return exprs
+	return s.SortConditions.ToExpressions()
 }
 
 // WithChildren implements the Node interface.
@@ -110,7 +106,7 @@ func (s *Sort) WithChildren(ctx *sql.Context, children ...sql.Node) (sql.Node, e
 		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 1)
 	}
 
-	return NewSort(s.SortFields, children[0]), nil
+	return NewSort(s.SortConditions, children[0]), nil
 }
 
 // CollationCoercibility implements the interface sql.CollationCoercible.
@@ -120,43 +116,44 @@ func (s *Sort) CollationCoercibility(ctx *sql.Context) (collation sql.CollationI
 
 // WithExpressions implements the Expressioner interface.
 func (s *Sort) WithExpressions(ctx *sql.Context, exprs ...sql.Expression) (sql.Node, error) {
-	if len(exprs) != len(s.SortFields) {
-		return nil, sql.ErrInvalidChildrenNumber.New(s, len(exprs), len(s.SortFields))
+	if len(exprs) != len(s.SortConditions) {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(exprs), len(s.SortConditions))
 	}
 
-	fields := s.SortFields.FromExpressions(ctx, exprs...)
-	return NewSort(fields, s.Child), nil
+	conds := s.SortConditions.FromExpressions(ctx, exprs...)
+	return NewSort(conds, s.Child), nil
 }
 
-func (s *Sort) GetSortFields() sql.SortFields {
-	return s.SortFields
+func (s *Sort) GetSortConditions() sql.SortConditions {
+	return s.SortConditions
 }
 
 // TopN was a sort node that has a limit. It doesn't need to buffer everything,
 // but can calculate the top n on the fly.
 type TopN struct {
 	UnaryNode
-	Limit         sql.Expression
-	Fields        sql.SortFields
-	CalcFoundRows bool
+	Limit          sql.Expression
+	SortConditions sql.SortConditions
+	CalcFoundRows  bool
 }
 
 // NewTopN creates a new TopN node.
-func NewTopN(fields sql.SortFields, limit sql.Expression, child sql.Node) *TopN {
+func NewTopN(conds sql.SortConditions, limit sql.Expression, child sql.Node) *TopN {
 	return &TopN{
-		UnaryNode: UnaryNode{child},
-		Limit:     limit,
-		Fields:    fields,
+		UnaryNode:      UnaryNode{child},
+		Limit:          limit,
+		SortConditions: conds,
 	}
 }
 
 var _ sql.Node = (*TopN)(nil)
 var _ sql.Expressioner = (*TopN)(nil)
 var _ sql.CollationCoercible = (*TopN)(nil)
+var _ Sortable = (*TopN)(nil)
 
 // Resolved implements the Resolvable interface.
 func (n *TopN) Resolved() bool {
-	for _, f := range n.Fields {
+	for _, f := range n.SortConditions {
 		if !f.Expr.Resolved() {
 			return false
 		}
@@ -164,9 +161,9 @@ func (n *TopN) Resolved() bool {
 	return n.Child.Resolved()
 }
 
-func (n TopN) WithCalcFoundRows(v bool) *TopN {
+func (n *TopN) WithCalcFoundRows(v bool) *TopN {
 	n.CalcFoundRows = v
-	return &n
+	return n
 }
 
 func (n *TopN) IsReadOnly() bool {
@@ -175,22 +172,22 @@ func (n *TopN) IsReadOnly() bool {
 
 func (n *TopN) String() string {
 	pr := sql.NewTreePrinter()
-	var fields = make([]string, len(n.Fields))
-	for i, f := range n.Fields {
-		fields[i] = fmt.Sprintf("%s %s", f.Expr, f.Order)
+	var conds = make([]string, len(n.SortConditions))
+	for i, f := range n.SortConditions {
+		conds[i] = fmt.Sprintf("%s %s", f.Expr, f.Order)
 	}
-	_ = pr.WriteNode("TopN(Limit: [%s]; %s)", n.Limit.String(), strings.Join(fields, ", "))
+	_ = pr.WriteNode("TopN(Limit: [%s]; %s)", n.Limit.String(), strings.Join(conds, ", "))
 	_ = pr.WriteChildren(n.Child.String())
 	return pr.String()
 }
 
 func (n *TopN) DebugString(ctx *sql.Context) string {
 	pr := sql.NewTreePrinter()
-	var fields = make([]string, len(n.Fields))
-	for i, f := range n.Fields {
-		fields[i] = sql.DebugString(ctx, f)
+	var conds = make([]string, len(n.SortConditions))
+	for i, f := range n.SortConditions {
+		conds[i] = sql.DebugString(ctx, f)
 	}
-	_ = pr.WriteNode("TopN(Limit: [%s]; %s)", sql.DebugString(ctx, n.Limit), strings.Join(fields, ", "))
+	_ = pr.WriteNode("TopN(Limit: [%s]; %s)", sql.DebugString(ctx, n.Limit), strings.Join(conds, ", "))
 	_ = pr.WriteChildren(sql.DebugString(ctx, n.Child))
 	return pr.String()
 }
@@ -198,7 +195,7 @@ func (n *TopN) DebugString(ctx *sql.Context) string {
 // Expressions implements the Expressioner interface.
 func (n *TopN) Expressions() []sql.Expression {
 	exprs := []sql.Expression{n.Limit}
-	exprs = append(exprs, n.Fields.ToExpressions()...)
+	exprs = append(exprs, n.SortConditions.ToExpressions()...)
 	return exprs
 }
 
@@ -208,7 +205,7 @@ func (n *TopN) WithChildren(ctx *sql.Context, children ...sql.Node) (sql.Node, e
 		return nil, sql.ErrInvalidChildrenNumber.New(n, len(children), 1)
 	}
 
-	topn := NewTopN(n.Fields, n.Limit, children[0])
+	topn := NewTopN(n.SortConditions, n.Limit, children[0])
 	topn.CalcFoundRows = n.CalcFoundRows
 	return topn, nil
 }
@@ -220,18 +217,18 @@ func (n *TopN) CollationCoercibility(ctx *sql.Context) (collation sql.CollationI
 
 // WithExpressions implements the Expressioner interface.
 func (n *TopN) WithExpressions(ctx *sql.Context, exprs ...sql.Expression) (sql.Node, error) {
-	if len(exprs) != len(n.Fields)+1 {
-		return nil, sql.ErrInvalidChildrenNumber.New(n, len(exprs), len(n.Fields)+1)
+	if len(exprs) != len(n.SortConditions)+1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(n, len(exprs), len(n.SortConditions)+1)
 	}
 
 	var limit = exprs[0]
-	var fields = n.Fields.FromExpressions(ctx, exprs[1:]...)
+	var conds = n.SortConditions.FromExpressions(ctx, exprs[1:]...)
 
-	topn := NewTopN(fields, limit, n.Child)
+	topn := NewTopN(conds, limit, n.Child)
 	topn.CalcFoundRows = n.CalcFoundRows
 	return topn, nil
 }
 
-func (n *TopN) GetSortFields() sql.SortFields {
-	return n.Fields
+func (n *TopN) GetSortConditions() sql.SortConditions {
+	return n.SortConditions
 }

--- a/sql/plan/sort.go
+++ b/sql/plan/sort.go
@@ -49,7 +49,7 @@ var _ sql.Describable = (*Sort)(nil)
 // Resolved implements the Resolvable interface.
 func (s *Sort) Resolved() bool {
 	for _, f := range s.SortFields {
-		if !f.Column.Resolved() {
+		if !f.Expr.Resolved() {
 			return false
 		}
 	}
@@ -64,7 +64,7 @@ func (s *Sort) String() string {
 	pr := sql.NewTreePrinter()
 	var fields = make([]string, len(s.SortFields))
 	for i, f := range s.SortFields {
-		fields[i] = fmt.Sprintf("%s %s", f.Column, f.Order)
+		fields[i] = fmt.Sprintf("%s %s", f.Expr, f.Order)
 	}
 	_ = pr.WriteNode("Sort(%s)", strings.Join(fields, ", "))
 	_ = pr.WriteChildren(s.Child.String())
@@ -99,7 +99,7 @@ func (s *Sort) Expressions() []sql.Expression {
 	// TODO: use shared method
 	var exprs = make([]sql.Expression, len(s.SortFields))
 	for i, f := range s.SortFields {
-		exprs[i] = f.Column
+		exprs[i] = f.Expr
 	}
 	return exprs
 }
@@ -157,7 +157,7 @@ var _ sql.CollationCoercible = (*TopN)(nil)
 // Resolved implements the Resolvable interface.
 func (n *TopN) Resolved() bool {
 	for _, f := range n.Fields {
-		if !f.Column.Resolved() {
+		if !f.Expr.Resolved() {
 			return false
 		}
 	}
@@ -177,7 +177,7 @@ func (n *TopN) String() string {
 	pr := sql.NewTreePrinter()
 	var fields = make([]string, len(n.Fields))
 	for i, f := range n.Fields {
-		fields[i] = fmt.Sprintf("%s %s", f.Column, f.Order)
+		fields[i] = fmt.Sprintf("%s %s", f.Expr, f.Order)
 	}
 	_ = pr.WriteNode("TopN(Limit: [%s]; %s)", n.Limit.String(), strings.Join(fields, ", "))
 	_ = pr.WriteChildren(n.Child.String())

--- a/sql/plan/sort.go
+++ b/sql/plan/sort.go
@@ -96,7 +96,6 @@ func (s *Sort) DebugString(ctx *sql.Context) string {
 
 // Expressions implements the Expressioner interface.
 func (s *Sort) Expressions() []sql.Expression {
-	// TODO: use shared method
 	return s.SortConditions.ToExpressions()
 }
 
@@ -162,8 +161,9 @@ func (n *TopN) Resolved() bool {
 }
 
 func (n *TopN) WithCalcFoundRows(v bool) *TopN {
-	n.CalcFoundRows = v
-	return n
+	ret := *n
+	ret.CalcFoundRows = v
+	return &ret
 }
 
 func (n *TopN) IsReadOnly() bool {

--- a/sql/plan/sort.go
+++ b/sql/plan/sort.go
@@ -33,7 +33,7 @@ type Sort struct {
 }
 
 // NewSort creates a new Sort node.
-func NewSort(sortFields []sql.SortField, child sql.Node) *Sort {
+func NewSort(sortFields sql.SortFields, child sql.Node) *Sort {
 	return &Sort{
 		UnaryNode:  UnaryNode{child},
 		SortFields: sortFields,

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -485,22 +485,7 @@ func (b *Builder) buildGroupConcat(inScope *scope, e *ast.GroupConcatExpr) sql.E
 	}
 
 	orderByScope := b.analyzeOrderBy(inScope, inScope, e.OrderBy)
-	var sortFields sql.SortFields
-	for _, c := range orderByScope.cols {
-		so := sql.Ascending
-		if c.descending {
-			so = sql.Descending
-		}
-		scalar := c.scalar
-		if scalar == nil {
-			scalar = c.scalarGf()
-		}
-		sf := sql.SortField{
-			Column: scalar,
-			Order:  so,
-		}
-		sortFields = append(sortFields, sf)
-	}
+	sortConditions := b.buildSortConditions(orderByScope, doNotReplaceAlias)
 
 	// TODO: this should be acquired at runtime, not at parse time, so fix this
 	gcml, err := b.ctx.GetSessionVariable(b.ctx, "group_concat_max_len")
@@ -510,70 +495,13 @@ func (b *Builder) buildGroupConcat(inScope *scope, e *ast.GroupConcatExpr) sql.E
 	groupConcatMaxLen := gcml.(uint64)
 
 	// todo store ref to aggregate
-	agg := aggregation.NewGroupConcat(e.Distinct, sortFields, separatorS, args, int(groupConcatMaxLen))
+	agg := aggregation.NewGroupConcat(e.Distinct, sortConditions, separatorS, args, int(groupConcatMaxLen))
 	aggName := strings.ToLower(plan.AliasSubqueryString(b.ctx, agg))
 	col := scopeColumn{col: aggName, scalar: agg, typ: agg.Type(b.ctx), nullable: agg.IsNullable(b.ctx)}
 
 	id := gb.outScope.newColumn(col)
 
 	agg = agg.WithId(sql.ColumnId(id)).(*aggregation.GroupConcat)
-	gb.outScope.cols[len(gb.outScope.cols)-1].scalar = agg
-	col.scalar = agg
-
-	gb.addAggStr(col)
-	col.id = id
-	return col.scalarGf()
-}
-
-// buildOrderedInjectedExpr builds an InjectedExpr with an ORDER BY dependency
-func (b *Builder) buildOrderedInjectedExpr(inScope *scope, e *ast.OrderedInjectedExpr) sql.Expression {
-	inScope.initGroupBy()
-	gb := inScope.groupBy
-
-	var resolvedChildren []any
-	if len(e.Children) > 0 {
-		resolvedChildren = make([]any, len(e.Children))
-		for i, child := range e.Children {
-			resolvedChildren[i] = b.buildScalar(inScope, child)
-		}
-	} else {
-		resolvedChildren = make([]any, len(e.SelectExprChildren))
-		for i, child := range e.SelectExprChildren {
-			resolvedChildren[i] = b.selectExprToExpression(inScope, child)
-		}
-	}
-
-	orderByScope := b.analyzeOrderBy(inScope, inScope, e.OrderBy)
-	var sortFields sql.SortFields
-	for _, c := range orderByScope.cols {
-		so := sql.Ascending
-		if c.descending {
-			so = sql.Descending
-		}
-		scalar := c.scalar
-		if scalar == nil {
-			scalar = c.scalarGf()
-		}
-		sf := sql.SortField{
-			Column: scalar,
-			Order:  so,
-		}
-		sortFields = append(sortFields, sf)
-	}
-
-	resolvedChildren = append(resolvedChildren, sortFields)
-
-	expr := b.buildInjectedExpressionFromResolvedChildren(e.InjectedExpr, resolvedChildren)
-	agg, ok := expr.(sql.Aggregation)
-	if !ok {
-		b.handleErr(fmt.Errorf("expected sql.Aggregation, got %T", expr))
-	}
-
-	aggName := strings.ToLower(plan.AliasSubqueryString(b.ctx, agg))
-	col := scopeColumn{col: aggName, scalar: agg, typ: agg.Type(b.ctx), nullable: agg.IsNullable(b.ctx)}
-	id := gb.outScope.newColumn(col)
-
-	agg = agg.WithId(sql.ColumnId(id)).(sql.Aggregation)
 	gb.outScope.cols[len(gb.outScope.cols)-1].scalar = agg
 	col.scalar = agg
 
@@ -763,19 +691,19 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 		return nil
 	}
 
-	var sortFields sql.SortFields
-	for _, c := range def.OrderBy {
+	// TODO: We might be able to reuse b.buildSortConditions with some refactoring
+	sortConditions := make(sql.SortFields, len(def.OrderBy))
+	for i, c := range def.OrderBy {
 		// resolve col in fromScope
 		e := b.buildScalar(fromScope, c.Expr)
 		so := sql.Ascending
 		if c.Direction == ast.DescScr {
 			so = sql.Descending
 		}
-		sf := sql.SortField{
+		sortConditions[i] = sql.SortCondition{
 			Column: e,
 			Order:  so,
 		}
-		sortFields = append(sortFields, sf)
 	}
 
 	partitions := make([]sql.Expression, len(def.PartitionBy))
@@ -785,7 +713,7 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 
 	frame := b.NewFrame(fromScope, def.Frame)
 
-	windowDef := sql.NewWindowDefinition(partitions, sortFields, frame, def.NameRef.Lowered(), def.Name.Lowered())
+	windowDef := sql.NewWindowDefinition(partitions, sortConditions, frame, def.NameRef.Lowered(), def.Name.Lowered())
 	if ref, ok := fromScope.windowDefs[def.NameRef.Lowered()]; ok {
 		// this is only safe if windows are built in topo order
 		windowDef = b.mergeWindowDefs(windowDef, ref)

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -485,7 +485,7 @@ func (b *Builder) buildGroupConcat(inScope *scope, e *ast.GroupConcatExpr) sql.E
 	}
 
 	orderByScope := b.analyzeOrderBy(inScope, inScope, e.OrderBy)
-	sortConditions := b.buildSortConditions(orderByScope, doNotReplaceAlias)
+	sortConditions := b.buildSortConditions(orderByScope, transform.SameTree)
 
 	// TODO: this should be acquired at runtime, not at parse time, so fix this
 	gcml, err := b.ctx.GetSessionVariable(b.ctx, "group_concat_max_len")
@@ -692,7 +692,7 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 	}
 
 	// TODO: We might be able to reuse b.buildSortConditions with some refactoring
-	sortConditions := make(sql.SortFields, len(def.OrderBy))
+	sortConditions := make(sql.SortConditions, len(def.OrderBy))
 	for i, c := range def.OrderBy {
 		// resolve col in fromScope
 		e := b.buildScalar(fromScope, c.Expr)
@@ -741,7 +741,7 @@ func (b *Builder) mergeWindowDefs(def, ref *sql.WindowDefinition) *sql.WindowDef
 		panic("unreachable; cannot merge unresolved window definition")
 	}
 
-	var orderBy sql.SortFields
+	var orderBy sql.SortConditions
 	switch {
 	case len(def.OrderBy) > 0 && len(ref.OrderBy) > 0:
 		err := sql.ErrInvalidWindowInheritance.New("", "", "both contain order by clause")

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -701,8 +701,8 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 			so = sql.Descending
 		}
 		sortConditions[i] = sql.SortCondition{
-			Column: e,
-			Order:  so,
+			Expr:  e,
+			Order: so,
 		}
 	}
 

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -725,7 +725,7 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 	// "If OVER() is empty, the window consists of all query rows and the window function computes a result using all rows."
 	// This must be evaluated after merging with any referenced named window (OVER w), since the
 	// referenced window's ORDER BY determines the correct default frame, not this def's own (possibly empty) ORDER BY.
-	if windowDef.OrderBy == nil && windowDef.Frame == nil {
+	if len(windowDef.OrderBy) == 0 && windowDef.Frame == nil {
 		windowDef.Frame = plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame()
 	}
 

--- a/sql/planbuilder/cte.go
+++ b/sql/planbuilder/cte.go
@@ -16,13 +16,13 @@ package planbuilder
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/transform"
 	"strings"
 
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
 )
 
 func (b *Builder) buildWith(inScope *scope, with *ast.With) (outScope *scope) {

--- a/sql/planbuilder/cte.go
+++ b/sql/planbuilder/cte.go
@@ -16,6 +16,7 @@ package planbuilder
 
 import (
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/transform"
 	"strings"
 
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
@@ -172,7 +173,7 @@ func (b *Builder) buildRecursiveCte(inScope *scope, union *ast.SetOp, name strin
 	limit := b.buildLimit(inScope, union.Limit)
 
 	orderByScope := b.analyzeOrderBy(cteScope, leftScope, union.OrderBy)
-	sortConditions := b.buildSortConditions(orderByScope, doNotReplaceAlias)
+	sortConditions := b.buildSortConditions(orderByScope, transform.SameTree)
 
 	corr := leftSqScope.correlated().Union(rightInScope.correlated())
 	vol := leftSqScope.activeSubquery.volatile || rightInScope.activeSubquery.volatile

--- a/sql/planbuilder/cte.go
+++ b/sql/planbuilder/cte.go
@@ -172,29 +172,14 @@ func (b *Builder) buildRecursiveCte(inScope *scope, union *ast.SetOp, name strin
 	limit := b.buildLimit(inScope, union.Limit)
 
 	orderByScope := b.analyzeOrderBy(cteScope, leftScope, union.OrderBy)
-	var sortFields sql.SortFields
-	for _, c := range orderByScope.cols {
-		so := sql.Ascending
-		if c.descending {
-			so = sql.Descending
-		}
-		scalar := c.scalar
-		if scalar == nil {
-			scalar = c.scalarGf()
-		}
-		sf := sql.SortField{
-			Column: scalar,
-			Order:  so,
-		}
-		sortFields = append(sortFields, sf)
-	}
+	sortConditions := b.buildSortConditions(orderByScope, doNotReplaceAlias)
 
 	corr := leftSqScope.correlated().Union(rightInScope.correlated())
 	vol := leftSqScope.activeSubquery.volatile || rightInScope.activeSubquery.volatile
 
 	b.qFlags.Set(sql.QFlagRelSubquery)
 	cteScope.node = plan.NewSubqueryAlias(name, "",
-		plan.NewRecursiveCte(rInit, rightScope.node, name, columns, distinct, limit, sortFields).
+		plan.NewRecursiveCte(rInit, rightScope.node, name, columns, distinct, limit, sortConditions).
 			WithSchema(recSch).WithWorking(rTable).WithId(tableId).WithColumns(cols)).
 		WithColumnNames(columns).WithCorrelated(corr).WithVolatile(vol).WithScopeMapping(scopeMapping).
 		WithId(tableId).WithColumns(cols)

--- a/sql/planbuilder/factory.go
+++ b/sql/planbuilder/factory.go
@@ -243,7 +243,7 @@ func (f *factory) buildDistinct(ctx *sql.Context, child sql.Node, refsSubquery b
 	return plan.NewDistinct(child, distinctOn...), nil
 }
 
-func (f *factory) buildSort(ctx *sql.Context, child sql.Node, exprs []sql.SortField, deps sql.ColSet, subquery bool) (sql.Node, error) {
+func (f *factory) buildSort(ctx *sql.Context, child sql.Node, exprs sql.SortFields, deps sql.ColSet, subquery bool) (sql.Node, error) {
 	{
 		// The default binder behavior adds a projection before and after
 		// sort nodes for alias dependency correctness. In many cases the sort

--- a/sql/planbuilder/factory.go
+++ b/sql/planbuilder/factory.go
@@ -198,7 +198,7 @@ func (f *factory) buildDistinct(ctx *sql.Context, child sql.Node, refsSubquery b
 				}
 				minMatching := min(len(distinctOn), len(sort.SortFields))
 				for i := 0; i < minMatching; i++ {
-					if _, ok := dMap[strings.ToLower(sort.SortFields[i].Column.String())]; !ok {
+					if _, ok := dMap[strings.ToLower(sort.SortFields[i].Expr.String())]; !ok {
 						return nil, sql.ErrDistinctOnMatchOrderBy.New()
 					}
 				}
@@ -223,7 +223,7 @@ func (f *factory) buildDistinct(ctx *sql.Context, child sql.Node, refsSubquery b
 			}
 			hasDiff := false
 			for _, s := range sort.SortFields {
-				if _, ok := projMap[strings.ToLower(s.Column.String())]; !ok {
+				if _, ok := projMap[strings.ToLower(s.Expr.String())]; !ok {
 					hasDiff = true
 					break
 				}

--- a/sql/planbuilder/factory.go
+++ b/sql/planbuilder/factory.go
@@ -196,9 +196,9 @@ func (f *factory) buildDistinct(ctx *sql.Context, child sql.Node, refsSubquery b
 				for _, expr := range distinctOn {
 					dMap[strings.ToLower(expr.String())] = struct{}{}
 				}
-				minMatching := min(len(distinctOn), len(sort.SortFields))
+				minMatching := min(len(distinctOn), len(sort.SortConditions))
 				for i := 0; i < minMatching; i++ {
-					if _, ok := dMap[strings.ToLower(sort.SortFields[i].Expr.String())]; !ok {
+					if _, ok := dMap[strings.ToLower(sort.SortConditions[i].Expr.String())]; !ok {
 						return nil, sql.ErrDistinctOnMatchOrderBy.New()
 					}
 				}
@@ -222,7 +222,7 @@ func (f *factory) buildDistinct(ctx *sql.Context, child sql.Node, refsSubquery b
 				projMap[strings.ToLower(p.String())] = struct{}{}
 			}
 			hasDiff := false
-			for _, s := range sort.SortFields {
+			for _, s := range sort.SortConditions {
 				if _, ok := projMap[strings.ToLower(s.Expr.String())]; !ok {
 					hasDiff = true
 					break
@@ -243,7 +243,7 @@ func (f *factory) buildDistinct(ctx *sql.Context, child sql.Node, refsSubquery b
 	return plan.NewDistinct(child, distinctOn...), nil
 }
 
-func (f *factory) buildSort(ctx *sql.Context, child sql.Node, exprs sql.SortFields, deps sql.ColSet, subquery bool) (sql.Node, error) {
+func (f *factory) buildSort(ctx *sql.Context, child sql.Node, exprs sql.SortConditions, deps sql.ColSet, subquery bool) (sql.Node, error) {
 	{
 		// The default binder behavior adds a projection before and after
 		// sort nodes for alias dependency correctness. In many cases the sort

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -202,7 +202,7 @@ func (b *Builder) buildOrderBy(inScope, orderByScope *scope) {
 	if len(orderByScope.cols) == 0 {
 		return
 	}
-	sortConditions := b.buildSortConditions(orderByScope, doNotReplaceAlias)
+	sortConditions := b.buildSortConditions(orderByScope, transform.SameTree)
 	sort, err := b.f.buildSort(b.ctx, inScope.node, sortConditions, orderByScope.colset, inScope.refsSubquery)
 	if err != nil {
 		b.handleErr(err)
@@ -211,16 +211,9 @@ func (b *Builder) buildOrderBy(inScope, orderByScope *scope) {
 	return
 }
 
-type replaceAliasFlag bool
-
-const (
-	doReplaceAlias    replaceAliasFlag = true
-	doNotReplaceAlias replaceAliasFlag = false
-)
-
 // buildSortConditions builds a sql.SortConditions based on an ORDER BY scope and also returns dependencies
-func (b *Builder) buildSortConditions(orderByScope *scope, replaceAlias replaceAliasFlag) sql.SortFields {
-	sortConditions := make(sql.SortFields, len(orderByScope.cols))
+func (b *Builder) buildSortConditions(orderByScope *scope, sameAlias transform.TreeIdentity) sql.SortConditions {
+	sortConditions := make(sql.SortConditions, len(orderByScope.cols))
 	for i, c := range orderByScope.cols {
 		so := sql.Ascending
 		if c.descending {
@@ -232,7 +225,7 @@ func (b *Builder) buildSortConditions(orderByScope *scope, replaceAlias replaceA
 		}
 		// Some nodes such as unions pass ORDER BYs to the top scope, where the original ORDER BY may no longer be
 		// accessible. It is safe to assume that the alias has already been computed.
-		if replaceAlias {
+		if !sameAlias {
 			scalar, _, _ = transform.Expr(b.ctx, scalar, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 				switch e := e.(type) {
 				case *expression.Alias:
@@ -269,7 +262,7 @@ func (b *Builder) buildOrderedInjectedExpr(inScope *scope, e *ast.OrderedInjecte
 	}
 
 	orderByScope := b.analyzeOrderBy(inScope, inScope, e.OrderBy)
-	sortConditions := b.buildSortConditions(orderByScope, doNotReplaceAlias)
+	sortConditions := b.buildSortConditions(orderByScope, transform.SameTree)
 
 	resolvedChildren = append(resolvedChildren, sortConditions)
 

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -16,6 +16,7 @@ package planbuilder
 
 import (
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/plan"
 	"strings"
 
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
@@ -201,9 +202,26 @@ func (b *Builder) buildOrderBy(inScope, orderByScope *scope) {
 	if len(orderByScope.cols) == 0 {
 		return
 	}
-	var sortFields sql.SortFields
-	var deps sql.ColSet
-	for _, c := range orderByScope.cols {
+	sortConditions := b.buildSortConditions(orderByScope, doNotReplaceAlias)
+	sort, err := b.f.buildSort(b.ctx, inScope.node, sortConditions, orderByScope.colset, inScope.refsSubquery)
+	if err != nil {
+		b.handleErr(err)
+	}
+	inScope.node = sort
+	return
+}
+
+type replaceAliasFlag bool
+
+const (
+	replaceAlias      replaceAliasFlag = true
+	doNotReplaceAlias replaceAliasFlag = false
+)
+
+// buildSortConditions builds a sql.SortConditions based on an ORDER BY scope and also returns dependencies
+func (b *Builder) buildSortConditions(orderByScope *scope, replaceAlias replaceAliasFlag) sql.SortFields {
+	sortConditions := make(sql.SortFields, len(orderByScope.cols))
+	for i, c := range orderByScope.cols {
 		so := sql.Ascending
 		if c.descending {
 			so = sql.Descending
@@ -212,19 +230,66 @@ func (b *Builder) buildOrderBy(inScope, orderByScope *scope) {
 		if scalar == nil {
 			scalar = c.scalarGf()
 		}
-		sf := sql.SortField{
+		// Some nodes such as unions pass ORDER BYs to the top scope, where the original ORDER BY may no longer be
+		// accessible. It is safe to assume that the alias has already been computed.
+		if replaceAlias {
+			scalar, _, _ = transform.Expr(b.ctx, scalar, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+				switch e := e.(type) {
+				case *expression.Alias:
+					return expression.NewGetField(int(c.id), e.Type(ctx), e.Name(), e.IsNullable(ctx)), transform.NewTree, nil
+				default:
+					return e, transform.SameTree, nil
+				}
+			})
+		}
+		sortConditions[i] = sql.SortCondition{
 			Column: scalar,
 			Order:  so,
 		}
-		sortFields = append(sortFields, sf)
-		deps.Add(sql.ColumnId(c.id))
 	}
-	sort, err := b.f.buildSort(b.ctx, inScope.node, sortFields, deps, inScope.refsSubquery)
-	if err != nil {
-		b.handleErr(err)
+	return sortConditions
+}
+
+// buildOrderedInjectedExpr builds an InjectedExpr with an ORDER BY dependency
+func (b *Builder) buildOrderedInjectedExpr(inScope *scope, e *ast.OrderedInjectedExpr) sql.Expression {
+	inScope.initGroupBy()
+	gb := inScope.groupBy
+
+	var resolvedChildren []any
+	if len(e.Children) > 0 {
+		resolvedChildren = make([]any, len(e.Children))
+		for i, child := range e.Children {
+			resolvedChildren[i] = b.buildScalar(inScope, child)
+		}
+	} else {
+		resolvedChildren = make([]any, len(e.SelectExprChildren))
+		for i, child := range e.SelectExprChildren {
+			resolvedChildren[i] = b.selectExprToExpression(inScope, child)
+		}
 	}
-	inScope.node = sort
-	return
+
+	orderByScope := b.analyzeOrderBy(inScope, inScope, e.OrderBy)
+	sortConditions := b.buildSortConditions(orderByScope, doNotReplaceAlias)
+
+	resolvedChildren = append(resolvedChildren, sortConditions)
+
+	expr := b.buildInjectedExpressionFromResolvedChildren(e.InjectedExpr, resolvedChildren)
+	agg, ok := expr.(sql.Aggregation)
+	if !ok {
+		b.handleErr(fmt.Errorf("expected sql.Aggregation, got %T", expr))
+	}
+
+	aggName := strings.ToLower(plan.AliasSubqueryString(b.ctx, agg))
+	col := scopeColumn{col: aggName, scalar: agg, typ: agg.Type(b.ctx), nullable: agg.IsNullable(b.ctx)}
+	id := gb.outScope.newColumn(col)
+
+	agg = agg.WithId(sql.ColumnId(id)).(sql.Aggregation)
+	gb.outScope.cols[len(gb.outScope.cols)-1].scalar = agg
+	col.scalar = agg
+
+	gb.addAggStr(col)
+	col.id = id
+	return col.scalarGf()
 }
 
 // unwrapExpression unwraps expressions wrapped in ParenExpr (parenthesis)

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -214,7 +214,7 @@ func (b *Builder) buildOrderBy(inScope, orderByScope *scope) {
 type replaceAliasFlag bool
 
 const (
-	replaceAlias      replaceAliasFlag = true
+	doReplaceAlias    replaceAliasFlag = true
 	doNotReplaceAlias replaceAliasFlag = false
 )
 

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -16,13 +16,13 @@ package planbuilder
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/plan"
 	"strings"
 
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -243,8 +243,8 @@ func (b *Builder) buildSortConditions(orderByScope *scope, replaceAlias replaceA
 			})
 		}
 		sortConditions[i] = sql.SortCondition{
-			Column: scalar,
-			Order:  so,
+			Expr:  scalar,
+			Order: so,
 		}
 	}
 	return sortConditions

--- a/sql/planbuilder/set_op.go
+++ b/sql/planbuilder/set_op.go
@@ -81,16 +81,16 @@ func (b *Builder) buildSetOp(inScope *scope, u *ast.SetOp) (outScope *scope) {
 
 	// mysql errors for order by right projection
 	orderByScope := b.analyzeOrderBy(leftScope, leftScope, u.OrderBy)
-	sortConditions := b.buildSortConditions(orderByScope, doReplaceAlias)
+	sortConditions := b.buildSortConditions(orderByScope, transform.NewTree)
 
 	n, ok := leftScope.node.(*plan.SetOp)
 	if ok {
-		if len(n.SortFields) > 0 {
+		if len(n.SortConditions) > 0 {
 			if len(sortConditions) > 0 {
 				err := sql.ErrConflictingExternalQuery.New()
 				b.handleErr(err)
 			}
-			sortConditions = n.SortFields
+			sortConditions = n.SortConditions
 		}
 		if n.Limit != nil {
 			if limit != nil {

--- a/sql/planbuilder/set_op.go
+++ b/sql/planbuilder/set_op.go
@@ -81,43 +81,16 @@ func (b *Builder) buildSetOp(inScope *scope, u *ast.SetOp) (outScope *scope) {
 
 	// mysql errors for order by right projection
 	orderByScope := b.analyzeOrderBy(leftScope, leftScope, u.OrderBy)
-
-	var sortFields sql.SortFields
-	for _, c := range orderByScope.cols {
-		so := sql.Ascending
-		if c.descending {
-			so = sql.Descending
-		}
-		scalar := c.scalar
-		if scalar == nil {
-			scalar = c.scalarGf()
-		}
-		// Unions pass order bys to the top scope, where the original
-		// order by get field may no longer be accessible. Here it is
-		// safe to assume the alias has already been computed.
-		scalar, _, _ = transform.Expr(b.ctx, scalar, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
-			switch e := e.(type) {
-			case *expression.Alias:
-				return expression.NewGetField(int(c.id), e.Type(ctx), e.Name(), e.IsNullable(ctx)), transform.NewTree, nil
-			default:
-				return e, transform.SameTree, nil
-			}
-		})
-		sf := sql.SortField{
-			Column: scalar,
-			Order:  so,
-		}
-		sortFields = append(sortFields, sf)
-	}
+	sortConditions := b.buildSortConditions(orderByScope, replaceAlias)
 
 	n, ok := leftScope.node.(*plan.SetOp)
 	if ok {
 		if len(n.SortFields) > 0 {
-			if len(sortFields) > 0 {
+			if len(sortConditions) > 0 {
 				err := sql.ErrConflictingExternalQuery.New()
 				b.handleErr(err)
 			}
-			sortFields = n.SortFields
+			sortConditions = n.SortFields
 		}
 		if n.Limit != nil {
 			if limit != nil {
@@ -142,7 +115,7 @@ func (b *Builder) buildSetOp(inScope *scope, u *ast.SetOp) (outScope *scope) {
 	}
 	b.tabId++
 	tabId := b.tabId
-	ret := plan.NewSetOp(setOpType, leftScope.node, rightScope.node, distinct, limit, offset, sortFields).WithId(tabId).WithColumns(cols)
+	ret := plan.NewSetOp(setOpType, leftScope.node, rightScope.node, distinct, limit, offset, sortConditions).WithId(tabId).WithColumns(cols)
 	outScope = leftScope
 	outScope.cols = b.mergeSetOpScopeColumns(leftScope.cols, rightScope.cols, tabId)
 	outScope.node = b.mergeSetOpSchemas(ret.(*plan.SetOp))

--- a/sql/planbuilder/set_op.go
+++ b/sql/planbuilder/set_op.go
@@ -81,7 +81,7 @@ func (b *Builder) buildSetOp(inScope *scope, u *ast.SetOp) (outScope *scope) {
 
 	// mysql errors for order by right projection
 	orderByScope := b.analyzeOrderBy(leftScope, leftScope, u.OrderBy)
-	sortConditions := b.buildSortConditions(orderByScope, replaceAlias)
+	sortConditions := b.buildSortConditions(orderByScope, doReplaceAlias)
 
 	n, ok := leftScope.node.(*plan.SetOp)
 	if ok {

--- a/sql/rowexec/group_by_test.go
+++ b/sql/rowexec/group_by_test.go
@@ -90,13 +90,13 @@ func TestGroupByRowIter(t *testing.T) {
 	}
 
 	p := plan.NewSort(
-		[]sql.SortField{
+		sql.SortConditions{
 			{
-				Column: expression.NewGetField(0, types.LongText, "col1", true),
-				Order:  sql.Ascending,
+				Expr:  expression.NewGetField(0, types.LongText, "col1", true),
+				Order: sql.Ascending,
 			}, {
-				Column: expression.NewGetField(1, types.Int64, "col2", true),
-				Order:  sql.Ascending,
+				Expr:  expression.NewGetField(1, types.Int64, "col2", true),
+				Order: sql.Ascending,
 			},
 		},
 		plan.NewGroupBy(

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -51,9 +51,9 @@ func (b *BaseBuilder) buildTopN(ctx *sql.Context, n *plan.TopN, row sql.Row) (sq
 
 	var topIter sql.RowIter
 	if limit == 1 {
-		topIter = iters.NewTopRowIter(n.Fields, n.CalcFoundRows, i)
+		topIter = iters.NewTopRowIter(n.SortConditions, n.CalcFoundRows, i)
 	} else {
-		topIter = iters.NewTopRowsIter(n.Fields, limit, n.CalcFoundRows, i, len(n.Child.Schema(ctx)))
+		topIter = iters.NewTopRowsIter(n.SortConditions, limit, n.CalcFoundRows, i)
 	}
 	return sql.NewSpanIter(span, topIter), nil
 }
@@ -457,20 +457,20 @@ func (b *BaseBuilder) buildRecursiveCte(ctx *sql.Context, n *plan.RecursiveCte, 
 		deduplicate: n.Union().Distinct,
 		b:           b,
 	}
-	if n.Union().Limit != nil && len(n.Union().SortFields) > 0 {
+	if n.Union().Limit != nil && len(n.Union().SortConditions) > 0 {
 		limit, err := iters.GetInt64Value(ctx, n.Union().Limit)
 		if err != nil {
 			return nil, err
 		}
-		iter = iters.NewTopRowsIter(n.Union().SortFields, limit, false, iter, len(n.Union().Schema(ctx)))
+		iter = iters.NewTopRowsIter(n.Union().SortConditions, limit, false, iter)
 	} else if n.Union().Limit != nil {
 		limit, err := iters.GetInt64Value(ctx, n.Union().Limit)
 		if err != nil {
 			return nil, err
 		}
 		iter = &iters.LimitIter{Limit: limit, ChildIter: iter}
-	} else if len(n.Union().SortFields) > 0 {
-		iter = iters.NewSortIter(n.Union().SortFields, iter)
+	} else if len(n.Union().SortConditions) > 0 {
+		iter = iters.NewSortIter(n.Union().SortConditions, iter)
 	}
 	return iter, nil
 }
@@ -878,20 +878,20 @@ func (b *BaseBuilder) buildSetOp(ctx *sql.Context, s *plan.SetOp, row sql.Row) (
 		}
 		iter = &offsetIter{skip: offset, childIter: iter}
 	}
-	if s.Limit != nil && len(s.SortFields) > 0 {
+	if s.Limit != nil && len(s.SortConditions) > 0 {
 		limit, err := iters.GetInt64Value(ctx, s.Limit)
 		if err != nil {
 			return nil, err
 		}
-		iter = iters.NewTopRowsIter(s.SortFields, limit, false, iter, len(s.Schema(ctx)))
+		iter = iters.NewTopRowsIter(s.SortConditions, limit, false, iter)
 	} else if s.Limit != nil {
 		limit, err := iters.GetInt64Value(ctx, s.Limit)
 		if err != nil {
 			return nil, err
 		}
 		iter = &iters.LimitIter{Limit: limit, ChildIter: iter}
-	} else if len(s.SortFields) > 0 {
-		iter = iters.NewSortIter(s.SortFields, iter)
+	} else if len(s.SortConditions) > 0 {
+		iter = iters.NewSortIter(s.SortConditions, iter)
 	}
 	return sql.NewSpanIter(span, iter), nil
 }
@@ -918,7 +918,7 @@ func (b *BaseBuilder) buildSort(ctx *sql.Context, n *plan.Sort, row sql.Row) (sq
 		span.End()
 		return nil, err
 	}
-	return sql.NewSpanIter(span, iters.NewSortIter(n.SortFields, i)), nil
+	return sql.NewSpanIter(span, iters.NewSortIter(n.SortConditions, i)), nil
 }
 
 func (b *BaseBuilder) buildPrepareQuery(ctx *sql.Context, n *plan.PrepareQuery, row sql.Row) (sql.RowIter, error) {

--- a/sql/rowexec/sort_test.go
+++ b/sql/rowexec/sort_test.go
@@ -35,9 +35,9 @@ func TestSort(t *testing.T) {
 	})
 
 	type sortTest struct {
-		rows       []sql.Row
-		sortFields []sql.SortField
-		expected   []sql.Row
+		rows           []sql.Row
+		sortConditions sql.SortConditions
+		expected       []sql.Row
 	}
 
 	testCases := []sortTest{
@@ -49,10 +49,10 @@ func TestSort(t *testing.T) {
 				sql.NewRow("c", int32(1), float64(1.0)),
 				sql.NewRow(nil, int32(1), nil),
 			},
-			sortFields: []sql.SortField{
-				{Column: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Descending, NullOrdering: sql.NullsLast},
-				{Column: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+			sortConditions: sql.SortConditions{
+				{Expr: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Descending, NullOrdering: sql.NullsLast},
+				{Expr: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
 			},
 			expected: []sql.Row{
 				sql.NewRow("c", nil, nil),
@@ -67,10 +67,10 @@ func TestSort(t *testing.T) {
 				sql.NewRow("c", int32(3), float64(3.0)),
 				sql.NewRow("c", int32(3), nil),
 			},
-			sortFields: []sql.SortField{
-				{Column: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Descending, NullOrdering: sql.NullsLast},
-				{Column: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+			sortConditions: sql.SortConditions{
+				{Expr: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Descending, NullOrdering: sql.NullsLast},
+				{Expr: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
 			},
 			expected: []sql.Row{
 				sql.NewRow("c", int32(3), nil),
@@ -85,10 +85,10 @@ func TestSort(t *testing.T) {
 				sql.NewRow("c", int32(1), float64(1.0)),
 				sql.NewRow(nil, int32(1), nil),
 			},
-			sortFields: []sql.SortField{
-				{Column: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsLast},
+			sortConditions: sql.SortConditions{
+				{Expr: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsLast},
 			},
 			expected: []sql.Row{
 				sql.NewRow("c", nil, nil),
@@ -103,10 +103,10 @@ func TestSort(t *testing.T) {
 				sql.NewRow("a", int32(1), float64(2)),
 				sql.NewRow("a", int32(1), float64(1)),
 			},
-			sortFields: []sql.SortField{
-				{Column: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+			sortConditions: sql.SortConditions{
+				{Expr: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
 			},
 			expected: []sql.Row{
 				sql.NewRow("a", int32(1), float64(1)),
@@ -122,10 +122,10 @@ func TestSort(t *testing.T) {
 				sql.NewRow("b", int32(2), float64(2)),
 				sql.NewRow("c", int32(3), float64(1)),
 			},
-			sortFields: []sql.SortField{
-				{Column: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Descending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+			sortConditions: sql.SortConditions{
+				{Expr: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Descending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
 			},
 			expected: []sql.Row{
 				sql.NewRow("a", int32(3), float64(1)),
@@ -141,10 +141,10 @@ func TestSort(t *testing.T) {
 				sql.NewRow(nil, nil, float64(2)),
 				sql.NewRow(nil, nil, float64(1)),
 			},
-			sortFields: []sql.SortField{
-				{Column: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+			sortConditions: sql.SortConditions{
+				{Expr: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
 			},
 			expected: []sql.Row{
 				sql.NewRow(nil, nil, float64(1)),
@@ -156,10 +156,10 @@ func TestSort(t *testing.T) {
 				sql.NewRow(nil, nil, float64(1)),
 				sql.NewRow(nil, nil, float64(2)),
 			},
-			sortFields: []sql.SortField{
-				{Column: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Descending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Descending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Descending, NullOrdering: sql.NullsFirst},
+			sortConditions: sql.SortConditions{
+				{Expr: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Descending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Descending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Descending, NullOrdering: sql.NullsFirst},
 			},
 			expected: []sql.Row{
 				sql.NewRow(nil, nil, float64(2)),
@@ -171,10 +171,10 @@ func TestSort(t *testing.T) {
 				sql.NewRow(nil, nil, float64(1)),
 				sql.NewRow(nil, nil, nil),
 			},
-			sortFields: []sql.SortField{
-				{Column: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
-				{Column: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+			sortConditions: sql.SortConditions{
+				{Expr: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+				{Expr: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
 			},
 			expected: []sql.Row{
 				sql.NewRow(nil, nil, nil),
@@ -186,10 +186,10 @@ func TestSort(t *testing.T) {
 				sql.NewRow(nil, nil, nil),
 				sql.NewRow(nil, nil, float64(1)),
 			},
-			sortFields: []sql.SortField{
-				{Column: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsLast},
-				{Column: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsLast},
-				{Column: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsLast},
+			sortConditions: sql.SortConditions{
+				{Expr: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsLast},
+				{Expr: expression.NewGetField(1, types.Int32, "col2", true), Order: sql.Ascending, NullOrdering: sql.NullsLast},
+				{Expr: expression.NewGetField(2, types.Float64, "col3", true), Order: sql.Ascending, NullOrdering: sql.NullsLast},
 			},
 			expected: []sql.Row{
 				sql.NewRow(nil, nil, float64(1)),
@@ -211,7 +211,7 @@ func TestSort(t *testing.T) {
 				require.NoError(tbl.Insert(ctx, row))
 			}
 
-			sort := plan.NewSort(tt.sortFields, plan.NewResolvedTable(tbl, nil, nil))
+			sort := plan.NewSort(tt.sortConditions, plan.NewResolvedTable(tbl, nil, nil))
 
 			actual, err := NodeToRows(ctx, sort)
 			require.NoError(err)
@@ -244,10 +244,10 @@ func TestSortAscending(t *testing.T) {
 		require.NoError(child.Insert(ctx, row))
 	}
 
-	sf := []sql.SortField{
-		{Column: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
+	sc := sql.SortConditions{
+		{Expr: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Ascending, NullOrdering: sql.NullsFirst},
 	}
-	s := plan.NewSort(sf, plan.NewResolvedTable(child, nil, nil))
+	s := plan.NewSort(sc, plan.NewResolvedTable(child, nil, nil))
 	require.Equal(schema.Schema, s.Schema(ctx))
 
 	expected := []sql.Row{
@@ -287,10 +287,10 @@ func TestSortDescending(t *testing.T) {
 		require.NoError(child.Insert(ctx, row))
 	}
 
-	sf := []sql.SortField{
-		{Column: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Descending, NullOrdering: sql.NullsFirst},
+	sc := sql.SortConditions{
+		{Expr: expression.NewGetField(0, types.Text, "col1", true), Order: sql.Descending, NullOrdering: sql.NullsFirst},
 	}
-	s := plan.NewSort(sf, plan.NewResolvedTable(child, nil, nil))
+	s := plan.NewSort(sc, plan.NewResolvedTable(child, nil, nil))
 	require.Equal(schema.Schema, s.Schema(ctx))
 
 	expected := []sql.Row{

--- a/sql/sort_condition.go
+++ b/sql/sort_condition.go
@@ -30,31 +30,31 @@ type SortCondition struct {
 	NullOrdering NullOrdering
 }
 
-type SortFields []SortCondition
+type SortConditions []SortCondition
 
-func (sf SortFields) ToExpressions() []Expression {
-	es := make([]Expression, len(sf))
-	for i, f := range sf {
+func (sc SortConditions) ToExpressions() []Expression {
+	es := make([]Expression, len(sc))
+	for i, f := range sc {
 		es[i] = f.Expr
 	}
 	return es
 }
 
-func (sf SortFields) FromExpressions(ctx *Context, exprs ...Expression) SortFields {
-	var fields = make(SortFields, len(sf))
+func (sc SortConditions) FromExpressions(ctx *Context, exprs ...Expression) SortConditions {
+	var conds = make(SortConditions, len(sc))
 
-	if len(exprs) != len(fields) {
-		panic(fmt.Sprintf("Invalid expression slice. Wanted %d elements, got %d", len(fields), len(exprs)))
+	if len(exprs) != len(conds) {
+		panic(fmt.Sprintf("Invalid expression slice. Wanted %d elements, got %d", len(conds), len(exprs)))
 	}
 
 	for i, expr := range exprs {
-		fields[i] = SortCondition{
+		conds[i] = SortCondition{
 			Expr:         expr,
-			NullOrdering: sf[i].NullOrdering,
-			Order:        sf[i].Order,
+			NullOrdering: sc[i].NullOrdering,
+			Order:        sc[i].Order,
 		}
 	}
-	return fields
+	return conds
 }
 
 func (s SortCondition) String() string {

--- a/sql/sort_condition.go
+++ b/sql/sort_condition.go
@@ -22,10 +22,8 @@ import (
 
 // SortCondition defines an Expression and ordering by which a query will be sorted.
 type SortCondition struct {
-	// Column to order by.
+	// Expr to order by.
 	Expr Expression
-	// Column ValueExpression to order by. This is always the same value as Column, but avoids a type cast
-	ValueExprColumn ValueExpression
 	// Order type.
 	Order SortOrder
 	// NullOrdering defining how nulls will be ordered.
@@ -50,12 +48,10 @@ func (sf SortFields) FromExpressions(ctx *Context, exprs ...Expression) SortFiel
 	}
 
 	for i, expr := range exprs {
-		valueExpr, _ := expr.(ValueExpression)
 		fields[i] = SortCondition{
-			Expr:            expr,
-			ValueExprColumn: valueExpr,
-			NullOrdering:    sf[i].NullOrdering,
-			Order:           sf[i].Order,
+			Expr:         expr,
+			NullOrdering: sf[i].NullOrdering,
+			Order:        sf[i].Order,
 		}
 	}
 	return fields

--- a/sql/sort_condition.go
+++ b/sql/sort_condition.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Dolthub, Inc.
+// Copyright 2026 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 // SortCondition defines an Expression and ordering by which a query will be sorted.
 type SortCondition struct {
 	// Column to order by.
-	Column Expression
+	Expr Expression
 	// Column ValueExpression to order by. This is always the same value as Column, but avoids a type cast
 	ValueExprColumn ValueExpression
 	// Order type.
@@ -37,7 +37,7 @@ type SortFields []SortCondition
 func (sf SortFields) ToExpressions() []Expression {
 	es := make([]Expression, len(sf))
 	for i, f := range sf {
-		es[i] = f.Column
+		es[i] = f.Expr
 	}
 	return es
 }
@@ -52,7 +52,7 @@ func (sf SortFields) FromExpressions(ctx *Context, exprs ...Expression) SortFiel
 	for i, expr := range exprs {
 		valueExpr, _ := expr.(ValueExpression)
 		fields[i] = SortCondition{
-			Column:          expr,
+			Expr:            expr,
 			ValueExprColumn: valueExpr,
 			NullOrdering:    sf[i].NullOrdering,
 			Order:           sf[i].Order,
@@ -62,7 +62,7 @@ func (sf SortFields) FromExpressions(ctx *Context, exprs ...Expression) SortFiel
 }
 
 func (s SortCondition) String() string {
-	return fmt.Sprintf("%s %s", s.Column, s.Order)
+	return fmt.Sprintf("%s %s", s.Expr, s.Order)
 }
 
 func (s SortCondition) DebugString(ctx *Context) string {
@@ -70,7 +70,7 @@ func (s SortCondition) DebugString(ctx *Context) string {
 	if s.NullOrdering == NullsLast {
 		nullOrdering = "nullsLast"
 	}
-	return fmt.Sprintf("%s %s %s", DebugString(ctx, s.Column), DebugString(ctx, s.Order), nullOrdering)
+	return fmt.Sprintf("%s %s %s", DebugString(ctx, s.Expr), DebugString(ctx, s.Order), nullOrdering)
 }
 
 // ErrUnableSort is thrown when something happens on sorting

--- a/sql/sort_field.go
+++ b/sql/sort_field.go
@@ -20,10 +20,8 @@ import (
 	"gopkg.in/src-d/go-errors.v1"
 )
 
-// SortField defines an Expression and ordering by which a query will be sorted.
-// TODO: SortField is confusingly and inaccurately named. The name SortField and the struct field Column imply that rows
-// are sorted based on a column or table field but that is incorrect since Column actually an Expression.
-type SortField struct {
+// SortCondition defines an Expression and ordering by which a query will be sorted.
+type SortCondition struct {
 	// Column to order by.
 	Column Expression
 	// Column ValueExpression to order by. This is always the same value as Column, but avoids a type cast
@@ -34,7 +32,7 @@ type SortField struct {
 	NullOrdering NullOrdering
 }
 
-type SortFields []SortField
+type SortFields []SortCondition
 
 func (sf SortFields) ToExpressions() []Expression {
 	es := make([]Expression, len(sf))
@@ -53,7 +51,7 @@ func (sf SortFields) FromExpressions(ctx *Context, exprs ...Expression) SortFiel
 
 	for i, expr := range exprs {
 		valueExpr, _ := expr.(ValueExpression)
-		fields[i] = SortField{
+		fields[i] = SortCondition{
 			Column:          expr,
 			ValueExprColumn: valueExpr,
 			NullOrdering:    sf[i].NullOrdering,
@@ -63,11 +61,11 @@ func (sf SortFields) FromExpressions(ctx *Context, exprs ...Expression) SortFiel
 	return fields
 }
 
-func (s SortField) String() string {
+func (s SortCondition) String() string {
 	return fmt.Sprintf("%s %s", s.Column, s.Order)
 }
 
-func (s SortField) DebugString(ctx *Context) string {
+func (s SortCondition) DebugString(ctx *Context) string {
 	nullOrdering := "nullsFirst"
 	if s.NullOrdering == NullsLast {
 		nullOrdering = "nullsLast"

--- a/sql/window.go
+++ b/sql/window.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 )
 
-func NewWindowDefinition(partitionBy []Expression, orderBy SortFields, frame WindowFrame, ref, name string) *WindowDefinition {
+func NewWindowDefinition(partitionBy []Expression, orderBy SortConditions, frame WindowFrame, ref, name string) *WindowDefinition {
 	return &WindowDefinition{
 		PartitionBy: partitionBy,
 		OrderBy:     orderBy,
@@ -37,7 +37,7 @@ type WindowDefinition struct {
 	Ref         string
 	Name        string
 	PartitionBy []Expression
-	OrderBy     SortFields
+	OrderBy     SortConditions
 	id          uint64
 }
 


### PR DESCRIPTION
The names `SortField(s)` and `Column` are confusing and inaccurate because it implies a field/column, which is wrong because `Column` is actually an expression. This PR renames `SortField(s)` to `SortCondition(s)` and `Column` to `Expr`. It also removes `ValueExprColumn` from the struct since it was never actually read anywhere and was not actually written to most of the time.

Dolt updated in dolthub/dolt#11311
Doltgres updated in dolthub/doltgresql#2942