### PR TITLE
Recompute generated columns after foreign key referential actions

### DIFF
--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -2731,6 +2731,121 @@ var ForeignKeyTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "ON UPDATE CASCADE maintains an index over a virtual column",
+		SetUpScript: []string{
+			"CREATE TABLE vc_parent (id int PRIMARY KEY);",
+			"CREATE TABLE vc_child (id int PRIMARY KEY, parentId int, vcol int AS (parentId) VIRTUAL, UNIQUE KEY uk (vcol), FOREIGN KEY (parentId) REFERENCES vc_parent(id) ON UPDATE CASCADE);",
+			"INSERT INTO vc_parent VALUES (2);",
+			"INSERT INTO vc_child (id, parentId) VALUES (20, 2);",
+			"UPDATE vc_parent SET id = 99 WHERE id = 2;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, parentId, vcol FROM vc_child ORDER BY id;",
+				Expected: []sql.Row{{20, 99, 99}},
+			},
+			{
+				Query:    "SELECT id FROM vc_child WHERE vcol = 99;",
+				Expected: []sql.Row{{20}},
+			},
+			{
+				Query: "SELECT id FROM vc_child WHERE vcol = 2;",
+				// The old value 2 must no longer be in the index.
+				Expected: []sql.Row{},
+			},
+			{
+				Query:       "INSERT INTO vc_child (id, parentId) VALUES (40, 99);",
+				ExpectedErr: sql.ErrUniqueKeyViolation,
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "ON UPDATE CASCADE recomputes chained virtual columns",
+		SetUpScript: []string{
+			"CREATE TABLE vc_parent (id int PRIMARY KEY);",
+			"CREATE TABLE vc_child (id int PRIMARY KEY, parentId int, v1 int AS (parentId) VIRTUAL, v2 int AS (v1 + 100) VIRTUAL, UNIQUE KEY uk (v2), FOREIGN KEY (parentId) REFERENCES vc_parent(id) ON UPDATE CASCADE);",
+			"INSERT INTO vc_parent VALUES (2);",
+			"INSERT INTO vc_child (id, parentId) VALUES (20, 2);",
+			"UPDATE vc_parent SET id = 99 WHERE id = 2;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, parentId, v1, v2 FROM vc_child ORDER BY id;",
+				Expected: []sql.Row{{20, 99, 99, 199}},
+			},
+			{
+				Query:    "SELECT id FROM vc_child WHERE v2 = 199;",
+				Expected: []sql.Row{{20}},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "ON DELETE SET NULL maintains an index over a virtual column",
+		SetUpScript: []string{
+			"CREATE TABLE vc_parent (id int PRIMARY KEY);",
+			"CREATE TABLE vc_child (id int PRIMARY KEY, parentId int, vcol int AS (parentId) VIRTUAL, UNIQUE KEY uk (vcol), FOREIGN KEY (parentId) REFERENCES vc_parent(id) ON DELETE SET NULL);",
+			"INSERT INTO vc_parent VALUES (2);",
+			"INSERT INTO vc_child (id, parentId) VALUES (20, 2);",
+			"DELETE FROM vc_parent WHERE id = 2;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, parentId, vcol FROM vc_child ORDER BY id;",
+				Expected: []sql.Row{{20, nil, nil}},
+			},
+			{
+				Query: "SELECT id FROM vc_child WHERE vcol = 2;",
+				// The old value 2 must no longer be in the index.
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "ON UPDATE SET NULL maintains an index over a virtual column",
+		SetUpScript: []string{
+			"CREATE TABLE vc_parent (id int PRIMARY KEY);",
+			"CREATE TABLE vc_child (id int PRIMARY KEY, parentId int, vcol int AS (parentId) VIRTUAL, UNIQUE KEY uk (vcol), FOREIGN KEY (parentId) REFERENCES vc_parent(id) ON UPDATE SET NULL);",
+			"INSERT INTO vc_parent VALUES (2);",
+			"INSERT INTO vc_child (id, parentId) VALUES (20, 2);",
+			"UPDATE vc_parent SET id = 99 WHERE id = 2;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, parentId, vcol FROM vc_child ORDER BY id;",
+				Expected: []sql.Row{{20, nil, nil}},
+			},
+			{
+				Query: "SELECT id FROM vc_child WHERE vcol = 2;",
+				// The old value 2 must no longer be in the index.
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "self-referential ON DELETE SET NULL maintains an index over a virtual column",
+		SetUpScript: []string{
+			"CREATE TABLE vc_t (id int PRIMARY KEY, parentId int, parentKey int AS (parentId) VIRTUAL, UNIQUE KEY uk (parentKey), FOREIGN KEY (parentId) REFERENCES vc_t(id) ON DELETE SET NULL);",
+			"INSERT INTO vc_t (id, parentId) VALUES (1, NULL), (2, 1), (3, 2);",
+			"DELETE FROM vc_t WHERE id = 2;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, parentId, parentKey FROM vc_t ORDER BY id;",
+				Expected: []sql.Row{{1, nil, nil}, {3, nil, nil}},
+			},
+			{
+				Query: "SELECT id FROM vc_t WHERE parentKey = 2;",
+				// The old value 2 must no longer be in the index.
+				Expected: []sql.Row{},
+			},
+		},
+	},
 }
 
 var CreateForeignKeyTests = []ScriptTest{

--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -2751,8 +2751,7 @@ var ForeignKeyTests = []ScriptTest{
 				Expected: []sql.Row{{20}},
 			},
 			{
-				Query: "SELECT id FROM vc_child WHERE vcol = 2;",
-				// The old value 2 must no longer be in the index.
+				Query:    "SELECT id FROM vc_child WHERE vcol = 2;",
 				Expected: []sql.Row{},
 			},
 			{
@@ -2798,8 +2797,7 @@ var ForeignKeyTests = []ScriptTest{
 				Expected: []sql.Row{{20, nil, nil}},
 			},
 			{
-				Query: "SELECT id FROM vc_child WHERE vcol = 2;",
-				// The old value 2 must no longer be in the index.
+				Query:    "SELECT id FROM vc_child WHERE vcol = 2;",
 				Expected: []sql.Row{},
 			},
 		},
@@ -2820,8 +2818,7 @@ var ForeignKeyTests = []ScriptTest{
 				Expected: []sql.Row{{20, nil, nil}},
 			},
 			{
-				Query: "SELECT id FROM vc_child WHERE vcol = 2;",
-				// The old value 2 must no longer be in the index.
+				Query:    "SELECT id FROM vc_child WHERE vcol = 2;",
 				Expected: []sql.Row{},
 			},
 		},
@@ -2840,8 +2837,7 @@ var ForeignKeyTests = []ScriptTest{
 				Expected: []sql.Row{{1, nil, nil}, {3, nil, nil}},
 			},
 			{
-				Query: "SELECT id FROM vc_t WHERE parentKey = 2;",
-				// The old value 2 must no longer be in the index.
+				Query:    "SELECT id FROM vc_t WHERE parentKey = 2;",
 				Expected: []sql.Row{},
 			},
 		},

