### PR TITLE
sql/expression/function: CONCAT() evaluates as binary when mixing binary and nonbinary arguments

### DIFF
--- a/sql/expression/function/concat.go
+++ b/sql/expression/function/concat.go
@@ -17,6 +17,7 @@ package function
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -51,13 +52,6 @@ func (c *Concat) Description() string {
 
 // Type implements the Expression interface.
 func (c *Concat) Type(ctx *sql.Context) sql.Type {
-	// If any argument is a true CHARACTER SET 'binary' string (e.g. CHAR(N) without a collation, or a
-	// VARBINARY/BLOB column), MySQL evaluates and returns the whole CONCAT result as binary rather than silently
-	// reinterpreting those bytes as text -- see "mixing nonbinary and binary strings evaluates the operands as
-	// binary strings" (https://dev.mysql.com/doc/refman/8.0/en/charset-collation-coercibility.html). Note this
-	// intentionally checks each argument's own string type rather than the resolved CollationCoercibility(),
-	// because this codebase also uses Collation_binary as a "no real collation" placeholder for non-string
-	// arguments (e.g. numeric literals), which must NOT force the result to binary.
 	if c.hasBinaryStringArg(ctx) {
 		return types.LongBlob
 	}
@@ -156,9 +150,12 @@ func (c *Concat) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	joined := strings.Join(parts, "")
 
-	// Funnel through Type() so that a binary result (see Type, above) actually becomes a genuine []byte rather
-	// than a Go string that silently discards the charset info a caller (e.g. JSON conversion) needs downstream.
-	result, _, err := c.Type(ctx).Convert(ctx, joined)
+	resultType := c.Type(ctx)
+	// Match MySQL: invalid UTF-8 on the text CONCAT path is an error (1300), not a truncate.
+	if !types.IsBinaryType(resultType) && !utf8.ValidString(joined) {
+		return nil, types.ErrBadCharsetString.New(joined, "<unknown>", int64(0))
+	}
+	result, _, err := resultType.Convert(ctx, joined)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/expression/function/concat.go
+++ b/sql/expression/function/concat.go
@@ -50,7 +50,29 @@ func (c *Concat) Description() string {
 }
 
 // Type implements the Expression interface.
-func (c *Concat) Type(ctx *sql.Context) sql.Type { return types.LongText }
+func (c *Concat) Type(ctx *sql.Context) sql.Type {
+	// If any argument is a true CHARACTER SET 'binary' string (e.g. CHAR(N) without a collation, or a
+	// VARBINARY/BLOB column), MySQL evaluates and returns the whole CONCAT result as binary rather than silently
+	// reinterpreting those bytes as text -- see "mixing nonbinary and binary strings evaluates the operands as
+	// binary strings" (https://dev.mysql.com/doc/refman/8.0/en/charset-collation-coercibility.html). Note this
+	// intentionally checks each argument's own string type rather than the resolved CollationCoercibility(),
+	// because this codebase also uses Collation_binary as a "no real collation" placeholder for non-string
+	// arguments (e.g. numeric literals), which must NOT force the result to binary.
+	if c.hasBinaryStringArg(ctx) {
+		return types.LongBlob
+	}
+	return types.LongText
+}
+
+// hasBinaryStringArg returns true if any argument is itself a string type using the binary character set.
+func (c *Concat) hasBinaryStringArg(ctx *sql.Context) bool {
+	for _, arg := range c.args {
+		if st, ok := arg.Type(ctx).(sql.StringType); ok && st.IsStringType() && st.CharacterSet() == sql.CharacterSet_binary {
+			return true
+		}
+	}
+	return false
+}
 
 // CollationCoercibility implements the interface sql.CollationCoercible.
 func (c *Concat) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
@@ -132,5 +154,14 @@ func (c *Concat) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		parts = append(parts, content)
 	}
 
-	return strings.Join(parts, ""), nil
+	joined := strings.Join(parts, "")
+
+	// Funnel through Type() so that a binary result (see Type, above) actually becomes a genuine []byte rather
+	// than a Go string that silently discards the charset info a caller (e.g. JSON conversion) needs downstream.
+	result, _, err := c.Type(ctx).Convert(ctx, joined)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/sql/expression/function/concat.go
+++ b/sql/expression/function/concat.go
@@ -151,7 +151,6 @@ func (c *Concat) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	joined := strings.Join(parts, "")
 
 	resultType := c.Type(ctx)
-	// Match MySQL: invalid UTF-8 on the text CONCAT path is an error (1300), not a truncate.
 	if !types.IsBinaryType(resultType) && !utf8.ValidString(joined) {
 		return nil, types.ErrBadCharsetString.New(joined, "<unknown>", int64(0))
 	}

--- a/sql/expression/function/concat_test.go
+++ b/sql/expression/function/concat_test.go
@@ -17,6 +17,7 @@ package function
 import (
 	"testing"
 
+	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -49,6 +50,40 @@ func TestConcat(t *testing.T) {
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
 		require.Equal(nil, v)
+	})
+
+	t.Run("mixing a CHARACTER SET binary argument with a nonbinary argument evaluates as binary", func(t *testing.T) {
+		// Regression test for https://github.com/dolthub/dolt/issues/11216: MySQL evaluates CONCAT() as binary
+		// (CHARACTER SET 'binary') whenever any argument is itself a binary-charset string, e.g. CHAR(N) without
+		// an explicit collation. Concat.Type() and Eval() must mirror that -- matching how Char.Type()/Eval()
+		// already behave -- rather than silently reporting/producing a nonbinary LongText/string result.
+		require := require.New(t)
+		ctx := sql.NewEmptyContext()
+		binaryArg := expression.NewLiteral([]byte{0xE9}, types.MustCreateBinary(sqltypes.VarBinary, 4))
+		f, err := NewConcat(ctx, expression.NewLiteral(`"`, types.LongText), binaryArg, expression.NewLiteral(`"`, types.LongText))
+		require.NoError(err)
+
+		require.True(types.IsBinaryType(f.Type(ctx)))
+
+		v, err := f.Eval(ctx, nil)
+		require.NoError(err)
+		require.IsType([]byte{}, v)
+		require.Equal([]byte{'"', 0xE9, '"'}, v)
+	})
+
+	t.Run("mixing a numeric argument with a string argument does not force binary", func(t *testing.T) {
+		// Regression test: numeric literals also carry a "no real collation" placeholder in this codebase and
+		// must NOT be confused with a genuine CHARACTER SET 'binary' string argument (see Type, above).
+		require := require.New(t)
+		ctx := sql.NewEmptyContext()
+		f, err := NewConcat(ctx, expression.NewLiteral("foo", types.LongText), expression.NewLiteral(123, types.Int64), expression.NewLiteral("bar", types.LongText))
+		require.NoError(err)
+
+		require.False(types.IsBinaryType(f.Type(ctx)))
+
+		v, err := f.Eval(ctx, nil)
+		require.NoError(err)
+		require.Equal("foo123bar", v)
 	})
 }
 


### PR DESCRIPTION
`CONCAT()` with a mixed binary/non-binary argument list now follows MySQL's rule that the whole result is binary: `Type()` reports a binary type and `Eval()` returns `[]byte` instead of always using `LongText`/`string`. That keeps comparisons, `ORDER BY`/`GROUP BY`/`DISTINCT`, and downstream charset-aware conversion on the binary path.

On the text (non-binary) path, invalid UTF-8 is rejected with MySQL error 1300 instead of silently truncating trailing bytes.

Partial fix for the engine side of https://github.com/dolthub/dolt/issues/11216 (thanks @elianddb). Full JSON `INSERT` rejection of binary-charset strings still needs a charset check earlier in convert/`INSERT` (tracked in #3631).
