### PR TITLE
Bug fixes for secondary indexes using virtual columns

### DIFF
--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -2731,6 +2731,199 @@ var ForeignKeyTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "ON UPDATE CASCADE maintains an index over a virtual column",
+		SetUpScript: []string{
+			"CREATE TABLE vc_parent (id int PRIMARY KEY);",
+			"CREATE TABLE vc_child (id int PRIMARY KEY, parentId int, vcol int AS (parentId) VIRTUAL, UNIQUE KEY uk (vcol), FOREIGN KEY (parentId) REFERENCES vc_parent(id) ON UPDATE CASCADE);",
+			"INSERT INTO vc_parent VALUES (2);",
+			"INSERT INTO vc_child (id, parentId) VALUES (20, 2);",
+			"UPDATE vc_parent SET id = 99 WHERE id = 2;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, parentId, vcol FROM vc_child ORDER BY id;",
+				Expected: []sql.Row{{20, 99, 99}},
+			},
+			{
+				Query:              "SELECT id FROM vc_child WHERE vcol = 99;",
+				Expected:           []sql.Row{{20}},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk"},
+			},
+			{
+				Query:              "SELECT id FROM vc_child WHERE vcol = 2;",
+				Expected:           []sql.Row{},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk"},
+			},
+			{
+				Query:       "INSERT INTO vc_child (id, parentId) VALUES (40, 99);",
+				ExpectedErr: sql.ErrUniqueKeyViolation,
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "ON UPDATE CASCADE recomputes chained virtual columns",
+		SetUpScript: []string{
+			"CREATE TABLE vc_parent (id int PRIMARY KEY);",
+			"CREATE TABLE vc_child (id int PRIMARY KEY, parentId int, v1 int AS (parentId) VIRTUAL, v2 int AS (v1 + 100) VIRTUAL, UNIQUE KEY uk (v2), FOREIGN KEY (parentId) REFERENCES vc_parent(id) ON UPDATE CASCADE);",
+			"INSERT INTO vc_parent VALUES (2);",
+			"INSERT INTO vc_child (id, parentId) VALUES (20, 2);",
+			"UPDATE vc_parent SET id = 99 WHERE id = 2;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, parentId, v1, v2 FROM vc_child ORDER BY id;",
+				Expected: []sql.Row{{20, 99, 99, 199}},
+			},
+			{
+				Query:              "SELECT id FROM vc_child WHERE v2 = 199;",
+				Expected:           []sql.Row{{20}},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk"},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "ON DELETE SET NULL maintains an index over a virtual column",
+		SetUpScript: []string{
+			"CREATE TABLE vc_parent (id int PRIMARY KEY);",
+			"CREATE TABLE vc_child (id int PRIMARY KEY, parentId int, vcol int AS (parentId) VIRTUAL, UNIQUE KEY uk (vcol), FOREIGN KEY (parentId) REFERENCES vc_parent(id) ON DELETE SET NULL);",
+			"INSERT INTO vc_parent VALUES (2);",
+			"INSERT INTO vc_child (id, parentId) VALUES (20, 2);",
+			"DELETE FROM vc_parent WHERE id = 2;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, parentId, vcol FROM vc_child ORDER BY id;",
+				Expected: []sql.Row{{20, nil, nil}},
+			},
+			{
+				Query:              "SELECT id FROM vc_child WHERE vcol = 2;",
+				Expected:           []sql.Row{},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk"},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "ON UPDATE SET NULL maintains an index over a virtual column",
+		SetUpScript: []string{
+			"CREATE TABLE vc_parent (id int PRIMARY KEY);",
+			"CREATE TABLE vc_child (id int PRIMARY KEY, parentId int, vcol int AS (parentId) VIRTUAL, UNIQUE KEY uk (vcol), FOREIGN KEY (parentId) REFERENCES vc_parent(id) ON UPDATE SET NULL);",
+			"INSERT INTO vc_parent VALUES (2);",
+			"INSERT INTO vc_child (id, parentId) VALUES (20, 2);",
+			"UPDATE vc_parent SET id = 99 WHERE id = 2;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, parentId, vcol FROM vc_child ORDER BY id;",
+				Expected: []sql.Row{{20, nil, nil}},
+			},
+			{
+				Query:              "SELECT id FROM vc_child WHERE vcol = 2;",
+				Expected:           []sql.Row{},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk"},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "self-referential ON DELETE SET NULL maintains an index over a virtual column",
+		SetUpScript: []string{
+			"CREATE TABLE vc_t (id int PRIMARY KEY, parentId int, parentKey int AS (parentId) VIRTUAL, UNIQUE KEY uk (parentKey), FOREIGN KEY (parentId) REFERENCES vc_t(id) ON DELETE SET NULL);",
+			"INSERT INTO vc_t (id, parentId) VALUES (1, NULL), (2, 1), (3, 2);",
+			"DELETE FROM vc_t WHERE id = 2;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, parentId, parentKey FROM vc_t ORDER BY id;",
+				Expected: []sql.Row{{1, nil, nil}, {3, nil, nil}},
+			},
+			{
+				Query:              "SELECT id FROM vc_t WHERE parentKey = 2;",
+				Expected:           []sql.Row{},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk"},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "ON DELETE CASCADE maintains an index over a virtual column, self-referential",
+		SetUpScript: []string{
+			"CREATE TABLE vc_t2 (id int PRIMARY KEY, parentId int, parentKey int AS (parentId) VIRTUAL, UNIQUE KEY uk (parentKey), FOREIGN KEY (parentId) REFERENCES vc_t2(id) ON DELETE CASCADE);",
+			"INSERT INTO vc_t2 (id, parentId) VALUES (1, NULL), (2, 1);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "DELETE FROM vc_t2 WHERE id = 1;",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "SELECT id, parentId, parentKey FROM vc_t2 ORDER BY id;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:              "SELECT parentKey FROM vc_t2 WHERE parentKey = 1;",
+				Expected:           []sql.Row{},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk"},
+			},
+			{
+				Query:    "INSERT INTO vc_t2 (id, parentId) VALUES (3, NULL), (4, 3);",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "SELECT id, parentId, parentKey FROM vc_t2 ORDER BY id;",
+				Expected: []sql.Row{{3, nil, nil}, {4, 3, 3}},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11317
+		Name: "ON DELETE CASCADE maintains an index over a virtual column between stored columns",
+		SetUpScript: []string{
+			"CREATE TABLE vc_parent2 (id int PRIMARY KEY);",
+			"CREATE TABLE vc_child2 (" +
+				"id int PRIMARY KEY, " +
+				"parentId int, " +
+				"doubled int AS (parentId * 2) VIRTUAL, " +
+				"note varchar(10), " +
+				"KEY idx_doubled (doubled), " +
+				"FOREIGN KEY (parentId) REFERENCES vc_parent2(id) ON DELETE CASCADE);",
+			"INSERT INTO vc_parent2 VALUES (1), (2);",
+			"INSERT INTO vc_child2 (id, parentId, note) VALUES (10, 1, 'a'), (20, 1, 'b'), (30, 2, 'c');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "DELETE FROM vc_parent2 WHERE id = 1;",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "SELECT id, parentId, doubled, note FROM vc_child2 ORDER BY id;",
+				Expected: []sql.Row{{30, 2, 4, "c"}},
+			},
+			{
+				Query:              "SELECT id FROM vc_child2 WHERE doubled = 4;",
+				Expected:           []sql.Row{{30}},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"idx_doubled"},
+			},
+			{
+				Query:              "SELECT id FROM vc_child2 WHERE doubled = 2;",
+				Expected:           []sql.Row{},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"idx_doubled"},
+			},
+		},
+	},
 }
 
 var CreateForeignKeyTests = []ScriptTest{

--- a/enginetest/queries/generated_columns.go
+++ b/enginetest/queries/generated_columns.go
@@ -1250,6 +1250,257 @@ var GeneratedColumnTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "virtual column index survives DROP COLUMN on an unrelated column",
+		SetUpScript: []string{
+			"create table t1 (id int primary key, c1 int, c2 int, junk int, sum int generated always as (c1 + c2) virtual, index idx_sum (sum))",
+			"insert into t1 (id, c1, c2, junk) values (1, 2, 3, 999), (2, 1, 4, 999)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "alter table t1 drop column junk",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "insert into t1 (id, c1, c2) values (3, 10, -5)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}, {3}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+		},
+	},
+	{
+		Name: "virtual column index survives DROP COLUMN of a column between the generated column's dependencies",
+		SetUpScript: []string{
+			"create table t1 (id int primary key, c1 int, junk int, c2 int, sum int generated always as (c1 + c2) virtual, index idx_sum (sum))",
+			"insert into t1 (id, c1, junk, c2) values (1, 2, 999, 3), (2, 1, 999, 4)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "alter table t1 drop column junk",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "select id, sum from t1 order by id",
+				Expected: []sql.Row{{1, 5}, {2, 5}},
+			},
+		},
+	},
+	{
+		Name: "virtual column index survives MODIFY COLUMN reordering a base column",
+		SetUpScript: []string{
+			"create table t1 (id int primary key, c1 int, c2 int, sum int generated always as (c1 + c2) virtual, index idx_sum (sum))",
+			"insert into t1 (id, c1, c2) values (1, 2, 3), (2, 1, 4)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "alter table t1 modify column c1 int after c2",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+		},
+	},
+	{
+		Name: "virtual column index survives ADD PRIMARY KEY on an unrelated column",
+		SetUpScript: []string{
+			"create table t1 (id int, c1 int, c2 int, sum int generated always as (c1 + c2) virtual, index idx_sum (sum))",
+			"insert into t1 (id, c1, c2) values (1, 2, 3), (2, 1, 4)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "alter table t1 add primary key (id)",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+		},
+	},
+	{
+		Name: "virtual column index survives DROP PRIMARY KEY",
+		SetUpScript: []string{
+			"create table t1 (id int primary key, c1 int, c2 int, sum int generated always as (c1 + c2) virtual, index idx_sum (sum))",
+			"insert into t1 (id, c1, c2) values (1, 2, 3), (2, 1, 4)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "alter table t1 drop primary key",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+		},
+	},
+	{
+		Name: "virtual column index survives ADD COLUMN on an unrelated column",
+		SetUpScript: []string{
+			"create table t1 (id int primary key, c1 int, c2 int, sum int generated always as (c1 + c2) virtual, index idx_sum (sum))",
+			"insert into t1 (id, c1, c2) values (1, 2, 3), (2, 1, 4)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "alter table t1 add column junk int",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+		},
+	},
+	{
+		Name: "unique virtual column index survives DROP COLUMN on an unrelated column",
+		SetUpScript: []string{
+			"create table t1 (id int primary key, c1 int, c2 int, junk int, sum int generated always as (c1 + c2) virtual, unique index idx_sum (sum))",
+			"insert into t1 (id, c1, c2, junk) values (1, 2, 3, 999), (2, 10, 20, 999)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:           "select id from t1 where sum = 30 order by id",
+				Expected:        []sql.Row{{2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "alter table t1 drop column junk",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:           "select id from t1 where sum = 30 order by id",
+				Expected:        []sql.Row{{2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:       "insert into t1 (id, c1, c2) values (3, 1, 4)",
+				ExpectedErr: sql.ErrUniqueKeyViolation,
+			},
+			{
+				Query:    "insert into t1 (id, c1, c2) values (4, 100, 100)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "select id from t1 where sum = 200",
+				Expected: []sql.Row{{4}},
+			},
+		},
+	},
+	{
+		Name: "virtual column index survives DROP COLUMN on an unrelated column, keyless table",
+		SetUpScript: []string{
+			"create table t1 (id int, c1 int, c2 int, junk int, sum int generated always as (c1 + c2) virtual, index idx_sum (sum))",
+			"insert into t1 (id, c1, c2, junk) values (1, 2, 3, 999), (2, 1, 4, 999)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "alter table t1 drop column junk",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "insert into t1 (id, c1, c2) values (3, 10, -5)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}, {3}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+		},
+	},
+	{
+		Name: "virtual column index survives MODIFY COLUMN reordering the generated column itself",
+		SetUpScript: []string{
+			"create table t1 (id int primary key, c1 int, c2 int, sum int generated always as (c1 + c2) virtual, index idx_sum (sum))",
+			"insert into t1 (id, c1, c2) values (1, 2, 3), (2, 1, 4)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+			{
+				Query:    "alter table t1 modify column sum int generated always as (c1 + c2) virtual after c1",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:           "select id from t1 where sum = 5 order by id",
+				Expected:        []sql.Row{{1}, {2}},
+				ExpectedIndexes: []string{"idx_sum"},
+			},
+		},
+	},
+	{
 		Name: "virtual column index on a keyless table",
 		SetUpScript: []string{
 			"create table t1 (j json, v int generated always as (j->>'$.a') virtual, index idx_v (v))",

--- a/enginetest/queries/generated_columns.go
+++ b/enginetest/queries/generated_columns.go
@@ -1778,6 +1778,60 @@ var GeneratedColumnTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		// See https://github.com/dolthub/dolt/issues/8881
+		Name: "INSERT ON DUPLICATE KEY UPDATE with an index over a virtual generated column",
+		SetUpScript: []string{
+			"CREATE TABLE odku_v (id int PRIMARY KEY, base int, vcol int AS (base + 100) VIRTUAL, UNIQUE KEY uk_v (vcol));",
+			"INSERT INTO odku_v (id, base) VALUES (1, 10), (2, 20);",
+			"INSERT INTO odku_v (id, base) VALUES (2, 55) ON DUPLICATE KEY UPDATE base = 99;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, base, vcol FROM odku_v ORDER BY id;",
+				Expected: []sql.Row{{1, 10, 110}, {2, 99, 199}},
+			},
+			{
+				Query:              "SELECT id FROM odku_v WHERE vcol = 199;",
+				Expected:           []sql.Row{{2}},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk_v"},
+			},
+			{
+				Query:              "SELECT id FROM odku_v WHERE vcol = 120;",
+				Expected:           []sql.Row{},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk_v"},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/8881
+		Name: "REPLACE INTO with an index over a virtual generated column",
+		SetUpScript: []string{
+			"CREATE TABLE replace_v (id int PRIMARY KEY, base int, vcol int AS (base + 100) VIRTUAL, UNIQUE KEY uk_v (vcol));",
+			"INSERT INTO replace_v (id, base) VALUES (1, 10), (2, 20);",
+			"REPLACE INTO replace_v (id, base) VALUES (2, 88);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, base, vcol FROM replace_v ORDER BY id;",
+				Expected: []sql.Row{{1, 10, 110}, {2, 88, 188}},
+			},
+			{
+				Query:              "SELECT id FROM replace_v WHERE vcol = 188;",
+				Expected:           []sql.Row{{2}},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk_v"},
+			},
+			{
+				Query:              "SELECT id FROM replace_v WHERE vcol = 120;",
+				Expected:           []sql.Row{},
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk_v"},
+			},
+		},
+	},
 }
 
 var BrokenGeneratedColumnTests = []ScriptTest{

--- a/memory/table_editor.go
+++ b/memory/table_editor.go
@@ -460,7 +460,11 @@ func (pke *pkTableEditAccumulator) Get(value sql.Row) (sql.Row, bool, error) {
 	for _, partition := range pke.tableData.partitions {
 		for _, partitionRow := range partition {
 			if columnsMatch(pkColIdxes, nil, partitionRow, value, pke.tableData.schema.Schema) {
-				return partitionRow, true, nil
+				row := partitionRow
+				if pke.tableData.schema.HasVirtualColumns() {
+					row = normalizeRowForRead(partitionRow, len(pke.tableData.schema.Schema), pke.tableData.virtualColIndexes())
+				}
+				return row, true, nil
 			}
 		}
 	}

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -254,7 +254,10 @@ func getForeignKeyReferences(ctx *sql.Context, catalog *Catalog, tbl sql.Foreign
 	}
 	fkChain = fkChain.AddTable(fks[0].Database, fks[0].SchemaName, fks[0].Table).AddTableUpdater(fks[0].Database, fks[0].SchemaName, fks[0].Table, updater)
 
-	tblSch := tbl.Schema(ctx)
+	tblSch, err := resolveSchemaColumnExpressions(ctx, catalog, tbl)
+	if err != nil {
+		return nil, err
+	}
 	fkEditor := &plan.ForeignKeyEditor{
 		Schema:     tblSch,
 		Editor:     updater,
@@ -342,7 +345,10 @@ func getForeignKeyRefActions(ctx *sql.Context, catalog *Catalog, tbl sql.Foreign
 		return cachedFkEditor, nil
 	}
 	// No matching editor was cached, so we either create a new one or add to the existing one
-	tblSch := tbl.Schema(ctx)
+	tblSch, err := resolveSchemaColumnExpressions(ctx, catalog, tbl)
+	if err != nil {
+		return nil, err
+	}
 	if fkEditor == nil {
 		fkEditor = &plan.ForeignKeyEditor{
 			Schema:     tblSch,
@@ -406,7 +412,7 @@ func getForeignKeyRefActions(ctx *sql.Context, catalog *Catalog, tbl sql.Foreign
 		//       manually do that here. Moving all the FK information into the binding, planbuilder, phase would
 		//       clean this up. We should also fix assignExecIndexes to find all these FK schema references and fix
 		//       their exec indexes.
-		childTblSch, err := resolveSchemaDefaults(ctx, catalog, childTbl)
+		childTblSch, err := resolveSchemaColumnExpressions(ctx, catalog, childTbl)
 		if err != nil {
 			return nil, err
 		}
@@ -451,9 +457,10 @@ func getForeignKeyRefActions(ctx *sql.Context, catalog *Catalog, tbl sql.Foreign
 				IndexPositions:        indexPositions,
 				AppendTypes:           appendTypes,
 			},
-			Editor:             childEditor,
-			ForeignKey:         fk,
-			ChildParentMapping: childParentMapping,
+			Editor:               childEditor,
+			ForeignKey:           fk,
+			ChildParentMapping:   childParentMapping,
+			GeneratedProjections: childEditor.Schema.GeneratedExpressions(),
 		}
 	}
 	return fkEditor, nil
@@ -489,23 +496,25 @@ func getForeignKeyHandlerFromUpdateTarget(ctx *sql.Context, catalog *Catalog, up
 	}, nil
 }
 
-// resolveSchemaDefaults resolves the default values for the schema of |table|. This is primarily needed for column
-// default value expressions, since those don't get resolved during the planbuilder phase and assignExecIndexes
-// doesn't traverse through the ForeignKeyEditors and referential actions to find all of them. In addition to resolving
-// the expressions, this also ensures their GetField indexes are correct, knowing that those expressions will only
-// be evaluated in the context of a single table.
-func resolveSchemaDefaults(ctx *sql.Context, catalog *Catalog, table sql.Table) (sql.Schema, error) {
-	// Resolve any column default expressions in tblSch
+// resolveSchemaColumnExpressions returns the schema of |table| with its default and generated column
+// expressions resolved, because the planbuilder phase does not resolve them for this foreign key
+// path and assignExecIndexes does not traverse foreign key editors to find them. It also decrements their
+// GetField indexes by one, which is safe because they are only evaluated against a single table's row.
+func resolveSchemaColumnExpressions(ctx *sql.Context, catalog *Catalog, table sql.Table) (sql.Schema, error) {
+	// Resolve the default and generated column expressions in tblSch
 	builder := planbuilder.New(ctx, catalog, nil)
 	childTblSch := builder.ResolveSchemaDefaults(ctx.GetCurrentDatabase(), table.Name(), table.Schema(ctx))
 
 	// Field Indexes are off by one initially and don't fixed by assignExecIndexes because it doesn't traverse through
 	// the ForeignKeyEditors and referential actions, so we correct them here. This is safe because we know these fields
 	// will only ever be accessed within the scope of a single table, so all we have to do is decrement the index by 1.
-	for i, col := range childTblSch {
-		if col.Default != nil {
-			expr := col.Default.Expr
-			expr, identity, err := transform.Expr(ctx, expr, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+	// TODO: rm correction once foreign key schemas are resolved during binding, where assignExecIndexes would number these expressions correctly.
+	for i := range childTblSch {
+		for _, cd := range []*sql.ColumnDefaultValue{childTblSch[i].Default, childTblSch[i].Generated} {
+			if cd == nil {
+				continue
+			}
+			expr, identity, err := transform.Expr(ctx, cd.Expr, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 				if gf, ok := e.(*expression.GetField); ok {
 					return gf.WithIndex(gf.Index() - 1), transform.NewTree, nil
 				}
@@ -515,7 +524,7 @@ func resolveSchemaDefaults(ctx *sql.Context, catalog *Catalog, table sql.Table) 
 				return nil, err
 			}
 			if identity == transform.NewTree {
-				childTblSch[i].Default.Expr = expr
+				cd.Expr = expr
 			}
 		}
 	}

--- a/sql/plan/foreign_key_editor.go
+++ b/sql/plan/foreign_key_editor.go
@@ -43,7 +43,9 @@ type ForeignKeyRefActionData struct {
 	RowMapper          *ForeignKeyRowMapper
 	Editor             *ForeignKeyEditor
 	ChildParentMapping ChildParentMapping
-	ForeignKey         sql.ForeignKeyConstraint
+	// GeneratedProjections holds the child schema's generated column expressions to eval FK referential actions.
+	GeneratedProjections []sql.Expression
+	ForeignKey           sql.ForeignKeyConstraint
 }
 
 // ForeignKeyEditor handles update and delete operations, as they may have referential actions on other tables (such as
@@ -192,6 +194,9 @@ func (fkEditor *ForeignKeyEditor) OnUpdateCascade(ctx *sql.Context, refActionDat
 				updatedRow[i] = new[mappedVal]
 			}
 		}
+		if err = sql.EvalProjections(ctx, refActionData.GeneratedProjections, updatedRow); err != nil {
+			return err
+		}
 		err = refActionData.Editor.Update(ctx, rowToUpdate, updatedRow, depth)
 		if err != nil {
 			return err
@@ -244,6 +249,9 @@ func (fkEditor *ForeignKeyEditor) OnUpdateSetDefault(ctx *sql.Context, refAction
 				}
 			}
 		}
+		if err = sql.EvalProjections(ctx, refActionData.GeneratedProjections, modifiedRow); err != nil {
+			return err
+		}
 		err = refActionData.Editor.Update(ctx, rowToDefault, modifiedRow, depth)
 		if err != nil {
 			return err
@@ -279,6 +287,9 @@ func (fkEditor *ForeignKeyEditor) OnUpdateSetNull(ctx *sql.Context, refActionDat
 			if refActionData.ChildParentMapping[i] == -1 {
 				updatedRow[i] = rowToUpdate[i]
 			}
+		}
+		if err = sql.EvalProjections(ctx, refActionData.GeneratedProjections, updatedRow); err != nil {
+			return err
 		}
 		err = refActionData.Editor.Update(ctx, rowToUpdate, updatedRow, depth)
 		if err != nil {
@@ -408,6 +419,9 @@ func (fkEditor *ForeignKeyEditor) OnDeleteSetDefault(ctx *sql.Context, refAction
 				}
 			}
 		}
+		if err = sql.EvalProjections(ctx, refActionData.GeneratedProjections, modifiedRow); err != nil {
+			return err
+		}
 		err = refActionData.Editor.Update(ctx, rowToDefault, modifiedRow, depth)
 		if err != nil {
 			return err
@@ -443,6 +457,9 @@ func (fkEditor *ForeignKeyEditor) OnDeleteSetNull(ctx *sql.Context, refActionDat
 			if refActionData.ChildParentMapping[i] == -1 {
 				nulledRow[i] = rowToNull[i]
 			}
+		}
+		if err = sql.EvalProjections(ctx, refActionData.GeneratedProjections, nulledRow); err != nil {
+			return err
 		}
 		err = refActionData.Editor.Update(ctx, rowToNull, nulledRow, depth)
 		if err != nil {

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -793,12 +793,14 @@ func (b *BaseBuilder) buildAlterPK(ctx *sql.Context, n *plan.AlterPK, row sql.Ro
 			columns:      n.Columns,
 			pkAlterable:  pkAlterable,
 			db:           n.Database(),
+			overrides:    b.EngineOverrides,
 		}, nil
 	case plan.PrimaryKeyAction_Drop:
 		return &dropPkIter{
 			targetSchema: n.TargetSchema(),
 			pkAlterable:  pkAlterable,
 			db:           n.Database(),
+			overrides:    b.EngineOverrides,
 		}, nil
 	default:
 		panic("unreachable")

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -609,7 +609,7 @@ func (i *modifyColumnIter) Close(context *sql.Context) error {
 
 // rewriteTable rewrites the table given if required or requested, and returns whether it was rewritten
 func (i *modifyColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) (bool, error) {
-	targetSchema := i.m.TargetSchema()
+	targetSchema := resolveGeneratedColumns(ctx, i.overrides, i.m.Db.Name(), rwt.Name(), i.m.TargetSchema())
 	oldColName := i.m.Column()
 	oldColIdx := targetSchema.IndexOfColName(oldColName)
 	if oldColIdx == -1 {
@@ -617,7 +617,7 @@ func (i *modifyColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTabl
 		return false, sql.ErrTableColumnNotFound.New(rwt.Name(), oldColName)
 	}
 
-	oldCol := i.m.TargetSchema()[oldColIdx]
+	oldCol := targetSchema[oldColIdx]
 	newCol := i.m.NewColumn()
 	newSch, projections, err := modifyColumnInSchema(ctx, targetSchema, oldColName, newCol, i.m.Order(ctx))
 	if err != nil {
@@ -788,32 +788,34 @@ func modifyColumnInSchema(ctx *sql.Context, schema sql.Schema, name string, colu
 			c = column
 		}
 		newSch[j] = c
-		projections[j] = expression.NewGetField(i, oldCol.Type, oldCol.Name, oldCol.Nullable)
+		projections[j] = columnRewriteProjection(i, oldCol)
 	}
 
-	// If a column was renamed or moved, we need to update any column defaults that refer to it
+	// If a column was renamed or moved, we need to update any column defaults or generated
+	// expressions that refer to it.
+	remapFieldRef := func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+		gf, ok := e.(*expression.GetField)
+		if !ok {
+			return e, transform.SameTree, nil
+		}
+
+		colName := gf.Name()
+		// handle column renames
+		if strings.ToLower(colName) == strings.ToLower(name) {
+			colName = column.Name
+		}
+
+		newSchemaIdx := newSch.IndexOfColName(colName)
+		if newSchemaIdx == -1 {
+			return nil, transform.SameTree, sql.ErrColumnNotFound.New(colName)
+		}
+		return expression.NewGetFieldWithTable(newSchemaIdx, int(gf.TableId()), gf.Type(ctx), gf.Database(), gf.Table(), colName, gf.IsNullable(ctx)), transform.NewTree, nil
+	}
 	for i := range newSch {
 		newCol := newSch[oldToNewIdxMapping[i]]
 
 		if newCol.Default != nil {
-			newDefault, _, err := transform.Expr(ctx, newCol.Default.Expr, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
-				gf, ok := e.(*expression.GetField)
-				if !ok {
-					return e, transform.SameTree, nil
-				}
-
-				colName := gf.Name()
-				// handle column renames
-				if strings.ToLower(colName) == strings.ToLower(name) {
-					colName = column.Name
-				}
-
-				newSchemaIdx := newSch.IndexOfColName(colName)
-				if newSchemaIdx == -1 {
-					return nil, transform.SameTree, sql.ErrColumnNotFound.New(colName)
-				}
-				return expression.NewGetFieldWithTable(newSchemaIdx, int(gf.TableId()), gf.Type(ctx), gf.Database(), gf.Table(), colName, gf.IsNullable(ctx)), transform.NewTree, nil
-			})
+			newDefault, _, err := transform.Expr(ctx, newCol.Default.Expr, remapFieldRef)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -824,7 +826,25 @@ func modifyColumnInSchema(ctx *sql.Context, schema sql.Schema, name string, colu
 			}
 
 			newCol.Default = newDefault.(*sql.ColumnDefaultValue)
+		} else if newCol.Generated != nil {
+			newGenerated, _, err := transform.Expr(ctx, newCol.Generated.Expr, remapFieldRef)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			newGenerated, err = newCol.Generated.WithChildren(ctx, newGenerated)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			newCol.Generated = newGenerated.(*sql.ColumnDefaultValue)
 		}
+	}
+
+	// The projections computed above may also reference columns whose position shifted because of
+	// the drop/reorder; point those references at the new schema's layout too.
+	if err := fixupColumnRewriteFieldRefs(ctx, newSch, projections); err != nil {
+		return nil, nil, err
 	}
 
 	// TODO: do we need col defaults here? probably when changing a column to be non-null?
@@ -1167,6 +1187,7 @@ type createPkIter struct {
 	pkAlterable  sql.PrimaryKeyAlterableTable
 	targetSchema sql.Schema
 	columns      []sql.IndexColumn
+	overrides    sql.EngineOverrides
 	runOnce      bool
 }
 
@@ -1205,7 +1226,8 @@ func (c createPkIter) Close(context *sql.Context) error {
 }
 
 func (c *createPkIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) error {
-	newSchema := addKeyToSchema(rwt.Name(), c.targetSchema, c.columns)
+	targetSchema := resolveGeneratedColumns(ctx, c.overrides, c.db.Name(), rwt.Name(), c.targetSchema)
+	newSchema := addKeyToSchema(rwt.Name(), targetSchema, c.columns)
 
 	oldPkSchema, newPkSchema := sql.SchemaToPrimaryKeySchema(ctx, rwt, rwt.Schema(ctx)), newSchema
 
@@ -1222,6 +1244,16 @@ func (c *createPkIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) e
 	var rowIter sql.RowIter = sql.NewTableRowIter(ctx, rwt, partitions)
 	rowIter = withSafepointPeriodicallyIter(rowIter)
 
+	// Adding/dropping a primary key doesn't add, drop, or reorder any columns, so no reindexing of
+	// generated-column expressions is needed.
+	var projections []sql.Expression
+	if newSchema.Schema.HasVirtualColumns() {
+		projections = make([]sql.Expression, len(newSchema.Schema))
+		for idx, col := range newSchema.Schema {
+			projections[idx] = columnRewriteProjection(idx, col)
+		}
+	}
+
 	for {
 		r, err := rowIter.Next(ctx)
 		if err == io.EOF {
@@ -1230,6 +1262,15 @@ func (c *createPkIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) e
 			_ = inserter.DiscardChanges(ctx, err)
 			_ = inserter.Close(ctx)
 			return err
+		}
+
+		if projections != nil {
+			r, err = ProjectRow(ctx, projections, r)
+			if err != nil {
+				_ = inserter.DiscardChanges(ctx, err)
+				_ = inserter.Close(ctx)
+				return err
+			}
 		}
 
 		// check for null values in the primary key insert
@@ -1272,6 +1313,7 @@ type dropPkIter struct {
 	db           sql.Database
 	pkAlterable  sql.PrimaryKeyAlterableTable
 	targetSchema sql.Schema
+	overrides    sql.EngineOverrides
 	runOnce      bool
 }
 
@@ -1310,7 +1352,8 @@ func (d *dropPkIter) Close(context *sql.Context) error {
 }
 
 func (d *dropPkIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) error {
-	newSchema := dropKeyFromSchema(d.targetSchema)
+	targetSchema := resolveGeneratedColumns(ctx, d.overrides, d.db.Name(), rwt.Name(), d.targetSchema)
+	newSchema := dropKeyFromSchema(targetSchema)
 
 	oldPkSchema, newPkSchema := sql.SchemaToPrimaryKeySchema(ctx, rwt, rwt.Schema(ctx)), newSchema
 
@@ -1327,6 +1370,16 @@ func (d *dropPkIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) err
 	var rowIter sql.RowIter = sql.NewTableRowIter(ctx, rwt, partitions)
 	rowIter = withSafepointPeriodicallyIter(rowIter)
 
+	// Adding/dropping a primary key doesn't add, drop, or reorder any columns, so no reindexing of
+	// generated-column expressions is needed.
+	var projections []sql.Expression
+	if newSchema.Schema.HasVirtualColumns() {
+		projections = make([]sql.Expression, len(newSchema.Schema))
+		for idx, col := range newSchema.Schema {
+			projections[idx] = columnRewriteProjection(idx, col)
+		}
+	}
+
 	for {
 		r, err := rowIter.Next(ctx)
 		if err == io.EOF {
@@ -1335,6 +1388,15 @@ func (d *dropPkIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) err
 			_ = inserter.DiscardChanges(ctx, err)
 			_ = inserter.Close(ctx)
 			return err
+		}
+
+		if projections != nil {
+			r, err = ProjectRow(ctx, projections, r)
+			if err != nil {
+				_ = inserter.DiscardChanges(ctx, err)
+				_ = inserter.Close(ctx)
+				return err
+			}
 		}
 
 		err = inserter.Insert(ctx, r)
@@ -1624,6 +1686,84 @@ func (i *addColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) 
 	return true, nil
 }
 
+// resolveGeneratedColumns resolves any not-yet-resolved generated column expressions for
+// virtual columns in |schema|, so that a table rewrite (see columnRewriteProjection) can evaluate
+// them. A virtual column's expression may still be an *sql.UnresolvedColumnDefault placeholder
+// (parsed from persisted metadata rather than a bound expression tree) at this point. Returns
+// |schema| unmodified if nothing needs resolving.
+func resolveGeneratedColumns(ctx *sql.Context, overrides sql.EngineOverrides, dbName, tableName string, schema sql.Schema) sql.Schema {
+	for _, col := range schema {
+		if col.Virtual && col.Generated != nil && !col.Generated.Resolved() {
+			b := planbuilder.NewBuilderForColumnDefaultResolution(ctx, overrides)
+			return b.ResolveSchemaDefaults(dbName, tableName, schema)
+		}
+	}
+	return schema
+}
+
+// columnRewriteProjection returns the projection to use for |col|, found at position |idx| in the
+// row being scanned, when rewriting a table's existing rows for an ALTER TABLE / CREATE INDEX
+// operation (sql.RewritableTable). Virtual generated columns are never physically
+// persisted, so a raw partition scan (sql.NewTableRowIter) returns a placeholder for them; their
+// value must instead be recomputed from col.Generated, exactly as sql/analyzer/inserts.go's
+// wrapRowSource already does for ordinary INSERT.
+func columnRewriteProjection(idx int, col *sql.Column) sql.Expression {
+	if col.Virtual && col.Generated != nil {
+		return col.Generated
+	}
+	return expression.NewGetField(idx, col.Type, col.Name, col.Nullable)
+}
+
+// fixupColumnRewriteFieldRefs corrects GetField indexes embedded inside any default-value or
+// generated-column projection in |projections| so they refer to the right position in |newSch|.
+// This is necessary because ProjectRow evaluates such projections in a second pass against the new
+// row being built (see defaultValFromProjectExpr), not the original row being scanned, so any
+// column reference inside them must point at the new schema's layout.
+func fixupColumnRewriteFieldRefs(ctx *sql.Context, newSch sql.Schema, projections []sql.Expression) error {
+	if len(newSch) == 0 {
+		return nil
+	}
+
+	updateFieldRefs := func(ctx *sql.Context, s sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+		gf, ok := s.(*expression.GetField)
+		if !ok {
+			return s, transform.SameTree, nil
+		}
+		idx := newSch.IndexOf(gf.Name(), newSch[0].Source)
+		if idx < 0 {
+			return nil, transform.SameTree, sql.ErrTableColumnNotFound.New(newSch[0].Source, gf.Name())
+		}
+		return gf.WithIndex(idx), transform.NewTree, nil
+	}
+	for i := range projections {
+		switch p := projections[i].(type) {
+		case *sql.ColumnDefaultValue:
+			newExpr, _, err := transform.Expr(ctx, p, updateFieldRefs)
+			if err != nil {
+				return err
+			}
+			projections[i] = newExpr
+		case plan.ColDefaultExpression:
+			if p.Column.Default != nil {
+				newExpr, _, err := transform.Expr(ctx, p.Column.Default.Expr, updateFieldRefs)
+				if err != nil {
+					return err
+				}
+				p.Column.Default.Expr = newExpr
+				projections[i] = p
+			} else if p.Column.Generated != nil {
+				newExpr, _, err := transform.Expr(ctx, p.Column.Generated.Expr, updateFieldRefs)
+				if err != nil {
+					return err
+				}
+				p.Column.Generated.Expr = newExpr
+				projections[i] = p
+			}
+		}
+	}
+	return nil
+}
+
 // addColumnToSchema returns a new schema and a set of projection expressions that when applied to rows from the old
 // schema will result in rows in the new schema.
 func addColumnToSchema(ctx *sql.Context, schema sql.Schema, column *sql.Column, order *sql.ColumnOrder) (sql.Schema, []sql.Expression, error) {
@@ -1645,33 +1785,23 @@ func addColumnToSchema(ctx *sql.Context, schema sql.Schema, column *sql.Column, 
 	newSch := make(sql.Schema, 0, len(schema)+1)
 	projections := make([]sql.Expression, len(schema)+1)
 
-	newGetField := func(i int) sql.Expression {
-		col := schema[i]
-		if col.Virtual {
-			// Virtual generated columns are not stored in primary row data. The schema passed
-			// here should already have unresolved expressions resolved (see rewriteTable).
-			return col.Generated
-		}
-		return expression.NewGetField(i, col.Type, col.Name, col.Nullable)
-	}
-
 	if idx >= 0 {
 		newSch = append(newSch, schema[:idx]...)
 		newSch = append(newSch, column)
 		newSch = append(newSch, schema[idx:]...)
 
 		for i := 0; i < idx; i++ {
-			projections[i] = newGetField(i)
+			projections[i] = columnRewriteProjection(i, schema[i])
 		}
 		projections[idx] = plan.ColDefaultExpression{column}
 		for i := idx; i < len(schema); i++ {
-			projections[i+1] = newGetField(i)
+			projections[i+1] = columnRewriteProjection(i, schema[i])
 		}
 	} else { // new column at end
 		newSch = append(newSch, schema...)
 		newSch = append(newSch, column)
-		for i, _ := range schema {
-			projections[i] = newGetField(i)
+		for i, col := range schema {
+			projections[i] = columnRewriteProjection(i, col)
 		}
 		projections[len(schema)] = plan.ColDefaultExpression{column}
 	}
@@ -1679,46 +1809,8 @@ func addColumnToSchema(ctx *sql.Context, schema sql.Schema, column *sql.Column, 
 	// Alter old default expressions if they refer to other columns. The column indexes computed during analysis refer to the
 	// column indexes in the old result schema, which is not what we want here: we want the positions in the new
 	// schema, since that is what we'll be evaluating when we rewrite the table.
-	var updateFieldRefs transform.ExprFunc = func(ctx *sql.Context, s sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
-		switch s := s.(type) {
-		case *expression.GetField:
-			idx := newSch.IndexOf(s.Name(), newSch[0].Source)
-			if idx < 0 {
-				return nil, transform.SameTree, sql.ErrTableColumnNotFound.New(schema[0].Source, s.Name())
-			}
-			return s.WithIndex(idx), transform.NewTree, nil
-		default:
-			return s, transform.SameTree, nil
-		}
-		return s, transform.SameTree, nil
-	}
-	for i := range projections {
-		switch p := projections[i].(type) {
-		case *sql.ColumnDefaultValue:
-			newExpr, _, err := transform.Expr(ctx, p, updateFieldRefs)
-			if err != nil {
-				return nil, nil, err
-			}
-			projections[i] = newExpr
-			break
-		case plan.ColDefaultExpression:
-			if p.Column.Default != nil {
-				newExpr, _, err := transform.Expr(ctx, p.Column.Default.Expr, updateFieldRefs)
-				if err != nil {
-					return nil, nil, err
-				}
-				p.Column.Default.Expr = newExpr
-				projections[i] = p
-			} else if p.Column.Generated != nil {
-				newExpr, _, err := transform.Expr(ctx, p.Column.Generated.Expr, updateFieldRefs)
-				if err != nil {
-					return nil, nil, err
-				}
-				p.Column.Generated.Expr = newExpr
-				projections[i] = p
-			}
-			break
-		}
+	if err := fixupColumnRewriteFieldRefs(ctx, newSch, projections); err != nil {
+		return nil, nil, err
 	}
 
 	return newSch, projections, nil
@@ -1861,7 +1953,8 @@ func (i *dropColumnIter) Next(ctx *sql.Context) (sql.Row, error) {
 
 // rewriteTable rewrites the table given if required or requested, and returns whether it was rewritten
 func (i *dropColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) (bool, error) {
-	newSch, projections, err := dropColumnFromSchema(i.d.TargetSchema(), i.d.Column, i.alterable.Name())
+	targetSchema := resolveGeneratedColumns(ctx, i.overrides, i.d.Db.Name(), i.alterable.Name(), i.d.TargetSchema())
+	newSch, projections, err := dropColumnFromSchema(ctx, targetSchema, i.d.Column, i.alterable.Name())
 	if err != nil {
 		return false, err
 	}
@@ -1921,7 +2014,7 @@ func (i *dropColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable)
 	return true, nil
 }
 
-func dropColumnFromSchema(schema sql.Schema, column string, tableName string) (sql.Schema, []sql.Expression, error) {
+func dropColumnFromSchema(ctx *sql.Context, schema sql.Schema, column string, tableName string) (sql.Schema, []sql.Expression, error) {
 	idx := schema.IndexOf(column, tableName)
 	if idx < 0 {
 		return nil, nil, sql.ErrTableColumnNotFound.New(tableName, column)
@@ -1933,14 +2026,20 @@ func dropColumnFromSchema(schema sql.Schema, column string, tableName string) (s
 	i := 0
 	for j := range schema[:idx] {
 		newSch[i] = schema[j]
-		projections[i] = expression.NewGetField(j, schema[j].Type, schema[j].Name, schema[j].Nullable)
+		projections[i] = columnRewriteProjection(j, schema[j])
 		i++
 	}
 
 	for j := range schema[idx+1:] {
 		schIdx := j + i + 1
 		newSch[j+i] = schema[schIdx]
-		projections[j+i] = expression.NewGetField(schIdx, schema[schIdx].Type, schema[schIdx].Name, schema[schIdx].Nullable)
+		projections[j+i] = columnRewriteProjection(schIdx, schema[schIdx])
+	}
+
+	// Any surviving virtual/generated column's expression may reference a column whose position
+	// shifted because of the drop; point those references at the new schema's layout.
+	if err := fixupColumnRewriteFieldRefs(ctx, newSch, projections); err != nil {
+		return nil, nil, err
 	}
 
 	return newSch, projections, nil

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -788,7 +788,7 @@ func modifyColumnInSchema(ctx *sql.Context, schema sql.Schema, name string, colu
 			c = column
 		}
 		newSch[j] = c
-		projections[j] = columnRewriteProjection(i, oldCol)
+		projections[j] = getColumnExpression(i, oldCol)
 	}
 
 	// If a column was renamed or moved, we need to update any column defaults or generated
@@ -843,7 +843,7 @@ func modifyColumnInSchema(ctx *sql.Context, schema sql.Schema, name string, colu
 
 	// The projections computed above may also reference columns whose position shifted because of
 	// the drop/reorder; point those references at the new schema's layout too.
-	if err := fixupColumnRewriteFieldRefs(ctx, newSch, projections); err != nil {
+	if err := updateExpressionFieldRefs(ctx, newSch, projections); err != nil {
 		return nil, nil, err
 	}
 
@@ -1250,7 +1250,7 @@ func (c *createPkIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) e
 	if newSchema.Schema.HasVirtualColumns() {
 		projections = make([]sql.Expression, len(newSchema.Schema))
 		for idx, col := range newSchema.Schema {
-			projections[idx] = columnRewriteProjection(idx, col)
+			projections[idx] = getColumnExpression(idx, col)
 		}
 	}
 
@@ -1376,7 +1376,7 @@ func (d *dropPkIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) err
 	if newSchema.Schema.HasVirtualColumns() {
 		projections = make([]sql.Expression, len(newSchema.Schema))
 		for idx, col := range newSchema.Schema {
-			projections[idx] = columnRewriteProjection(idx, col)
+			projections[idx] = getColumnExpression(idx, col)
 		}
 	}
 
@@ -1687,7 +1687,7 @@ func (i *addColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) 
 }
 
 // resolveGeneratedColumns resolves any not-yet-resolved generated column expressions for
-// virtual columns in |schema|, so that a table rewrite (see columnRewriteProjection) can evaluate
+// virtual columns in |schema|, so that a table rewrite (see getColumnExpression) can evaluate
 // them. A virtual column's expression may still be an *sql.UnresolvedColumnDefault placeholder
 // (parsed from persisted metadata rather than a bound expression tree) at this point. Returns
 // |schema| unmodified if nothing needs resolving.
@@ -1701,13 +1701,10 @@ func resolveGeneratedColumns(ctx *sql.Context, overrides sql.EngineOverrides, db
 	return schema
 }
 
-// columnRewriteProjection returns the projection to use for |col|, found at position |idx| in the
-// row being scanned, when rewriting a table's existing rows for an ALTER TABLE / CREATE INDEX
-// operation (sql.RewritableTable). Virtual generated columns are never physically
-// persisted, so a raw partition scan (sql.NewTableRowIter) returns a placeholder for them; their
-// value must instead be recomputed from col.Generated, exactly as sql/analyzer/inserts.go's
-// wrapRowSource already does for ordinary INSERT.
-func columnRewriteProjection(idx int, col *sql.Column) sql.Expression {
+// getColumnExpression returns the expression to use to access |col|, found at position |idx| in the
+// row being scanned. For a virtual column, this will be the generation expression. For a phsyical
+// column, a getField expression is returned to access the column's value from a row.
+func getColumnExpression(idx int, col *sql.Column) sql.Expression {
 	if col.Virtual && col.Generated != nil {
 		return col.Generated
 	}
@@ -1715,11 +1712,8 @@ func columnRewriteProjection(idx int, col *sql.Column) sql.Expression {
 }
 
 // fixupColumnRewriteFieldRefs corrects GetField indexes embedded inside any default-value or
-// generated-column projection in |projections| so they refer to the right position in |newSch|.
-// This is necessary because ProjectRow evaluates such projections in a second pass against the new
-// row being built (see defaultValFromProjectExpr), not the original row being scanned, so any
-// column reference inside them must point at the new schema's layout.
-func fixupColumnRewriteFieldRefs(ctx *sql.Context, newSch sql.Schema, projections []sql.Expression) error {
+// generated-column expressions in |projections| so they refer to the right position in |newSch|.
+func updateExpressionFieldRefs(ctx *sql.Context, newSch sql.Schema, projections []sql.Expression) error {
 	if len(newSch) == 0 {
 		return nil
 	}
@@ -1791,17 +1785,17 @@ func addColumnToSchema(ctx *sql.Context, schema sql.Schema, column *sql.Column, 
 		newSch = append(newSch, schema[idx:]...)
 
 		for i := 0; i < idx; i++ {
-			projections[i] = columnRewriteProjection(i, schema[i])
+			projections[i] = getColumnExpression(i, schema[i])
 		}
 		projections[idx] = plan.ColDefaultExpression{column}
 		for i := idx; i < len(schema); i++ {
-			projections[i+1] = columnRewriteProjection(i, schema[i])
+			projections[i+1] = getColumnExpression(i, schema[i])
 		}
 	} else { // new column at end
 		newSch = append(newSch, schema...)
 		newSch = append(newSch, column)
 		for i, col := range schema {
-			projections[i] = columnRewriteProjection(i, col)
+			projections[i] = getColumnExpression(i, col)
 		}
 		projections[len(schema)] = plan.ColDefaultExpression{column}
 	}
@@ -1809,7 +1803,7 @@ func addColumnToSchema(ctx *sql.Context, schema sql.Schema, column *sql.Column, 
 	// Alter old default expressions if they refer to other columns. The column indexes computed during analysis refer to the
 	// column indexes in the old result schema, which is not what we want here: we want the positions in the new
 	// schema, since that is what we'll be evaluating when we rewrite the table.
-	if err := fixupColumnRewriteFieldRefs(ctx, newSch, projections); err != nil {
+	if err := updateExpressionFieldRefs(ctx, newSch, projections); err != nil {
 		return nil, nil, err
 	}
 
@@ -2026,19 +2020,19 @@ func dropColumnFromSchema(ctx *sql.Context, schema sql.Schema, column string, ta
 	i := 0
 	for j := range schema[:idx] {
 		newSch[i] = schema[j]
-		projections[i] = columnRewriteProjection(j, schema[j])
+		projections[i] = getColumnExpression(j, schema[j])
 		i++
 	}
 
 	for j := range schema[idx+1:] {
 		schIdx := j + i + 1
 		newSch[j+i] = schema[schIdx]
-		projections[j+i] = columnRewriteProjection(schIdx, schema[schIdx])
+		projections[j+i] = getColumnExpression(schIdx, schema[schIdx])
 	}
 
 	// Any surviving virtual/generated column's expression may reference a column whose position
 	// shifted because of the drop; point those references at the new schema's layout.
-	if err := fixupColumnRewriteFieldRefs(ctx, newSch, projections); err != nil {
+	if err := updateExpressionFieldRefs(ctx, newSch, projections); err != nil {
 		return nil, nil, err
 	}
 

--- a/sql/rows.go
+++ b/sql/rows.go
@@ -65,6 +65,23 @@ func (r Row) Equals(ctx *Context, row Row, schema Schema) (bool, error) {
 	return true, nil
 }
 
+// EvalProjections evaluates each non-nil expression in projections against row in index order and
+// writes the result back into the matching position, leaving nil positions unchanged. Evaluating in order
+// lets a projection reference a column that comes before it.
+func EvalProjections(ctx *Context, projections []Expression, row Row) error {
+	for i, expr := range projections {
+		if expr == nil {
+			continue
+		}
+		value, err := expr.Eval(ctx, row)
+		if err != nil {
+			return err
+		}
+		row[i] = value
+	}
+	return nil
+}
+
 // FormatRow returns a formatted string representing this row's values
 func FormatRow(row Row) string {
 	var sb strings.Builder

--- a/sql/schemas.go
+++ b/sql/schemas.go
@@ -63,6 +63,18 @@ func (s Schema) HasVirtualColumns() bool {
 	return false
 }
 
+// GeneratedExpressions returns the schema's generated column expressions indexed by column position,
+// with nil where a column has no generated expression.
+func (s Schema) GeneratedExpressions() []Expression {
+	projections := make([]Expression, len(s))
+	for i, col := range s {
+		if col.Generated != nil {
+			projections[i] = col.Generated
+		}
+	}
+	return projections
+}
+
 // PhysicalSchema returns a schema with only the physical (non-virtual) columns
 func (s Schema) PhysicalSchema() Schema {
 	var physical Schema


### PR DESCRIPTION
When updating a row in a secondary index, any virtual generated columns need their generation expression evaluated to get the correct data stored in the secondary index. There were a few edge case with virtual columns and secondary indexes where this evaluation wasn't happening. This PR closes those gaps. 

The first case is when a table rewrite is performed and secondary indexes are rebuilt (e.g. when dropping a column on a table). Not properly evaluating a virtual column's expression caused incorrect data to be stored in the index when it was rebuilt. 

A second case is for referential actions on a foreign key that update a table and its secondary index. Not properly evaluating a virtual column's expression here can also cause incorrect data to be written to the secondary index.

Fix for failing Dolt CI integration test in: https://github.com/dolthub/dolt/pull/11333