--- a/enginetest/queries/generated_columns.go
+++ b/enginetest/queries/generated_columns.go
@@ -1563,8 +1563,7 @@ var BrokenGeneratedColumnTests = []ScriptTest{
 				Expected: []sql.Row{{2}},
 			},
 			{
-				Query: "SELECT id FROM odku_v WHERE vcol = 120;",
-				// The old vcol=120 index entry must be gone.
+				Query:    "SELECT id FROM odku_v WHERE vcol = 120;",
 				Expected: []sql.Row{},
 			},
 		},
@@ -1587,8 +1586,7 @@ var BrokenGeneratedColumnTests = []ScriptTest{
 				Expected: []sql.Row{{2}},
 			},
 			{
-				Query: "SELECT id FROM replace_v WHERE vcol = 120;",
-				// The old vcol=120 index entry must be gone.
+				Query:    "SELECT id FROM replace_v WHERE vcol = 120;",
 				Expected: []sql.Row{},
 			},
 		},

--- a/enginetest/queries/generated_columns.go
+++ b/enginetest/queries/generated_columns.go
@@ -1545,4 +1545,52 @@ var BrokenGeneratedColumnTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		// See https://github.com/dolthub/dolt/issues/8881
+		Name: "INSERT ON DUPLICATE KEY UPDATE with an index over a virtual generated column",
+		SetUpScript: []string{
+			"CREATE TABLE odku_v (id int PRIMARY KEY, base int, vcol int AS (base + 100) VIRTUAL, UNIQUE KEY uk_v (vcol));",
+			"INSERT INTO odku_v (id, base) VALUES (1, 10), (2, 20);",
+			"INSERT INTO odku_v (id, base) VALUES (2, 55) ON DUPLICATE KEY UPDATE base = 99;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, base, vcol FROM odku_v ORDER BY id;",
+				Expected: []sql.Row{{1, 10, 110}, {2, 99, 199}},
+			},
+			{
+				Query:    "SELECT id FROM odku_v WHERE vcol = 199;",
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query: "SELECT id FROM odku_v WHERE vcol = 120;",
+				// The old vcol=120 index entry must be gone.
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/8881
+		Name: "REPLACE INTO with an index over a virtual generated column",
+		SetUpScript: []string{
+			"CREATE TABLE replace_v (id int PRIMARY KEY, base int, vcol int AS (base + 100) VIRTUAL, UNIQUE KEY uk_v (vcol));",
+			"INSERT INTO replace_v (id, base) VALUES (1, 10), (2, 20);",
+			"REPLACE INTO replace_v (id, base) VALUES (2, 88);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, base, vcol FROM replace_v ORDER BY id;",
+				Expected: []sql.Row{{1, 10, 110}, {2, 88, 188}},
+			},
+			{
+				Query:    "SELECT id FROM replace_v WHERE vcol = 188;",
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query: "SELECT id FROM replace_v WHERE vcol = 120;",
+				// The old vcol=120 index entry must be gone.
+				Expected: []sql.Row{},
+			},
+		},
+	},
 }

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -254,7 +254,10 @@ func getForeignKeyReferences(ctx *sql.Context, catalog *Catalog, tbl sql.Foreign
 	}
 	fkChain = fkChain.AddTable(fks[0].Database, fks[0].SchemaName, fks[0].Table).AddTableUpdater(fks[0].Database, fks[0].SchemaName, fks[0].Table, updater)
 
