### PR TITLE
/server: enable tcp keep alive to reap dead-peer clients

### DIFF
--- a/server/keepalive.go
+++ b/server/keepalive.go
@@ -19,19 +19,11 @@ import (
 	"time"
 )
 
-// DefaultTCPKeepAlive is applied to accepted TCP connections so the server
-// detects peers that died without a clean close -- a client host crash, a kill
-// -9 of the client host, or a network partition -- and reaps their in-flight
-// queries and open transactions within a bounded window, instead of leaving them
-// until net_read_timeout (default 8h) fires.
-//
-// It does not affect connections whose peer is alive: an idle-but-live client's
-// kernel answers keepalive probes at the TCP layer regardless of whether the
-// application is reading, so such connections are never closed by this mechanism.
-// That is the property that makes keepalive a false-positive-free liveness
-// signal, unlike an application-level read deadline.
-//
-// Worst-case detection latency is Idle + Interval*Count = 120s.
+// DefaultTCPKeepAlive detects peers that died without a clean close (host crash,
+// partition) so their queries/transactions are reaped in a bounded window rather
+// than lingering until net_read_timeout (8h). Live peers answer probes at the TCP
+// layer, so idle connections are never affected. Detection latency is
+// Idle+Interval*Count = 120s.
 var DefaultTCPKeepAlive = net.KeepAliveConfig{
 	Enable:   true,
 	Idle:     60 * time.Second,
@@ -39,8 +31,8 @@ var DefaultTCPKeepAlive = net.KeepAliveConfig{
 	Count:    4,
 }
 
-// keepAliveListener enables TCP keepalive on every accepted connection. Non-TCP
-// connections (unix socket, in-memory) pass through untouched.
+// keepAliveListener enables TCP keepalive on accepted connections. Non-TCP conns
+// pass through untouched.
 type keepAliveListener struct {
 	net.Listener
 	cfg net.KeepAliveConfig
@@ -52,9 +44,7 @@ func (l keepAliveListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 	if tc, ok := c.(*net.TCPConn); ok {
-		// Best-effort: SetKeepAliveConfig applies what the platform supports and
-		// returns an error only for unsupported fields, which we tolerate.
-		_ = tc.SetKeepAliveConfig(l.cfg)
+		_ = tc.SetKeepAliveConfig(l.cfg) // best-effort: unsupported fields are ignored
 	}
 	return c, nil
 }

--- a/server/keepalive.go
+++ b/server/keepalive.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net"
+	"time"
+)
+
+// DefaultTCPKeepAlive is applied to accepted TCP connections so the server
+// detects peers that died without a clean close -- a client host crash, a kill
+// -9 of the client host, or a network partition -- and reaps their in-flight
+// queries and open transactions within a bounded window, instead of leaving them
+// until net_read_timeout (default 8h) fires.
+//
+// It does not affect connections whose peer is alive: an idle-but-live client's
+// kernel answers keepalive probes at the TCP layer regardless of whether the
+// application is reading, so such connections are never closed by this mechanism.
+// That is the property that makes keepalive a false-positive-free liveness
+// signal, unlike an application-level read deadline.
+//
+// Worst-case detection latency is Idle + Interval*Count = 120s.
+var DefaultTCPKeepAlive = net.KeepAliveConfig{
+	Enable:   true,
+	Idle:     60 * time.Second,
+	Interval: 15 * time.Second,
+	Count:    4,
+}
+
+// keepAliveListener enables TCP keepalive on every accepted connection. Non-TCP
+// connections (unix socket, in-memory) pass through untouched.
+type keepAliveListener struct {
+	net.Listener
+	cfg net.KeepAliveConfig
+}
+
+func (l keepAliveListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	if tc, ok := c.(*net.TCPConn); ok {
+		// Best-effort: SetKeepAliveConfig applies what the platform supports and
+		// returns an error only for unsupported fields, which we tolerate.
+		_ = tc.SetKeepAliveConfig(l.cfg)
+	}
+	return c, nil
+}

--- a/server/keepalive.go
+++ b/server/keepalive.go
@@ -21,9 +21,9 @@ import (
 
 // DefaultTCPKeepAlive detects peers that died without a clean close (host crash,
 // partition) so their queries/transactions are reaped in a bounded window rather
-// than lingering until net_read_timeout (8h). Live peers answer probes at the TCP
-// layer, so idle connections are never affected. Detection latency is
-// Idle+Interval*Count = 120s.
+// than lingering until net_read_timeout fires (which embedders may set arbitrarily
+// high). Live peers answer probes at the TCP layer, so idle connections are never
+// affected. Detection latency is Idle+Interval*Count = 120s.
 var DefaultTCPKeepAlive = net.KeepAliveConfig{
 	Enable:   true,
 	Idle:     60 * time.Second,

--- a/server/keepalive_test.go
+++ b/server/keepalive_test.go
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
+//go:build linux
 
 package server
 
 import (
 	"net"
-	"runtime"
 	"testing"
 	"time"
 
@@ -27,10 +26,9 @@ import (
 )
 
 // TestAcceptedConnHasKeepAlive verifies keepAliveListener arms TCP keepalive on
-// every accepted connection -- the wiring that lets the server detect half-open
-// (dead-peer) clients that never send a FIN. It asserts the socket option
-// directly rather than trying to reap a dead peer, which cannot be simulated on
-// loopback (the client kernel answers keepalive probes).
+// accepted connections. Dead-peer detection itself can't be simulated on loopback
+// (the client kernel answers probes), so this asserts the socket options
+// directly. Linux-only: TCP_KEEPIDLE is Linux-specific.
 func TestAcceptedConnHasKeepAlive(t *testing.T) {
 	base, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -69,24 +67,16 @@ func TestAcceptedConnHasKeepAlive(t *testing.T) {
 	raw, err := tc.SyscallConn()
 	require.NoError(t, err)
 
-	var (
-		keepAlive int
-		idle      int
-		idleErr   error
-		getErr    error
-	)
+	var keepAlive, idle int
+	var getErr error
 	require.NoError(t, raw.Control(func(fd uintptr) {
 		keepAlive, getErr = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_KEEPALIVE)
-		if runtime.GOOS == "linux" {
-			// TCP_KEEPIDLE (seconds) is Linux-specific; other unixes map Idle
-			// differently, so only assert the value there.
-			idle, idleErr = unix.GetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPIDLE)
+		if getErr != nil {
+			return
 		}
+		idle, getErr = unix.GetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPIDLE)
 	}))
 	require.NoError(t, getErr)
 	require.Equal(t, 1, keepAlive, "SO_KEEPALIVE should be enabled on the accepted conn")
-	if runtime.GOOS == "linux" {
-		require.NoError(t, idleErr)
-		require.Equal(t, 37, idle, "TCP_KEEPIDLE should match the configured Idle")
-	}
+	require.Equal(t, 37, idle, "TCP_KEEPIDLE should match the configured Idle")
 }

--- a/server/keepalive_test.go
+++ b/server/keepalive_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package server
+
+import (
+	"net"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// TestAcceptedConnHasKeepAlive verifies keepAliveListener arms TCP keepalive on
+// every accepted connection -- the wiring that lets the server detect half-open
+// (dead-peer) clients that never send a FIN. It asserts the socket option
+// directly rather than trying to reap a dead peer, which cannot be simulated on
+// loopback (the client kernel answers keepalive probes).
+func TestAcceptedConnHasKeepAlive(t *testing.T) {
+	base, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer base.Close()
+
+	// Values distinguishable from any OS default so the assertions are meaningful.
+	l := keepAliveListener{Listener: base, cfg: net.KeepAliveConfig{
+		Enable:   true,
+		Idle:     37 * time.Second,
+		Interval: 11 * time.Second,
+		Count:    5,
+	}}
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		if c, err := l.Accept(); err == nil {
+			accepted <- c
+		}
+	}()
+
+	client, err := net.Dial("tcp", base.Addr().String())
+	require.NoError(t, err)
+	defer client.Close()
+
+	var srv net.Conn
+	select {
+	case srv = <-accepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listener never accepted the connection")
+	}
+	defer srv.Close()
+
+	tc, ok := srv.(*net.TCPConn)
+	require.True(t, ok, "accepted conn should be *net.TCPConn")
+
+	raw, err := tc.SyscallConn()
+	require.NoError(t, err)
+
+	var (
+		keepAlive int
+		idle      int
+		idleErr   error
+		getErr    error
+	)
+	require.NoError(t, raw.Control(func(fd uintptr) {
+		keepAlive, getErr = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_KEEPALIVE)
+		if runtime.GOOS == "linux" {
+			// TCP_KEEPIDLE (seconds) is Linux-specific; other unixes map Idle
+			// differently, so only assert the value there.
+			idle, idleErr = unix.GetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_KEEPIDLE)
+		}
+	}))
+	require.NoError(t, getErr)
+	require.Equal(t, 1, keepAlive, "SO_KEEPALIVE should be enabled on the accepted conn")
+	if runtime.GOOS == "linux" {
+		require.NoError(t, idleErr)
+		require.Equal(t, 37, idle, "TCP_KEEPIDLE should match the configured Idle")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -185,7 +185,7 @@ func newServerFromHandler(cfg Config, e *sqle.Engine, sm *SessionManager, handle
 	// Enable TCP keepalive on accepted connections so peers that die without a
 	// clean close (host crash, kill -9 of the client host, network partition) are
 	// detected and their queries/transactions reaped within a bounded window,
-	// rather than lingering until net_read_timeout (default 8h) fires.
+	// rather than lingering until net_read_timeout fires.
 	if l != nil {
 		kaCfg := DefaultTCPKeepAlive
 		if cfg.TCPKeepAlive != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -182,6 +182,18 @@ func newServerFromHandler(cfg Config, e *sqle.Engine, sm *SessionManager, handle
 		}
 	}
 
+	// Enable TCP keepalive on accepted connections so peers that die without a
+	// clean close (host crash, kill -9 of the client host, network partition) are
+	// detected and their queries/transactions reaped within a bounded window,
+	// rather than lingering until net_read_timeout (default 8h) fires.
+	if l != nil {
+		kaCfg := DefaultTCPKeepAlive
+		if cfg.TCPKeepAlive != nil {
+			kaCfg = *cfg.TCPKeepAlive
+		}
+		l = keepAliveListener{Listener: l, cfg: kaCfg}
+	}
+
 	listenerCfg := mysql.ListenerConfig{
 		Listener:                 l,
 		AuthServer:               e.Analyzer.Catalog.MySQLDb,

--- a/server/server_config.go
+++ b/server/server_config.go
@@ -109,6 +109,10 @@ type Config struct {
 	// true to let such queries run to completion regardless of the client's
 	// state.
 	DisableConnectionWatcher bool
+	// TCPKeepAlive overrides the keepalive settings applied to accepted TCP
+	// connections. Nil uses DefaultTCPKeepAlive; set a config with Enable=false to
+	// disable keepalive entirely.
+	TCPKeepAlive *net.KeepAliveConfig
 }
 
 func (c Config) NewConfig() (Config, error) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -216,4 +217,157 @@ func TestConnectionWatcherDisabled(t *testing.T) {
 	require.Never(t, func() bool {
 		return runningQueries(engine) == 0
 	}, 2*time.Second, 50*time.Millisecond, "query was cancelled despite watcher being disabled")
+}
+
+// sleepingConns counts connected sessions with no query running -- the state an
+// idle-in-transaction connection sits in.
+func sleepingConns(engine *sqle.Engine) int {
+	n := 0
+	for _, p := range engine.ProcessList.Processes() {
+		if p.Command == gsql.ProcessCommandSleep {
+			n++
+		}
+	}
+	return n
+}
+
+// connectClient opens a vitess client connection without issuing a query.
+func connectClient(t *testing.T, host string, port int) *vsql.Conn {
+	t.Helper()
+	conn, err := vsql.Connect(context.Background(), &vsql.ConnParams{
+		Host:   host,
+		Port:   port,
+		Uname:  "root",
+		DbName: "mydb",
+	})
+	require.NoError(t, err)
+	return conn
+}
+
+// seedTable creates a table on a short-lived, cleanly-closed connection.
+func seedTable(t *testing.T, host string, port int) {
+	t.Helper()
+	conn := connectClient(t, host, port)
+	defer conn.Close()
+	_, err := conn.ExecuteFetch("CREATE TABLE t (id INT PRIMARY KEY)", 1, false)
+	require.NoError(t, err)
+}
+
+// TestConnectionWatcherHalfOpenNotReaped: unlike a clean disconnect, a client
+// that stops reading without sending a FIN leaves the socket silent but open. The
+// watcher's Peek never returns, so a mid-query disconnect is NOT reaped.
+//
+// The client here is alive-but-silent (its kernel still ACKs), which is
+// indistinguishable from a legitimately long query the client is awaiting, so
+// this is correctly NOT reapable by liveness detection -- TCP keepalive leaves it
+// alone by design. The only thing that reaps an alive-but-silent socket is
+// net_read_timeout; see TestConnReadTimeoutReapsHalfOpenQuery. (Keepalive instead
+// targets a truly dead peer -- host crash / partition -- which cannot be
+// simulated on loopback; see TestAcceptedConnHasKeepAlive for that wiring.)
+func TestConnectionWatcherHalfOpenNotReaped(t *testing.T) {
+	engine, host, port := startWatcherTestServer(t, server.Config{})
+
+	// Long enough to outlast the window, short enough to self-clean after.
+	conn, _ := runSleepQuery(t, host, port, 10)
+	// Keep conn referenced so its fd isn't closed -- a close would make this the
+	// clean-disconnect case the watcher handles.
+	defer runtime.KeepAlive(conn)
+
+	require.Eventually(t, func() bool {
+		return runningQueries(engine) > 0
+	}, 10*time.Second, 10*time.Millisecond, "query never started running on server")
+
+	// Do NOT close conn: silent but open (half-open). ConnReadTimeout is unset, so
+	// the watcher's Peek blocks forever and the query keeps running.
+	require.Never(t, func() bool {
+		return runningQueries(engine) == 0
+	}, 3*time.Second, 50*time.Millisecond,
+		"half-open client's query was reaped, but the watcher cannot see a silent socket")
+}
+
+// TestConnReadTimeoutReapsHalfOpenQuery: net_read_timeout is the only backstop
+// for a half-open mid-query disconnect -- its read deadline wakes the watcher's
+// Peek, cancelling the query. (Default is infinite in GMS, 8h in Dolt.)
+func TestConnReadTimeoutReapsHalfOpenQuery(t *testing.T) {
+	engine, host, port := startWatcherTestServer(t, server.Config{
+		ConnReadTimeout: 2 * time.Second,
+	})
+
+	conn, _ := runSleepQuery(t, host, port, 30)
+	defer runtime.KeepAlive(conn)
+
+	require.Eventually(t, func() bool {
+		return runningQueries(engine) > 0
+	}, 10*time.Second, 10*time.Millisecond, "query never started running on server")
+
+	// Silent (half-open): the read deadline fires ~2s later and cancels the query.
+	require.Eventually(t, func() bool {
+		return runningQueries(engine) == 0
+	}, 10*time.Second, 50*time.Millisecond,
+		"half-open query was not reaped by net_read_timeout backstop")
+}
+
+// TestIdleTransactionHalfOpenNotReaped: a client opens a transaction (BEGIN +
+// INSERT) then goes silent while idle. The session sits in Sleep holding the
+// transaction; the watcher only examines running queries, so it is never reaped.
+//
+// As in TestConnectionWatcherHalfOpenNotReaped, the client is alive-but-silent
+// (kernel still ACKs), which is indistinguishable from a healthy idle connection,
+// so it is correctly NOT reapable by liveness detection -- TCP keepalive leaves
+// it alone. The only backstop for an alive-but-silent idle session is
+// net_read_timeout; see TestConnReadTimeoutReapsIdleTransaction. (Keepalive
+// targets a truly dead peer, which reaps the connection and rolls back its
+// transaction via the existing ConnectionClosed teardown.)
+func TestIdleTransactionHalfOpenNotReaped(t *testing.T) {
+	engine, host, port := startWatcherTestServer(t, server.Config{})
+
+	seedTable(t, host, port)
+
+	conn := connectClient(t, host, port)
+	defer runtime.KeepAlive(conn)
+	_, err := conn.ExecuteFetch("BEGIN", 1, false)
+	require.NoError(t, err)
+	_, err = conn.ExecuteFetch("INSERT INTO t VALUES (1)", 1, false)
+	require.NoError(t, err)
+
+	// Write returned: session is idle (Sleep) but still holds the transaction.
+	require.Eventually(t, func() bool {
+		return sleepingConns(engine) >= 1
+	}, 10*time.Second, 10*time.Millisecond, "session never reached idle (Sleep) state")
+
+	// Do NOT close conn: silent but open (half-open). No query runs, so the watcher
+	// never examines it and the transaction lingers.
+	require.Never(t, func() bool {
+		return sleepingConns(engine) == 0
+	}, 3*time.Second, 50*time.Millisecond,
+		"idle-in-transaction session was reaped, but the watcher never examines Sleep-state conns")
+	require.Zero(t, runningQueries(engine), "no query should be running for an idle session")
+}
+
+// TestConnReadTimeoutReapsIdleTransaction: net_read_timeout is the only backstop
+// for an idle-in-transaction half-open client -- the handler's next-command read
+// deadline fires, closing the connection and reaping the transaction.
+func TestConnReadTimeoutReapsIdleTransaction(t *testing.T) {
+	engine, host, port := startWatcherTestServer(t, server.Config{
+		ConnReadTimeout: 2 * time.Second,
+	})
+
+	seedTable(t, host, port)
+
+	conn := connectClient(t, host, port)
+	defer runtime.KeepAlive(conn)
+	_, err := conn.ExecuteFetch("BEGIN", 1, false)
+	require.NoError(t, err)
+	_, err = conn.ExecuteFetch("INSERT INTO t VALUES (1)", 1, false)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return sleepingConns(engine) >= 1
+	}, 10*time.Second, 10*time.Millisecond, "session never reached idle (Sleep) state")
+
+	// Silent (half-open): the read deadline fires ~2s later and reaps the conn.
+	require.Eventually(t, func() bool {
+		return sleepingConns(engine) == 0
+	}, 10*time.Second, 50*time.Millisecond,
+		"idle-in-transaction session was not reaped by net_read_timeout backstop")
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -280,7 +280,7 @@ func TestConnectionWatcherHalfOpenNotReaped(t *testing.T) {
 
 // TestConnReadTimeoutReapsHalfOpenQuery: net_read_timeout is the only backstop
 // for a half-open mid-query disconnect -- its read deadline wakes the watcher's
-// Peek, cancelling the query. (Default is infinite in GMS, 8h in Dolt.)
+// Peek, cancelling the query.
 func TestConnReadTimeoutReapsHalfOpenQuery(t *testing.T) {
 	engine, host, port := startWatcherTestServer(t, server.Config{
 		ConnReadTimeout: 2 * time.Second,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -253,32 +253,25 @@ func seedTable(t *testing.T, host string, port int) {
 	require.NoError(t, err)
 }
 
-// TestConnectionWatcherHalfOpenNotReaped: unlike a clean disconnect, a client
-// that stops reading without sending a FIN leaves the socket silent but open. The
-// watcher's Peek never returns, so a mid-query disconnect is NOT reaped.
-//
-// The client here is alive-but-silent (its kernel still ACKs), which is
-// indistinguishable from a legitimately long query the client is awaiting, so
-// this is correctly NOT reapable by liveness detection -- TCP keepalive leaves it
-// alone by design. The only thing that reaps an alive-but-silent socket is
-// net_read_timeout; see TestConnReadTimeoutReapsHalfOpenQuery. (Keepalive instead
-// targets a truly dead peer -- host crash / partition -- which cannot be
-// simulated on loopback; see TestAcceptedConnHasKeepAlive for that wiring.)
+// TestConnectionWatcherHalfOpenNotReaped: a client that goes silent without
+// closing (alive-but-silent, kernel still ACKs) is not reaped mid-query. This is
+// correct -- it's indistinguishable from a long query being awaited, so keepalive
+// leaves it alone; only net_read_timeout reaps it (see
+// TestConnReadTimeoutReapsHalfOpenQuery). Keepalive targets truly dead peers,
+// which can't be simulated on loopback (see TestAcceptedConnHasKeepAlive).
 func TestConnectionWatcherHalfOpenNotReaped(t *testing.T) {
 	engine, host, port := startWatcherTestServer(t, server.Config{})
 
 	// Long enough to outlast the window, short enough to self-clean after.
 	conn, _ := runSleepQuery(t, host, port, 10)
-	// Keep conn referenced so its fd isn't closed -- a close would make this the
-	// clean-disconnect case the watcher handles.
+	// Keep conn referenced so its fd isn't closed (a close would be Mode A).
 	defer runtime.KeepAlive(conn)
 
 	require.Eventually(t, func() bool {
 		return runningQueries(engine) > 0
 	}, 10*time.Second, 10*time.Millisecond, "query never started running on server")
 
-	// Do NOT close conn: silent but open (half-open). ConnReadTimeout is unset, so
-	// the watcher's Peek blocks forever and the query keeps running.
+	// Silent but open: the watcher's Peek blocks forever, so the query keeps running.
 	require.Never(t, func() bool {
 		return runningQueries(engine) == 0
 	}, 3*time.Second, 50*time.Millisecond,
@@ -308,16 +301,10 @@ func TestConnReadTimeoutReapsHalfOpenQuery(t *testing.T) {
 }
 
 // TestIdleTransactionHalfOpenNotReaped: a client opens a transaction (BEGIN +
-// INSERT) then goes silent while idle. The session sits in Sleep holding the
-// transaction; the watcher only examines running queries, so it is never reaped.
-//
-// As in TestConnectionWatcherHalfOpenNotReaped, the client is alive-but-silent
-// (kernel still ACKs), which is indistinguishable from a healthy idle connection,
-// so it is correctly NOT reapable by liveness detection -- TCP keepalive leaves
-// it alone. The only backstop for an alive-but-silent idle session is
-// net_read_timeout; see TestConnReadTimeoutReapsIdleTransaction. (Keepalive
-// targets a truly dead peer, which reaps the connection and rolls back its
-// transaction via the existing ConnectionClosed teardown.)
+// INSERT) then goes silent while idle (Sleep). The watcher only examines running
+// queries, so it never reaps this. Like the mid-query case, an alive-but-silent
+// idle session is correctly not reaped by keepalive; only net_read_timeout does
+// (see TestConnReadTimeoutReapsIdleTransaction).
 func TestIdleTransactionHalfOpenNotReaped(t *testing.T) {
 	engine, host, port := startWatcherTestServer(t, server.Config{})
 
@@ -335,8 +322,7 @@ func TestIdleTransactionHalfOpenNotReaped(t *testing.T) {
 		return sleepingConns(engine) >= 1
 	}, 10*time.Second, 10*time.Millisecond, "session never reached idle (Sleep) state")
 
-	// Do NOT close conn: silent but open (half-open). No query runs, so the watcher
-	// never examines it and the transaction lingers.
+	// Silent but open: no query runs, so the watcher never examines it.
 	require.Never(t, func() bool {
 		return sleepingConns(engine) == 0
 	}, 3*time.Second, 50*time.Millisecond,


### PR DESCRIPTION
When a client's host dies without a clean close — crash, kill -9 of the client host, or network partition — no FIN reaches the server. The connection watcher can't help (its Peek blocks forever on a silent socket, and it never examines idle sessions at all), so the client's in-flight query or idle-but-open transaction keeps running/holding locks until net_read_timeout fires — 8h by default in Dolt. These pile up as "running" and pin CPU.

This PR enables TCP keepalive on every accepted connection. A dead peer stops answering probes, so the kernel errors the socket within a bounded window (~120s default), which:
  - wakes the watcher's Peek and will cancel a long-running query.
  - wakes the handler's blocked read so that ConnectionClosed rolls back the transaction via existing teardown.