-	tblSch := tbl.Schema(ctx)
+	tblSch, err := resolveSchemaDefaults(ctx, catalog, tbl)
+	if err != nil {
+		return nil, err
+	}
 	fkEditor := &plan.ForeignKeyEditor{
 		Schema:     tblSch,
 		Editor:     updater,
@@ -342,7 +345,10 @@ func getForeignKeyRefActions(ctx *sql.Context, catalog *Catalog, tbl sql.Foreign
 		return cachedFkEditor, nil
 	}
 	// No matching editor was cached, so we either create a new one or add to the existing one
-	tblSch := tbl.Schema(ctx)
+	tblSch, err := resolveSchemaDefaults(ctx, catalog, tbl)
+	if err != nil {
+		return nil, err
+	}
 	if fkEditor == nil {
 		fkEditor = &plan.ForeignKeyEditor{
 			Schema:     tblSch,
@@ -502,21 +508,30 @@ func resolveSchemaDefaults(ctx *sql.Context, catalog *Catalog, table sql.Table) 
 	// Field Indexes are off by one initially and don't fixed by assignExecIndexes because it doesn't traverse through
 	// the ForeignKeyEditors and referential actions, so we correct them here. This is safe because we know these fields
 	// will only ever be accessed within the scope of a single table, so all we have to do is decrement the index by 1.
-	for i, col := range childTblSch {
-		if col.Default != nil {
-			expr := col.Default.Expr
-			expr, identity, err := transform.Expr(ctx, expr, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
-				if gf, ok := e.(*expression.GetField); ok {
-					return gf.WithIndex(gf.Index() - 1), transform.NewTree, nil
-				}
-				return e, transform.SameTree, nil
-			})
-			if err != nil {
-				return nil, err
+	decrementFieldIndexes := func(cd *sql.ColumnDefaultValue) error {
+		if cd == nil {
+			return nil
+		}
+		expr, identity, err := transform.Expr(ctx, cd.Expr, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+			if gf, ok := e.(*expression.GetField); ok {
+				return gf.WithIndex(gf.Index() - 1), transform.NewTree, nil
 			}
-			if identity == transform.NewTree {
-				childTblSch[i].Default.Expr = expr
-			}
+			return e, transform.SameTree, nil
+		})
+		if err != nil {
+			return err
+		}
+		if identity == transform.NewTree {
+			cd.Expr = expr
+		}
+		return nil
+	}
+	for i := range childTblSch {
+		if err := decrementFieldIndexes(childTblSch[i].Default); err != nil {
+			return nil, err
+		}
+		if err := decrementFieldIndexes(childTblSch[i].Generated); err != nil {
+			return nil, err
 		}
 	}
 

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -254,7 +254,7 @@ func getForeignKeyReferences(ctx *sql.Context, catalog *Catalog, tbl sql.Foreign
 	}
 	fkChain = fkChain.AddTable(fks[0].Database, fks[0].SchemaName, fks[0].Table).AddTableUpdater(fks[0].Database, fks[0].SchemaName, fks[0].Table, updater)
 
-	tblSch, err := resolveSchemaDefaults(ctx, catalog, tbl)
+	tblSch, err := resolveSchemaColumnExpressions(ctx, catalog, tbl)
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +345,7 @@ func getForeignKeyRefActions(ctx *sql.Context, catalog *Catalog, tbl sql.Foreign
 		return cachedFkEditor, nil
 	}
 	// No matching editor was cached, so we either create a new one or add to the existing one
-	tblSch, err := resolveSchemaDefaults(ctx, catalog, tbl)
+	tblSch, err := resolveSchemaColumnExpressions(ctx, catalog, tbl)
 	if err != nil {
 		return nil, err
 	}
@@ -412,7 +412,7 @@ func getForeignKeyRefActions(ctx *sql.Context, catalog *Catalog, tbl sql.Foreign
 		//       manually do that here. Moving all the FK information into the binding, planbuilder, phase would
 		//       clean this up. We should also fix assignExecIndexes to find all these FK schema references and fix
 		//       their exec indexes.
-		childTblSch, err := resolveSchemaDefaults(ctx, catalog, childTbl)
+		childTblSch, err := resolveSchemaColumnExpressions(ctx, catalog, childTbl)
 		if err != nil {
 			return nil, err
 		}
@@ -457,9 +457,10 @@ func getForeignKeyRefActions(ctx *sql.Context, catalog *Catalog, tbl sql.Foreign
 				IndexPositions:        indexPositions,
 				AppendTypes:           appendTypes,
 			},
-			Editor:             childEditor,
-			ForeignKey:         fk,
-			ChildParentMapping: childParentMapping,
+			Editor:               childEditor,
+			ForeignKey:           fk,
+			ChildParentMapping:   childParentMapping,
+			GeneratedProjections: childEditor.Schema.GeneratedProjections(),
 		}
 	}
 	return fkEditor, nil
@@ -495,43 +496,36 @@ func getForeignKeyHandlerFromUpdateTarget(ctx *sql.Context, catalog *Catalog, up
 	}, nil
 }
 
-// resolveSchemaDefaults resolves the default values for the schema of |table|. This is primarily needed for column
-// default value expressions, since those don't get resolved during the planbuilder phase and assignExecIndexes
-// doesn't traverse through the ForeignKeyEditors and referential actions to find all of them. In addition to resolving
-// the expressions, this also ensures their GetField indexes are correct, knowing that those expressions will only
-// be evaluated in the context of a single table.
-func resolveSchemaDefaults(ctx *sql.Context, catalog *Catalog, table sql.Table) (sql.Schema, error) {
-	// Resolve any column default expressions in tblSch
+// resolveSchemaColumnExpressions returns the schema of |table| with its default and generated column
+// expressions resolved, because the normal planbuilder phase does not resolve them for this foreign key
+// path and assignExecIndexes does not traverse foreign key editors to find them. It also decrements their
+// GetField indexes by one, which is safe because they are only evaluated against a single table's row.
+func resolveSchemaColumnExpressions(ctx *sql.Context, catalog *Catalog, table sql.Table) (sql.Schema, error) {
+	// Resolve the default and generated column expressions in tblSch
 	builder := planbuilder.New(ctx, catalog, nil)
 	childTblSch := builder.ResolveSchemaDefaults(ctx.GetCurrentDatabase(), table.Name(), table.Schema(ctx))
 
 	// Field Indexes are off by one initially and don't fixed by assignExecIndexes because it doesn't traverse through
 	// the ForeignKeyEditors and referential actions, so we correct them here. This is safe because we know these fields
 	// will only ever be accessed within the scope of a single table, so all we have to do is decrement the index by 1.
-	decrementFieldIndexes := func(cd *sql.ColumnDefaultValue) error {
-		if cd == nil {
-			return nil
-		}
-		expr, identity, err := transform.Expr(ctx, cd.Expr, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
-			if gf, ok := e.(*expression.GetField); ok {
-				return gf.WithIndex(gf.Index() - 1), transform.NewTree, nil
-			}
-			return e, transform.SameTree, nil
-		})
-		if err != nil {
-			return err
-		}
-		if identity == transform.NewTree {
-			cd.Expr = expr
-		}
-		return nil
-	}
+	// TODO(elianddb): rm correction once foreign key schemas are resolved during binding, where assignExecIndexes would number these expressions correctly.
 	for i := range childTblSch {
-		if err := decrementFieldIndexes(childTblSch[i].Default); err != nil {
-			return nil, err
-		}
-		if err := decrementFieldIndexes(childTblSch[i].Generated); err != nil {
-			return nil, err
+		for _, cd := range []*sql.ColumnDefaultValue{childTblSch[i].Default, childTblSch[i].Generated} {
+			if cd == nil {
+				continue
+			}
+			expr, identity, err := transform.Expr(ctx, cd.Expr, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+				if gf, ok := e.(*expression.GetField); ok {
+					return gf.WithIndex(gf.Index() - 1), transform.NewTree, nil
+				}
+				return e, transform.SameTree, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			if identity == transform.NewTree {
+				cd.Expr = expr
+			}
 		}
 	}
 

--- a/sql/plan/foreign_key_editor.go
+++ b/sql/plan/foreign_key_editor.go
@@ -43,7 +43,9 @@ type ForeignKeyRefActionData struct {
 	RowMapper          *ForeignKeyRowMapper
 	Editor             *ForeignKeyEditor
 	ChildParentMapping ChildParentMapping
-	ForeignKey         sql.ForeignKeyConstraint
+	// GeneratedProjections holds the child schema's generated column expressions to eval FK referential actions.
+	GeneratedProjections []sql.Expression
+	ForeignKey           sql.ForeignKeyConstraint
 }
 
 // ForeignKeyEditor handles update and delete operations, as they may have referential actions on other tables (such as
@@ -192,7 +194,7 @@ func (fkEditor *ForeignKeyEditor) OnUpdateCascade(ctx *sql.Context, refActionDat
 				updatedRow[i] = new[mappedVal]
 			}
 		}
-		if err = recomputeGeneratedColumns(ctx, refActionData.Editor.Schema, updatedRow); err != nil {
+		if err = sql.EvalProjections(ctx, refActionData.GeneratedProjections, updatedRow); err != nil {
 			return err
 		}
 		err = refActionData.Editor.Update(ctx, rowToUpdate, updatedRow, depth)
@@ -247,7 +249,7 @@ func (fkEditor *ForeignKeyEditor) OnUpdateSetDefault(ctx *sql.Context, refAction
 				}
 			}
 		}
-		if err = recomputeGeneratedColumns(ctx, refActionData.Editor.Schema, modifiedRow); err != nil {
+		if err = sql.EvalProjections(ctx, refActionData.GeneratedProjections, modifiedRow); err != nil {
 			return err
 		}
 		err = refActionData.Editor.Update(ctx, rowToDefault, modifiedRow, depth)
@@ -286,7 +288,7 @@ func (fkEditor *ForeignKeyEditor) OnUpdateSetNull(ctx *sql.Context, refActionDat
 				updatedRow[i] = rowToUpdate[i]
 			}
 		}
-		if err = recomputeGeneratedColumns(ctx, refActionData.Editor.Schema, updatedRow); err != nil {
+		if err = sql.EvalProjections(ctx, refActionData.GeneratedProjections, updatedRow); err != nil {
 			return err
 		}
 		err = refActionData.Editor.Update(ctx, rowToUpdate, updatedRow, depth)
@@ -332,24 +334,6 @@ func (fkEditor *ForeignKeyEditor) Delete(ctx *sql.Context, row sql.Row, depth in
 				return err
 			}
 		}
-	}
-	return nil
-}
-
-// recomputeGeneratedColumns re-evaluates the generated columns of row in place using the resolved
-// generated expressions in schema. A referential action builds the changed row by copying the non-foreign
-// key columns from the old row, which leaves any generated column that depends on the changed columns
-// holding its old value.
-func recomputeGeneratedColumns(ctx *sql.Context, schema sql.Schema, row sql.Row) error {
-	for i, col := range schema {
-		if col.Generated == nil {
-			continue
-		}
-		value, err := col.Generated.Eval(ctx, row)
-		if err != nil {
-			return err
-		}
-		row[i] = value
 	}
 	return nil
 }
@@ -435,7 +419,7 @@ func (fkEditor *ForeignKeyEditor) OnDeleteSetDefault(ctx *sql.Context, refAction
 				}
 			}
 		}
-		if err = recomputeGeneratedColumns(ctx, refActionData.Editor.Schema, modifiedRow); err != nil {
+		if err = sql.EvalProjections(ctx, refActionData.GeneratedProjections, modifiedRow); err != nil {
 			return err
 		}
 		err = refActionData.Editor.Update(ctx, rowToDefault, modifiedRow, depth)
@@ -474,7 +458,7 @@ func (fkEditor *ForeignKeyEditor) OnDeleteSetNull(ctx *sql.Context, refActionDat
 				nulledRow[i] = rowToNull[i]
 			}
 		}
-		if err = recomputeGeneratedColumns(ctx, refActionData.Editor.Schema, nulledRow); err != nil {
+		if err = sql.EvalProjections(ctx, refActionData.GeneratedProjections, nulledRow); err != nil {
 			return err
 		}
 		err = refActionData.Editor.Update(ctx, rowToNull, nulledRow, depth)

--- a/sql/plan/foreign_key_editor.go
+++ b/sql/plan/foreign_key_editor.go
@@ -192,6 +192,9 @@ func (fkEditor *ForeignKeyEditor) OnUpdateCascade(ctx *sql.Context, refActionDat
 				updatedRow[i] = new[mappedVal]
 			}
 		}
+		if err = recomputeGeneratedColumns(ctx, refActionData.Editor.Schema, updatedRow); err != nil {
+			return err
+		}
 		err = refActionData.Editor.Update(ctx, rowToUpdate, updatedRow, depth)
 		if err != nil {
 			return err
@@ -244,6 +247,9 @@ func (fkEditor *ForeignKeyEditor) OnUpdateSetDefault(ctx *sql.Context, refAction
 				}
 			}
 		}
+		if err = recomputeGeneratedColumns(ctx, refActionData.Editor.Schema, modifiedRow); err != nil {
+			return err
+		}
 		err = refActionData.Editor.Update(ctx, rowToDefault, modifiedRow, depth)
 		if err != nil {
 			return err
@@ -279,6 +285,9 @@ func (fkEditor *ForeignKeyEditor) OnUpdateSetNull(ctx *sql.Context, refActionDat
 			if refActionData.ChildParentMapping[i] == -1 {
 				updatedRow[i] = rowToUpdate[i]
 			}
+		}
+		if err = recomputeGeneratedColumns(ctx, refActionData.Editor.Schema, updatedRow); err != nil {
+			return err
 		}
 		err = refActionData.Editor.Update(ctx, rowToUpdate, updatedRow, depth)
 		if err != nil {
@@ -323,6 +332,24 @@ func (fkEditor *ForeignKeyEditor) Delete(ctx *sql.Context, row sql.Row, depth in
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+// recomputeGeneratedColumns re-evaluates the generated columns of row in place using the resolved
+// generated expressions in schema. A referential action builds the changed row by copying the non-foreign
+// key columns from the old row, which leaves any generated column that depends on the changed columns
+// holding its old value.
+func recomputeGeneratedColumns(ctx *sql.Context, schema sql.Schema, row sql.Row) error {
+	for i, col := range schema {
+		if col.Generated == nil {
+			continue
+		}
+		value, err := col.Generated.Eval(ctx, row)
+		if err != nil {
+			return err
+		}
+		row[i] = value
 	}
 	return nil
 }
@@ -408,6 +435,9 @@ func (fkEditor *ForeignKeyEditor) OnDeleteSetDefault(ctx *sql.Context, refAction
 				}
 			}
 		}
+		if err = recomputeGeneratedColumns(ctx, refActionData.Editor.Schema, modifiedRow); err != nil {
+			return err
+		}
 		err = refActionData.Editor.Update(ctx, rowToDefault, modifiedRow, depth)
 		if err != nil {
 			return err
@@ -443,6 +473,9 @@ func (fkEditor *ForeignKeyEditor) OnDeleteSetNull(ctx *sql.Context, refActionDat
 			if refActionData.ChildParentMapping[i] == -1 {
 				nulledRow[i] = rowToNull[i]
 			}
+		}
+		if err = recomputeGeneratedColumns(ctx, refActionData.Editor.Schema, nulledRow); err != nil {
+			return err
 		}
 		err = refActionData.Editor.Update(ctx, rowToNull, nulledRow, depth)
 		if err != nil {

--- a/sql/rows.go
+++ b/sql/rows.go
@@ -65,6 +65,23 @@ func (r Row) Equals(ctx *Context, row Row, schema Schema) (bool, error) {
 	return true, nil
 }
 
+// EvalProjections evaluates each non-nil expression in projections against row in index order and
+// writes the result back into the matching position, leaving nil positions unchanged. Evaluating in order
+// lets a projection reference a column that comes before it.
+func EvalProjections(ctx *Context, projections []Expression, row Row) error {
+	for i, expr := range projections {
+		if expr == nil {
+			continue
+		}
+		value, err := expr.Eval(ctx, row)
+		if err != nil {
+			return err
+		}
+		row[i] = value
+	}
+	return nil
+}
+
 // FormatRow returns a formatted string representing this row's values
 func FormatRow(row Row) string {
 	var sb strings.Builder

--- a/sql/schemas.go
+++ b/sql/schemas.go
@@ -63,6 +63,18 @@ func (s Schema) HasVirtualColumns() bool {
 	return false
 }
 
+// GeneratedProjections returns the schema's generated column expressions indexed by column position,
+// with nil where a column has no generated expression.
+func (s Schema) GeneratedProjections() []Expression {
+	projections := make([]Expression, len(s))
+	for i, col := range s {
+		if col.Generated != nil {
+			projections[i] = col.Generated
+		}
+	}
+	return projections
+}
+
 // PhysicalSchema returns a schema with only the physical (non-virtual) columns
 func (s Schema) PhysicalSchema() Schema {
 	var physical Schema


### PR DESCRIPTION
When a foreign key referential action such as `ON UPDATE CASCADE` or `ON DELETE SET NULL` changed a column, depending generated columns held stale values. This recomputes the generated columns whenever a referential action rewrites a row, so their indexes stay correct.
- `ForeignKeyEditor` referential-action methods now re-evaluate the row's generated columns after building the changed row before writes
- Rename `resolveSchemaDefaults` to `resolveSchemaColumnExpressions` since we extend its index correction to generated columns
- Generated expressions are resolved once when the editor is built under `ForeignKeyRefActionData.GeneratedProjections`
- Add `Schema.GeneratedProjections()` to build generated expression list
- Add `EvalProjections` to evaluate a positional list of expressions into a row in place
Blocks dolthub/dolt#11322