### PR TITLE
have coster consider not picking secondary indexes

### DIFF
--- a/enginetest/join_stats_tests.go
+++ b/enginetest/join_stats_tests.go
@@ -78,8 +78,8 @@ var JoinStatTests = []struct {
 			},
 			{
 				// b with filter is smaller
-				q:     "select /*+ LEFT_DEEP */ count(*) from `u-15` a join `u+15` b on a.b = b.b where b.b < 14",
-				order: [][]string{{"b", "aa"}},
+				q:     "select /*+ LEFT_DEEP */ count(*) from `u-15` a join `u+15` b on a.b = b.b where b.b < 4",
+				order: [][]string{{"b", "a"}},
 			},
 		},
 	},

--- a/enginetest/join_stats_tests.go
+++ b/enginetest/join_stats_tests.go
@@ -78,8 +78,8 @@ var JoinStatTests = []struct {
 			},
 			{
 				// b with filter is smaller
-				q:     "select /*+ LEFT_DEEP */ count(*) from `u-15` a join `u+15` b on a.b = b.b where b.b < 15",
-				order: [][]string{{"b", "a"}},
+				q:     "select /*+ LEFT_DEEP */ count(*) from `u-15` a join `u+15` b on a.b = b.b where b.b < 14",
+				order: [][]string{{"b", "aa"}},
 			},
 		},
 	},

--- a/enginetest/join_stats_tests.go
+++ b/enginetest/join_stats_tests.go
@@ -78,7 +78,7 @@ var JoinStatTests = []struct {
 			},
 			{
 				// b with filter is smaller
-				q:     "select /*+ LEFT_DEEP */ count(*) from `u-15` a join `u+15` b on a.b = b.b where b.b < 4",
+				q:     "select /*+ LEFT_DEEP */ count(*) from `u-15` a join `u+15` b on a.b = b.b where b.b < 15",
 				order: [][]string{{"b", "a"}},
 			},
 		},

--- a/enginetest/join_stats_tests.go
+++ b/enginetest/join_stats_tests.go
@@ -78,7 +78,7 @@ var JoinStatTests = []struct {
 			},
 			{
 				// b with filter is smaller
-				q:     "select /*+ LEFT_DEEP */ count(*) from `u-15` a join `u+15` b on a.b = b.b where b.b < 15",
+				q:     "select /*+ LEFT_DEEP */ count(*) from `u-15` a join `u+15` b on a.b = b.b where b.b < 10",
 				order: [][]string{{"b", "a"}},
 			},
 		},

--- a/memory/index.go
+++ b/memory/index.go
@@ -158,7 +158,7 @@ func (idx *Index) CoversColumns(cols []string) bool {
 			if !isGf {
 				return false
 			}
-			if gf.Name() != col {
+			if !strings.EqualFold(col, gf.Name()) {
 				return false
 			}
 		}

--- a/memory/index.go
+++ b/memory/index.go
@@ -151,6 +151,21 @@ func (idx *Index) IndexType() string {
 	return "BTREE" // fake but so are you
 }
 
+func (idx *Index) CoversColumns(cols []string) bool {
+	for _, col := range cols {
+		for _, expr := range idx.Exprs {
+			gf, isGf := expr.(*expression.GetField)
+			if !isGf {
+				return false
+			}
+			if gf.Name() != col {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 func (idx *Index) rowToIndexStorage(row sql.Row, partitionName string, rowIdx int) (sql.Row, error) {
 	if idx.Name == "PRIMARY" {
 		return row, nil

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -617,7 +617,7 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 	if rowCnt < c.bestCnt {
 		// TODO: secondary indexes incur an additional index lookup cost, so they need to reduce rowCount by a substantial amount
 		if s.Qualifier().Index() != "PRIMARY" && s.Qualifier().Index() != "" {
-			if rowCnt/4 < c.bestCnt {
+			if rowCnt < c.bestCnt/4 {
 				update = true
 			}
 			return

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -63,32 +63,61 @@ func costedIndexScans(ctx *sql.Context, a *Analyzer, n sql.Node, qFlags *sql.Que
 			return n, transform.SameTree, nil
 		}
 
-		var rt sql.TableNode
-		var aliasName string
-		switch n := filter.Child.(type) {
+		var tblNode sql.TableNode
+		var alias string
+		switch child := filter.Child.(type) {
 		case *plan.ResolvedTable:
-			rt = n
+			tblNode = child
 		case *plan.TableAlias:
-			rt, _ = n.Child.(sql.TableNode)
-			aliasName = n.Name()
-		}
-		if rt == nil {
+			tblNode, ok = child.Child.(sql.TableNode)
+			if !ok {
+				return n, transform.SameTree, nil
+			}
+			alias = child.Name()
+		default:
 			return n, transform.SameTree, nil
 		}
 
-		if is, ok := rt.UnderlyingTable().(sql.IndexSearchableTable); ok {
-			lookup, lookupFds, newFilter, ok, err := is.LookupForExpressions(ctx, expression.SplitConjunction(ctx, filter.Expression)...)
+		tbl := tblNode.UnderlyingTable()
+		if idxTbl, isIdxTbl := tbl.(sql.IndexSearchableTable); isIdxTbl {
+			exprs := expression.SplitConjunction(ctx, filter.Expression)
+			lookup, lookupFds, newFilter, ok, err := idxTbl.LookupForExpressions(ctx, exprs...)
 			if err != nil {
 				return n, transform.SameTree, err
 			}
 			if ok {
-				return indexSearchableLookup(ctx, n, rt, lookup, filter.Expression, newFilter, lookupFds, qFlags)
-			} else if is.SkipIndexCosting() {
+				return indexSearchableLookup(ctx, n, tblNode, lookup, filter.Expression, newFilter, lookupFds, qFlags)
+			}
+			if idxTbl.SkipIndexCosting() {
 				return n, transform.SameTree, nil
 			}
 		}
-		if iat, ok := rt.UnderlyingTable().(sql.IndexAddressableTable); ok {
-			return costedIndexLookup(ctx, n, a, iat, rt, aliasName, filter.Expression, qFlags)
+
+		if idxTbl, isIdxTbl := tbl.(sql.IndexAddressableTable); isIdxTbl {
+			idxs, err := idxTbl.GetIndexes(ctx)
+			if err != nil {
+				return n, transform.SameTree, err
+			}
+
+			exprs := expression.SplitConjunction(ctx, filter.Expression)
+			idxedTbl, stats, filters, err := getCostedIndexScan(ctx, a.Catalog, a.Catalog, tblNode, idxs, exprs, qFlags)
+			if err != nil || idxedTbl == nil {
+				return n, transform.SameTree, err
+			}
+			var ret sql.Node = idxedTbl
+			if alias != "" {
+				ret = plan.NewTableAlias(alias, ret)
+			}
+			// excluded from tree + not included in index scan => filter above scan
+			if len(filters) > 0 {
+				ret = plan.NewFilter(ctx, expression.JoinAnd(filters...), ret)
+			}
+			if a.Debug {
+				a.Log("new indexed table: %s/%s/%s", idxedTbl.Index().Database(), idxedTbl.Index().Table(), idxedTbl.Index().ID())
+				a.Log("index stats cnt: %d", stats.RowCount())
+				a.Log("index stats histogram: %s", stats.Histogram().DebugString(ctx))
+			}
+			return ret, transform.NewTree, nil
 		}
 		return n, transform.SameTree, nil
 	})
@@ -126,43 +155,6 @@ func indexSearchableLookup(ctx *sql.Context, n sql.Node, rt sql.TableNode, looku
 		qFlags.Set(sql.QFlagMax1Row)
 	}
 
-	return ret, transform.NewTree, nil
-}
-
-func costedIndexLookup(
-	ctx *sql.Context,
-	n sql.Node,
-	a *Analyzer,
-	iat sql.IndexAddressableTable,
-	rt sql.TableNode,
-	aliasName string,
-	oldFilter sql.Expression,
-	qFlags *sql.QueryFlags,
-) (sql.Node, transform.TreeIdentity, error) {
-	indexes, err := iat.GetIndexes(ctx)
-	if err != nil {
-		return n, transform.SameTree, err
-	}
-
-	ita, stats, filters, err := getCostedIndexScan(ctx, a.Catalog, a.Catalog, rt, indexes, expression.SplitConjunction(ctx, oldFilter), qFlags)
-	if err != nil || ita == nil {
-		return n, transform.SameTree, err
-	}
-	var ret sql.Node = ita
-	if aliasName != "" {
-		ret = plan.NewTableAlias(aliasName, ret)
-	}
-
-	if a.Debug {
-		a.Log("new indexed table: %s/%s/%s", ita.Index().Database(), ita.Index().Table(), ita.Index().ID())
-		a.Log("index stats cnt: %d", stats.RowCount())
-		a.Log("index stats histogram: %s", stats.Histogram().DebugString(ctx))
-	}
-
-	// excluded from tree + not included in index scan => filter above scan
-	if len(filters) > 0 {
-		ret = plan.NewFilter(ctx, expression.JoinAnd(filters...), ret)
-	}
 	return ret, transform.NewTree, nil
 }
 

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -240,12 +240,12 @@ func getCostedIndexScan(
 		}
 	}
 
-	// include an indexless option for best
+	// include an indexless option for coster
 	tblScanStat, err := uniformDistStatsticForTableScan(ctx, statsProvider, iat)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	c.updateBest(tblScanStat, nil, nil, sets.FastIntSet{}, 0, false)
+	c.updateBest(tblScanStat, tblScanStat.Histogram(), nil, sets.FastIntSet{}, 0, false)
 
 	for _, idx := range indexes {
 		// only use the index if the query filters include the index predicate
@@ -585,7 +585,12 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 	if s == nil {
 		return
 	}
-	rowCnt, _, _ := stats.GetNewCounts(hist)
+	// special exception for keyless cost option
+	if filters.Len() == 0 && s.Qualifier().Index() != "" {
+		return
+	}
+
+	rowCnt, _, _ := stats.GetNewCounts(hist) // TODO: wtf
 
 	var update bool
 	defer func() {
@@ -599,20 +604,35 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 		}
 	}()
 
-	if c.bestStat == nil { // TODO: if there is only one available index, we ALWAYS pick it even if it may be worse than no index
+	// TODO: if there is only one available index, we ALWAYS pick it even if it may be worse than no index
+	if c.bestStat == nil {
 		update = true
 		return
 	}
+
 	if bestFds := c.bestStat.FuncDeps(); bestFds != nil && bestFds.HasMax1Row() {
 		return
-	} else if rowCnt < c.bestCnt {
+	}
+
+	if rowCnt < c.bestCnt {
+		// TODO: secondary indexes incur an additional index lookup cost, so they need to reduce rowCount by a substantial amount
+		if s.Qualifier().Index() != "PRIMARY" && s.Qualifier().Index() != "" {
+			if rowCnt/4 < c.bestCnt {
+				update = true
+			}
+			return
+		}
 		update = true
 		return
-	} else if c.bestPrefix == 0 || prefix == 0 && c.bestPrefix != prefix {
+	}
+
+	if c.bestPrefix == 0 || prefix == 0 && c.bestPrefix != prefix {
 		// any prefix is better than no prefix
 		update = prefix > c.bestPrefix
 		return
-	} else if rowCnt == c.bestCnt {
+	}
+
+	if rowCnt == c.bestCnt {
 		// hand rules when stats don't exist or match exactly
 		cmp := fds
 		best := c.bestStat.FuncDeps()
@@ -620,6 +640,7 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 			update = true
 			return
 		}
+		c.bestStat.Qualifier().Empty()
 
 		// If one index uses a strict superset of the filters of the other, we should always pick the superset.
 		// This is true even if the index with more filters isn't unique.
@@ -2009,10 +2030,30 @@ func uniformDistStatsticForTableScan(ctx *sql.Context, statsProv sql.StatsProvid
 		}
 	}
 
+	// This is needed for cost row count
+	// one giant bucket
+	hist := sql.Histogram{
+		stats.Bucket{
+			RowCnt: rowCount,
+		},
+	}
+
 	distinctCount := rowCount
 	nullCount := uint64(float64(distinctCount) * dummyNotUniqueNull)
 	qual := sql.NewStatQualifier(dbName, schemaName, tableName, "")
-	stat := stats.NewStatistic(rowCount, distinctCount, nullCount, avgSize, time.Now(), qual, nil, nil, nil, sql.IndexClassDefault, nil)
+	stat := stats.NewStatistic(
+		rowCount,
+		distinctCount,
+		nullCount,
+		avgSize,
+		time.Now(),
+		qual,
+		nil,
+		nil,
+		hist,
+		sql.IndexClassDefault,
+		nil,
+	)
 	return stat, nil
 
 }

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -617,11 +617,17 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 	if rowCnt < c.bestCnt {
 		// TODO: secondary indexes incur an additional index lookup cost, so they need to reduce rowCount by a substantial amount
 		if s.Qualifier().Index() != "PRIMARY" && s.Qualifier().Index() != "" {
-			if rowCnt < c.bestCnt/4 {
+			if rowCnt < 10 || rowCnt < c.bestCnt/4 {
 				update = true
 			}
 			return
 		}
+		update = true
+		return
+	}
+
+	// Missing stats, just use the index
+	if rowCnt == 0 && c.bestCnt == 0 && c.bestStat.Qualifier().Index() == "" {
 		update = true
 		return
 	}

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -56,8 +56,13 @@ import (
 // fraction of its conjunctions into an indexScan, with the excluded
 // remaining in the parent filter. Much of the format conversions focus
 // on maintaining this invariant.
-func costedIndexScans(ctx *sql.Context, a *Analyzer, n sql.Node, qFlags *sql.QueryFlags) (sql.Node, transform.TreeIdentity, error) {
-	return transform.Node(ctx, n, func(ctx *sql.Context, n sql.Node) (sql.Node, transform.TreeIdentity, error) {
+func costedIndexScans(
+	ctx *sql.Context,
+	a *Analyzer,
+	node sql.Node,
+	qFlags *sql.QueryFlags,
+) (sql.Node, transform.TreeIdentity, error) {
+	return transform.Node(ctx, node, func(ctx *sql.Context, n sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		filter, ok := n.(*plan.Filter)
 		if !ok {
 			return n, transform.SameTree, nil
@@ -119,27 +124,38 @@ func costedIndexScans(ctx *sql.Context, a *Analyzer, n sql.Node, qFlags *sql.Que
 			}
 			return ret, transform.NewTree, nil
 		}
+
 		return n, transform.SameTree, nil
 	})
 }
 
-func indexSearchableLookup(ctx *sql.Context, n sql.Node, rt sql.TableNode, lookup sql.IndexLookup, oldFilter, newFilter sql.Expression, fds *sql.FuncDepSet, qFlags *sql.QueryFlags) (sql.Node, transform.TreeIdentity, error) {
+func indexSearchableLookup(
+	ctx *sql.Context,
+	node sql.Node,
+	tblNode sql.TableNode,
+	lookup sql.IndexLookup,
+	oldFilter, newFilter sql.Expression,
+	fds *sql.FuncDepSet,
+	qFlags *sql.QueryFlags,
+) (sql.Node, transform.TreeIdentity, error) {
+
 	if lookup.IsEmpty() {
-		return n, transform.SameTree, nil
+		return node, transform.SameTree, nil
 	}
+
 	var ret sql.Node
 	var err error
-	ret, err = plan.NewStaticIndexedAccessForTableNode(ctx, rt, lookup)
+	ret, err = plan.NewStaticIndexedAccessForTableNode(ctx, tblNode, lookup)
 	if err != nil {
-		return n, transform.SameTree, err
+		return node, transform.SameTree, err
 	}
 
-	iat, ok := rt.UnderlyingTable().(sql.IndexAddressableTable)
+	idxTbl, ok := tblNode.UnderlyingTable().(sql.IndexAddressableTable)
 	if !ok {
-		return n, transform.SameTree, nil
+		return node, transform.SameTree, nil
 	}
 
-	if !preciseIndexAccess(iat, lookup.Index) {
+	if !preciseIndexAccess(idxTbl, lookup.Index) {
 		// cannot drop any filters
 		newFilter = oldFilter
 	}

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -174,6 +174,24 @@ func indexSearchableLookup(
 	return ret, transform.NewTree, nil
 }
 
+// canUsePartialIndex returns true only if the query filters include the index predicate
+func canUsePartialIndex(idx sql.Index, filters []sql.Expression) bool {
+	partIdx, isPartIdx := idx.(sql.PartialIndex)
+	if !isPartIdx {
+		return true
+	}
+	pred := partIdx.Predicate()
+	if len(pred) == 0 {
+		return true
+	}
+	for _, f := range filters {
+		if strings.EqualFold(pred, f.String()) {
+			return true
+		}
+	}
+	return false
+}
+
 // getCostedIndexScan tries to build the lowest cost index scan for the filter expressions provided. Returns a nil
 // result if an index cannot satisfy the filters.
 func getCostedIndexScan(
@@ -258,19 +276,8 @@ func getCostedIndexScan(
 
 	for _, idx := range indexes {
 		// only use the index if the query filters include the index predicate
-		if pi, ok := idx.(sql.PartialIndex); ok && pi.Predicate() != "" {
-			predStr := pi.Predicate()
-			implied := false
-			for _, f := range filters {
-				fstr := f.String()
-				if strings.EqualFold(predStr, fstr) {
-					implied = true
-					break
-				}
-			}
-			if !implied {
-				continue
-			}
+		if !canUsePartialIndex(idx, filters) {
+			continue
 		}
 
 		qual.Idx = strings.ToLower(idx.ID())
@@ -600,7 +607,7 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 		return
 	}
 
-	rowCnt, _, _ := stats.GetNewCounts(hist) // TODO: wtf
+	rowCnt, _, _ := stats.GetNewCounts(hist)
 
 	var update bool
 	defer func() {
@@ -614,7 +621,6 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 		}
 	}()
 
-	// TODO: if there is only one available index, we ALWAYS pick it even if it may be worse than no index
 	if c.bestStat == nil {
 		update = true
 		return
@@ -625,9 +631,9 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 	}
 
 	if rowCnt < c.bestCnt {
-		// TODO: secondary indexes incur an additional index lookup cost, so they need to reduce rowCount by a substantial amount
+		// Secondary indexes incur an additional index lookup cost, so they need to reduce rowCount by a substantial amount
 		if s.Qualifier().Index() != "PRIMARY" && s.Qualifier().Index() != "" {
-			if rowCnt < 10 || c.bestStat.Qualifier().Idx != "" || rowCnt < c.bestCnt/4 {
+			if rowCnt < 10 || rowCnt < c.bestCnt/4 || c.bestStat.Qualifier().Idx != "" {
 				update = true
 			}
 			return

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -240,6 +240,13 @@ func getCostedIndexScan(
 		}
 	}
 
+	// include an indexless option for best
+	tblScanStat, err := uniformDistStatsticForTableScan(ctx, statsProvider, iat)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	c.updateBest(tblScanStat, nil, nil, sets.FastIntSet{}, 0, false)
+
 	for _, idx := range indexes {
 		// only use the index if the query filters include the index predicate
 		if pi, ok := idx.(sql.PartialIndex); ok && pi.Predicate() != "" {
@@ -575,7 +582,7 @@ func (c *indexCoster) cost(ctx *sql.Context, f indexFilter, stat sql.Statistic, 
 }
 
 func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fds *sql.FuncDepSet, filters sets.FastIntSet, prefix int, hasRange bool) {
-	if s == nil || filters.Len() == 0 {
+	if s == nil {
 		return
 	}
 	rowCnt, _, _ := stats.GetNewCounts(hist)
@@ -592,10 +599,11 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 		}
 	}()
 
-	if c.bestStat == nil {
+	if c.bestStat == nil { // TODO: if there is only one available index, we ALWAYS pick it even if it may be worse than no index
 		update = true
 		return
-	} else if c.bestStat.FuncDeps().HasMax1Row() {
+	}
+	if bestFds := c.bestStat.FuncDeps(); bestFds != nil && bestFds.HasMax1Row() {
 		return
 	} else if rowCnt < c.bestCnt {
 		update = true
@@ -1968,6 +1976,46 @@ func IndexLeafChildren(e sql.Expression) (sql.IndexScanOp, sql.Expression, sql.E
 
 const dummyNotUniqueDistinct = .90
 const dummyNotUniqueNull = .03
+
+func uniformDistStatsticForTableScan(ctx *sql.Context, statsProv sql.StatsProvider, iat sql.IndexAddressableTable) (sql.Statistic, error) {
+	var rowCount uint64
+	var avgSize uint64
+
+	var dbName string
+	if dbTable, ok := iat.(sql.Databaseable); ok {
+		dbName = strings.ToLower(dbTable.Database())
+	}
+	var schemaName string
+	if schTab, ok := iat.(sql.DatabaseSchemaTable); ok {
+		schemaName = strings.ToLower(schTab.DatabaseSchema().SchemaName())
+	}
+	tableName := strings.ToLower(iat.Name())
+
+	rowCount, _ = statsProv.RowCount(ctx, schemaName, dbName, iat)
+	if st, ok := iat.(sql.StatisticsTable); ok {
+		rCnt, _, err := st.RowCount(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if rowCount == 0 {
+			rowCount = rCnt
+		}
+		if rowCount > 0 {
+			dataSize, err := st.DataLength(ctx)
+			if err != nil {
+				return nil, err
+			}
+			avgSize = dataSize / rowCount
+		}
+	}
+
+	distinctCount := rowCount
+	nullCount := uint64(float64(distinctCount) * dummyNotUniqueNull)
+	qual := sql.NewStatQualifier(dbName, schemaName, tableName, "")
+	stat := stats.NewStatistic(rowCount, distinctCount, nullCount, avgSize, time.Now(), qual, nil, nil, nil, sql.IndexClassDefault, nil)
+	return stat, nil
+
+}
 
 func uniformDistStatisticsForIndex(ctx *sql.Context, statsProv sql.StatsProvider, iat sql.IndexAddressableTable, idx sql.Index) (sql.Statistic, error) {
 	var rowCount uint64

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -617,7 +617,7 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 	if rowCnt < c.bestCnt {
 		// TODO: secondary indexes incur an additional index lookup cost, so they need to reduce rowCount by a substantial amount
 		if s.Qualifier().Index() != "PRIMARY" && s.Qualifier().Index() != "" {
-			if rowCnt < 10 || rowCnt < c.bestCnt/4 {
+			if rowCnt < 10 || c.bestStat.Qualifier().Idx != "" || rowCnt < c.bestCnt/4 {
 				update = true
 			}
 			return

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -172,28 +172,41 @@ func getCostedIndexScan(
 	ctx *sql.Context,
 	statsProvider sql.StatsProvider,
 	cat sql.Catalog,
-	rt sql.TableNode,
+	tblNode sql.TableNode,
 	indexes []sql.Index,
 	filters []sql.Expression,
 	qFlags *sql.QueryFlags,
 ) (*plan.IndexedTableAccess, sql.Statistic, []sql.Expression, error) {
 	// run each index through coster, save the cheapest
-	table := rt.UnderlyingTable()
-	var schemaName string
-	if schTab, ok := table.(sql.DatabaseSchemaTable); ok {
-		schemaName = strings.ToLower(schTab.DatabaseSchema().SchemaName())
+	tbl := tblNode.UnderlyingTable()
+	idxTbl, isIdxTbl := tbl.(sql.IndexAddressableTable)
+	if !isIdxTbl {
+		return nil, nil, nil, nil
 	}
-	tableName := strings.ToLower(table.Name())
 
-	statistics, err := statsProvider.GetTableStats(ctx, schemaName, rt.Database().Name(), table)
+	tblName := tbl.Name()
+	var schName string
+	if schTab, ok := tbl.(sql.DatabaseSchemaTable); ok {
+		schName = schTab.DatabaseSchema().SchemaName()
+	}
+	var dbName string
+	switch t := tbl.(type) {
+	case sql.Databaseable:
+		dbName = t.Database()
+	case sql.Databaser:
+		dbName = t.Database().Name()
+	}
+
+	statistics, err := statsProvider.GetTableStats(ctx, schName, dbName, tbl)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	qualToStat := make(map[sql.StatQualifier]sql.Statistic)
 	for _, stat := range statistics {
-		if prev, ok := qualToStat[stat.Qualifier()]; !ok || (len(stat.Columns()) > len(prev.Columns())) {
-			qualToStat[stat.Qualifier()] = stat
+		statQual := stat.Qualifier()
+		if prev, ok := qualToStat[statQual]; !ok || (len(stat.Columns()) > len(prev.Columns())) {
+			qualToStat[statQual] = stat
 		}
 	}
 
@@ -202,25 +215,13 @@ func getCostedIndexScan(
 		expressionWalker = cat.Overrides().CostedIndexScanExpressionFilter
 	}
 
-	iat, ok := rt.UnderlyingTable().(sql.IndexAddressableTable)
-	if !ok {
-		return nil, nil, nil, err
-	}
-
-	var dbName string
-	if dbTab, ok := rt.UnderlyingTable().(sql.Databaseable); ok {
-		dbName = strings.ToLower(dbTab.Database())
-	} else if dber, ok := rt.UnderlyingTable().(sql.Databaser); ok {
-		dbName = dber.Database().Name()
-	}
-
 	// build the list of available indexed expressions that can be attempted to use in this scan
-	indexedExprs, err := buildIndexedExprToColumnNameMap(ctx, cat, indexes, rt)
+	indexedExprs, err := buildIndexedExprToColumnNameMap(ctx, cat, indexes, tblNode)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	c := newIndexCoster(rt.Name())
+	c := newIndexCoster(tblNode.Name())
 	c.indexedExprs = indexedExprs
 
 	root, leftover, imprecise := c.buildRoot(ctx, expression.JoinAnd(filters...), expressionWalker)
@@ -231,7 +232,7 @@ func getCostedIndexScan(
 	if len(qualToStat) > 0 {
 		// don't mix and match real and default stats
 		for _, idx := range indexes {
-			qual := sql.NewStatQualifier(dbName, schemaName, tableName, idx.ID())
+			qual := sql.NewStatQualifier(dbName, schName, tblName, idx.ID())
 			_, ok := qualToStat[qual]
 			if !ok {
 				qualToStat = nil
@@ -241,7 +242,7 @@ func getCostedIndexScan(
 	}
 
 	// include an indexless option for coster
-	tblScanStat, err := uniformDistStatsticForTableScan(ctx, statsProvider, iat)
+	tblScanStat, err := uniformDistStatsticForTableScan(ctx, statsProvider, idxTbl)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -250,11 +251,11 @@ func getCostedIndexScan(
 	for _, idx := range indexes {
 		// only use the index if the query filters include the index predicate
 		if pi, ok := idx.(sql.PartialIndex); ok && pi.Predicate() != "" {
-			predStr := strings.ToLower(pi.Predicate())
+			predStr := pi.Predicate()
 			implied := false
 			for _, f := range filters {
-				fstr := strings.ToLower(f.String())
-				if fstr == predStr {
+				fstr := f.String()
+				if strings.EqualFold(predStr, fstr) {
 					implied = true
 					break
 				}
@@ -264,16 +265,16 @@ func getCostedIndexScan(
 			}
 		}
 
-		qual := sql.NewStatQualifier(dbName, schemaName, tableName, idx.ID())
+		qual := sql.NewStatQualifier(dbName, schName, tblName, idx.ID())
 		stat, ok := qualToStat[qual]
 		if !ok {
 			// create statistic if table is missing a statsProvider
-			stat, err = uniformDistStatisticsForIndex(ctx, statsProvider, iat, idx)
+			stat, err = uniformDistStatisticsForIndex(ctx, statsProvider, idxTbl, idx)
 		}
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		err := c.cost(ctx, root, stat, idx)
+		err = c.cost(ctx, root, stat, idx)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -355,19 +356,19 @@ func getCostedIndexScan(
 		if matchAgainst.KeyCols.Type == fulltext.KeyType_None {
 			return nil, nil, nil, err
 		}
-		ret = plan.NewStaticIndexedAccessForFullTextTable(ctx, rt, lookup, &rowexec.FulltextFilterTable{
+		ret = plan.NewStaticIndexedAccessForFullTextTable(ctx, tblNode, lookup, &rowexec.FulltextFilterTable{
 			MatchAgainst: matchAgainst,
-			Table:        rt,
+			Table:        tblNode,
 		})
 	} else {
-		ret, err = plan.NewStaticIndexedAccessForTableNode(ctx, rt, lookup)
+		ret, err = plan.NewStaticIndexedAccessForTableNode(ctx, tblNode, lookup)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 	}
 
 	var retFilters []sql.Expression
-	if !preciseIndexAccess(iat, lookup.Index) {
+	if !preciseIndexAccess(idxTbl, lookup.Index) {
 		// cannot drop filters
 		retFilters = filters
 	} else if len(b.leftover) > 0 {

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -220,7 +220,6 @@ func getCostedIndexScan(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
 	c := newIndexCoster(tblNode.Name())
 	c.indexedExprs = indexedExprs
 
@@ -229,12 +228,13 @@ func getCostedIndexScan(
 		return nil, nil, nil, err
 	}
 
+	// reuse stat qualifier to save memory
+	qual := sql.NewStatQualifier(dbName, schName, tblName, "")
 	if len(qualToStat) > 0 {
 		// don't mix and match real and default stats
 		for _, idx := range indexes {
-			qual := sql.NewStatQualifier(dbName, schName, tblName, idx.ID())
-			_, ok := qualToStat[qual]
-			if !ok {
+			qual.Idx = strings.ToLower(idx.ID())
+			if _, ok := qualToStat[qual]; !ok {
 				qualToStat = nil
 				break
 			}
@@ -265,10 +265,10 @@ func getCostedIndexScan(
 			}
 		}
 
-		qual := sql.NewStatQualifier(dbName, schName, tblName, idx.ID())
+		qual.Idx = strings.ToLower(idx.ID())
 		stat, ok := qualToStat[qual]
 		if !ok {
-			// create statistic if table is missing a statsProvider
+			// create statistic if the table is missing a statsProvider
 			stat, err = uniformDistStatisticsForIndex(ctx, statsProvider, idxTbl, idx)
 		}
 		if err != nil {
@@ -284,6 +284,7 @@ func getCostedIndexScan(
 		return nil, nil, nil, err
 	}
 
+	// TODO: coster should just have pointer to best index
 	targetId := c.bestStat.Qualifier().Index()
 	var idx sql.Index
 	for _, i := range indexes {
@@ -324,11 +325,11 @@ func getCostedIndexScan(
 			allRange = allRange && uok && lok
 			if i == 0 && allRange {
 				// no prefix restriction
-				return nil, nil, nil, err
+				return nil, nil, nil, nil
 			}
 		}
 		if allRange {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil
 		}
 	}
 

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -272,7 +272,9 @@ func getCostedIndexScan(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	c.updateBest(tblScanStat, tblScanStat.Histogram(), nil, sets.FastIntSet{}, 0, false)
+	c.updateBest(tblScanStat, tblScanStat.Histogram(), nil, sets.FastIntSet{}, 0, false, false)
+
+	covTbl, isCovTbl := tbl.(sql.CoveringProjectedTable)
 
 	for _, idx := range indexes {
 		// only use the index if the query filters include the index predicate
@@ -289,7 +291,12 @@ func getCostedIndexScan(
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		err = c.cost(ctx, root, stat, idx)
+
+		// TODO: have a more elegant way of determining if index is covering table
+		//  pruneTable fills in the projectedSchema for dolt tables, so this solution reuses that effort
+		isCov := isCovTbl && covTbl.IsCovering(idx)
+
+		err = c.cost(ctx, root, stat, idx, isCov)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -549,7 +556,7 @@ type indexCoster struct {
 
 // cost tries to build the lowest cardinality index scan for an expression
 // tree rooted at |f| on the index |idx| whose statistics are represented by |stat|.
-func (c *indexCoster) cost(ctx *sql.Context, f indexFilter, stat sql.Statistic, idx sql.Index) error {
+func (c *indexCoster) cost(ctx *sql.Context, f indexFilter, stat sql.Statistic, idx sql.Index, isCov bool) error {
 	ordinals := ordinalsForStat(stat)
 
 	var newHist []sql.HistogramBucket
@@ -593,12 +600,12 @@ func (c *indexCoster) cost(ctx *sql.Context, f indexFilter, stat sql.Statistic, 
 		newFds = &sql.FuncDepSet{}
 	}
 
-	c.updateBest(stat, newHist, newFds, filters, prefix, hasRange)
+	c.updateBest(stat, newHist, newFds, filters, prefix, hasRange, isCov)
 
 	return nil
 }
 
-func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fds *sql.FuncDepSet, filters sets.FastIntSet, prefix int, hasRange bool) {
+func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fds *sql.FuncDepSet, filters sets.FastIntSet, prefix int, hasRange, isCov bool) {
 	if s == nil {
 		return
 	}
@@ -633,7 +640,7 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 	if rowCnt < c.bestCnt {
 		// Secondary indexes incur an additional index lookup cost, so they need to reduce rowCount by a substantial amount
 		if s.Qualifier().Index() != "PRIMARY" && s.Qualifier().Index() != "" {
-			if rowCnt < 10 || rowCnt < c.bestCnt/4 || c.bestStat.Qualifier().Idx != "" {
+			if isCov || rowCnt < 10 || rowCnt < c.bestCnt/4 || c.bestStat.Qualifier().Idx != "" {
 				update = true
 			}
 			return

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -644,6 +644,10 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 		case isCov:
 			update = true
 			return
+		// Performance impact is negligible for small tables, so use old behavior
+		case rowCnt < 10:
+			update = true
+			return
 		// Secondary index reduced rowCount substantially, outweighing secondary lookup costs
 		case rowCnt < c.bestCnt/4:
 			update = true

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -628,7 +628,7 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 		}
 	}()
 
-	if c.bestStat == nil {
+	if c.bestStat == nil { // TODO: replace this so that it is never true again
 		update = true
 		return
 	}
@@ -649,8 +649,9 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 		return
 	}
 
-	// Missing stats, just use the index
-	if rowCnt == 0 && c.bestCnt == 0 && c.bestStat.Qualifier().Index() == "" {
+	// Missing stats or good histogram comparison, so just use the index
+	// TODO: this breaks when the filter over the index is always true
+	if rowCnt == c.bestCnt && c.bestStat.Qualifier().Index() == "" {
 		update = true
 		return
 	}

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -275,7 +275,10 @@ func getCostedIndexScan(
 	c.bestStat = tblScanStat
 	c.bestCnt = tblScanStat.RowCount()
 
-	covTbl, isCovTbl := tbl.(sql.CoveringProjectedTable)
+	var projs []string
+	if projTbl, isProjTbl := tbl.(sql.ProjectedTable); isProjTbl {
+		projs = projTbl.Projections()
+	}
 	for _, idx := range indexes {
 		// only use the index if the query filters include the index predicate
 		if !canUsePartialIndex(idx, filters) {
@@ -292,9 +295,10 @@ func getCostedIndexScan(
 			return nil, nil, nil, err
 		}
 
-		// TODO: have a more elegant way of determining if index is covering table
-		//  pruneTable fills in the projectedSchema for dolt tables, so this solution reuses that effort
-		isCov := isCovTbl && covTbl.IsCovering(idx)
+		var isCov bool
+		if projs != nil {
+			isCov = idx.CoversColumns(projs)
+		}
 
 		err = c.cost(ctx, root, stat, idx, isCov)
 		if err != nil {

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -624,6 +624,11 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 		}
 	}()
 
+	if c.bestStat == nil {
+		update = true
+		return
+	}
+
 	// The current best is a full table scan
 	if c.bestStat.Qualifier().Index() == "" {
 		switch {

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -653,6 +653,8 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 		case rowCnt == c.bestCnt:
 			update = true
 			return
+		default:
+			return
 		}
 	}
 

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -268,14 +268,14 @@ func getCostedIndexScan(
 	}
 
 	// include an indexless option for coster
-	tblScanStat, err := uniformDistStatsticForTableScan(ctx, statsProvider, idxTbl)
+	tblScanStat, err := uniformDistStatsticForTableScan(ctx, statsProvider, qual, idxTbl)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	c.updateBest(tblScanStat, tblScanStat.Histogram(), nil, sets.FastIntSet{}, 0, false, false)
+	c.bestStat = tblScanStat
+	c.bestCnt = tblScanStat.RowCount()
 
 	covTbl, isCovTbl := tbl.(sql.CoveringProjectedTable)
-
 	for _, idx := range indexes {
 		// only use the index if the query filters include the index predicate
 		if !canUsePartialIndex(idx, filters) {
@@ -606,11 +606,7 @@ func (c *indexCoster) cost(ctx *sql.Context, f indexFilter, stat sql.Statistic, 
 }
 
 func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fds *sql.FuncDepSet, filters sets.FastIntSet, prefix int, hasRange, isCov bool) {
-	if s == nil {
-		return
-	}
-	// special exception for keyless cost option
-	if filters.Len() == 0 && s.Qualifier().Index() != "" {
+	if s == nil || filters.Len() == 0 {
 		return
 	}
 
@@ -628,9 +624,27 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 		}
 	}()
 
-	if c.bestStat == nil { // TODO: replace this so that it is never true again
-		update = true
-		return
+	// The current best is a full table scan
+	if c.bestStat.Qualifier().Index() == "" {
+		switch {
+		// Primary Keys are always better
+		case s.Qualifier().Index() == "primary":
+			update = true
+			return
+		// Covering index scans are always better
+		case isCov:
+			update = true
+			return
+		// Secondary index reduced rowCount substantially, outweighing secondary lookup costs
+		case rowCnt < c.bestCnt/4:
+			update = true
+			return
+		// Missing stats or good histogram comparison, so default to old behavior which is using the index
+		// TODO: this breaks when the filter over the index is always true
+		case rowCnt == c.bestCnt:
+			update = true
+			return
+		}
 	}
 
 	if bestFds := c.bestStat.FuncDeps(); bestFds != nil && bestFds.HasMax1Row() {
@@ -638,20 +652,6 @@ func (c *indexCoster) updateBest(s sql.Statistic, hist []sql.HistogramBucket, fd
 	}
 
 	if rowCnt < c.bestCnt {
-		// Secondary indexes incur an additional index lookup cost, so they need to reduce rowCount by a substantial amount
-		if s.Qualifier().Index() != "PRIMARY" && s.Qualifier().Index() != "" {
-			if isCov || rowCnt < 10 || rowCnt < c.bestCnt/4 || c.bestStat.Qualifier().Idx != "" {
-				update = true
-			}
-			return
-		}
-		update = true
-		return
-	}
-
-	// Missing stats or good histogram comparison, so just use the index
-	// TODO: this breaks when the filter over the index is always true
-	if rowCnt == c.bestCnt && c.bestStat.Qualifier().Index() == "" {
 		update = true
 		return
 	}
@@ -2028,30 +2028,24 @@ func IndexLeafChildren(e sql.Expression) (sql.IndexScanOp, sql.Expression, sql.E
 const dummyNotUniqueDistinct = .90
 const dummyNotUniqueNull = .03
 
-func uniformDistStatsticForTableScan(ctx *sql.Context, statsProv sql.StatsProvider, iat sql.IndexAddressableTable) (sql.Statistic, error) {
-	var rowCount uint64
+func uniformDistStatsticForTableScan(
+	ctx *sql.Context,
+	statsProv sql.StatsProvider,
+	qual sql.StatQualifier,
+	idxTbl sql.IndexAddressableTable,
+) (sql.Statistic, error) {
+
 	var avgSize uint64
-
-	var dbName string
-	if dbTable, ok := iat.(sql.Databaseable); ok {
-		dbName = strings.ToLower(dbTable.Database())
-	}
-	var schemaName string
-	if schTab, ok := iat.(sql.DatabaseSchemaTable); ok {
-		schemaName = strings.ToLower(schTab.DatabaseSchema().SchemaName())
-	}
-	tableName := strings.ToLower(iat.Name())
-
-	rowCount, _ = statsProv.RowCount(ctx, schemaName, dbName, iat)
-	if st, ok := iat.(sql.StatisticsTable); ok {
+	rowCount, _ := statsProv.RowCount(ctx, qual.Schema(), qual.Db(), idxTbl)
+	if st, ok := idxTbl.(sql.StatisticsTable); ok {
 		rCnt, _, err := st.RowCount(ctx)
 		if err != nil {
 			return nil, err
 		}
-		if rowCount == 0 {
+		switch {
+		case rowCount == 0:
 			rowCount = rCnt
-		}
-		if rowCount > 0 {
+		case rowCount > 0:
 			dataSize, err := st.DataLength(ctx)
 			if err != nil {
 				return nil, err
@@ -2060,32 +2054,26 @@ func uniformDistStatsticForTableScan(ctx *sql.Context, statsProv sql.StatsProvid
 		}
 	}
 
-	// This is needed for cost row count
-	// one giant bucket
-	hist := sql.Histogram{
-		stats.Bucket{
-			RowCnt: rowCount,
-		},
-	}
-
 	distinctCount := rowCount
 	nullCount := uint64(float64(distinctCount) * dummyNotUniqueNull)
-	qual := sql.NewStatQualifier(dbName, schemaName, tableName, "")
+
+	// mark as full table scan
+	qual.Idx = ""
+
 	stat := stats.NewStatistic(
 		rowCount,
 		distinctCount,
 		nullCount,
 		avgSize,
-		time.Now(),
+		time.Time{},
 		qual,
 		nil,
 		nil,
-		hist,
+		nil,
 		sql.IndexClassDefault,
 		nil,
 	)
 	return stat, nil
-
 }
 
 func uniformDistStatisticsForIndex(ctx *sql.Context, statsProv sql.StatsProvider, iat sql.IndexAddressableTable, idx sql.Index) (sql.Statistic, error) {

--- a/sql/analyzer/costed_index_scan_test.go
+++ b/sql/analyzer/costed_index_scan_test.go
@@ -799,7 +799,7 @@ func TestRangeBuilder(t *testing.T) {
 			stat, err := newUniformDistStatistic(ctx, "mydb", "", testTable, sch, idx, 10, 10)
 			require.NoError(t, err)
 
-			err = c.cost(ctx, root, stat, idx)
+			err = c.cost(ctx, root, stat, idx, false)
 			require.NoError(t, err)
 
 			include := c.bestFilters

--- a/sql/analyzer/index_analyzer_test.go
+++ b/sql/analyzer/index_analyzer_test.go
@@ -153,6 +153,7 @@ func (i *dummyIdx) IsVector() bool                        { return false }
 func (i *dummyIdx) Comment() string                       { return "" }
 func (i *dummyIdx) IsGenerated() bool                     { return false }
 func (i *dummyIdx) CanSupportOrderBy(sql.Expression) bool { return false }
+func (i *dummyIdx) CoversColumns([]string) bool           { return false }
 
 func (i *dummyIdx) IndexType() string       { return "BTREE" }
 func (i *dummyIdx) PrefixLengths() []uint16 { return nil }

--- a/sql/index.go
+++ b/sql/index.go
@@ -183,7 +183,8 @@ type Index interface {
 	// CanSupportOrderBy returns whether this index can optimize ORDER BY a given expression type.
 	// Verifying that the expression's children match the index columns are done separately.
 	CanSupportOrderBy(expr Expression) bool
-
+	// CoversColumns returns whether this index covers the given columns
+	CoversColumns(cols []string) bool
 	// PrefixLengths returns the prefix lengths for each column in this index
 	PrefixLengths() []uint16
 }

--- a/sql/index_builder_test.go
+++ b/sql/index_builder_test.go
@@ -212,6 +212,10 @@ func (testIndex) IndexType() string {
 	return "FAKE"
 }
 
+func (testIndex) CoversColumns([]string) bool {
+	return false
+}
+
 func (testIndex) IsGenerated() bool {
 	return false
 }

--- a/sql/index_registry_test.go
+++ b/sql/index_registry_test.go
@@ -444,18 +444,19 @@ func (i dummyIdx) Expressions() []string {
 	return exprs
 }
 
-func (i dummyIdx) ID() string              { return i.id }
-func (i dummyIdx) Database() string        { return i.database }
-func (i dummyIdx) Table() string           { return i.table }
-func (i dummyIdx) Driver() string          { return "dummy" }
-func (i dummyIdx) IsUnique() bool          { return false }
-func (i dummyIdx) IsSpatial() bool         { return false }
-func (i dummyIdx) IsFullText() bool        { return false }
-func (i dummyIdx) IsVector() bool          { return false }
-func (i dummyIdx) Comment() string         { return "" }
-func (i dummyIdx) IsGenerated() bool       { return false }
-func (i dummyIdx) IndexType() string       { return "BTREE" }
-func (i dummyIdx) PrefixLengths() []uint16 { return nil }
+func (i dummyIdx) ID() string                  { return i.id }
+func (i dummyIdx) Database() string            { return i.database }
+func (i dummyIdx) Table() string               { return i.table }
+func (i dummyIdx) Driver() string              { return "dummy" }
+func (i dummyIdx) IsUnique() bool              { return false }
+func (i dummyIdx) IsSpatial() bool             { return false }
+func (i dummyIdx) IsFullText() bool            { return false }
+func (i dummyIdx) IsVector() bool              { return false }
+func (i dummyIdx) Comment() string             { return "" }
+func (i dummyIdx) IsGenerated() bool           { return false }
+func (i dummyIdx) IndexType() string           { return "BTREE" }
+func (i dummyIdx) PrefixLengths() []uint16     { return nil }
+func (i dummyIdx) CoversColumns([]string) bool { return false }
 
 func (i dummyIdx) NewLookup(ctx *Context, ranges ...Range) (IndexLookup, error) {
 	panic("not implemented")

--- a/sql/memo/rel_props_test.go
+++ b/sql/memo/rel_props_test.go
@@ -245,6 +245,10 @@ func (dummyIndex) IndexType() string {
 	return "FAKE"
 }
 
+func (dummyIndex) CoversColumns([]string) bool {
+	return false
+}
+
 func (dummyIndex) IsGenerated() bool {
 	return false
 }

--- a/sql/stats/distributions.go
+++ b/sql/stats/distributions.go
@@ -23,11 +23,22 @@ import (
 )
 
 func NewNormDistIter(colCnt, rowCnt int, mean, std float64) sql.RowIter {
-	return &normDistIter{cols: colCnt, cnt: rowCnt, std: std, mean: mean}
+	return &normDistIter{
+		cols: colCnt,
+		cnt:  rowCnt,
+		std:  std,
+		mean: mean,
+		rnd:  rand.New(rand.NewSource(0)),
+	}
 }
 
 func NewExpDistIter(colCnt, rowCnt int, lambda float64) sql.RowIter {
-	return &expDistIter{cols: colCnt, cnt: rowCnt, lambda: lambda}
+	return &expDistIter{
+		cols:   colCnt,
+		cnt:    rowCnt,
+		lambda: lambda,
+		rnd:    rand.New(rand.NewSource(0)),
+	}
 }
 
 type normDistIter struct {
@@ -35,6 +46,7 @@ type normDistIter struct {
 	cols      int
 	cnt       int
 	std, mean float64
+	rnd       *rand.Rand
 }
 
 var _ sql.RowIter = (*normDistIter)(nil)
@@ -47,7 +59,7 @@ func (d *normDistIter) Next(*sql.Context) (sql.Row, error) {
 	var ret sql.Row
 	ret = append(ret, d.i)
 	for i := 0; i < d.cols; i++ {
-		val := rand.NormFloat64()*d.std + d.mean
+		val := d.rnd.NormFloat64()*d.std + d.mean
 		if math.IsNaN(val) || math.IsInf(val, 0) {
 			val = math.MaxInt
 		}
@@ -65,6 +77,7 @@ type expDistIter struct {
 	cols   int
 	cnt    int
 	lambda float64
+	rnd    *rand.Rand
 }
 
 var _ sql.RowIter = (*expDistIter)(nil)
@@ -77,7 +90,7 @@ func (d *expDistIter) Next(*sql.Context) (sql.Row, error) {
 	var ret sql.Row
 	ret = append(ret, d.i)
 	for i := 0; i < d.cols; i++ {
-		val := -math.Log2(rand.NormFloat64()) / d.lambda
+		val := -math.Log2(d.rnd.NormFloat64()) / d.lambda
 		if math.IsNaN(val) || math.IsInf(val, 0) {
 			val = math.MaxInt32
 		}

--- a/sql/tables.go
+++ b/sql/tables.go
@@ -107,13 +107,6 @@ type CommentedTable interface {
 	Comment() string
 }
 
-// CoveringProjectedTable is a table that has projections on it and is capable of verifying if an index covers those
-// projections
-type CoveringProjectedTable interface {
-	ProjectedTable
-	IsCovering(index Index) bool
-}
-
 // ProjectedTable is a table that can return only a subset of its columns from RowIter. This provides a very large
 // efficiency gain during table scans. Tables that implement this interface must return only the projected columns
 // in future calls to Schema.

--- a/sql/tables.go
+++ b/sql/tables.go
@@ -107,6 +107,8 @@ type CommentedTable interface {
 	Comment() string
 }
 
+// CoveringProjectedTable is a table that has projections on it and is capable of verifying if an index covers those
+// projections
 type CoveringProjectedTable interface {
 	ProjectedTable
 	IsCovering(index Index) bool

--- a/sql/tables.go
+++ b/sql/tables.go
@@ -107,6 +107,11 @@ type CommentedTable interface {
 	Comment() string
 }
 
+type CoveringProjectedTable interface {
+	ProjectedTable
+	IsCovering(index Index) bool
+}
+
 // ProjectedTable is a table that can return only a subset of its columns from RowIter. This provides a very large
 // efficiency gain during table scans. Tables that implement this interface must return only the projected columns
 // in future calls to Schema.


### PR DESCRIPTION
This PR adds a "no index" option to the coster and some additional heuristics for index costing.
Before, we would always pick any available index, which would sometimes be sub-optimal, especially if the index is a non-covering secondary index.
Additionally, the `normal_dist` and `exp_dist` tables are now seeded to reduce random variability between test runs.

Benchmarks:
https://github.com/dolthub/dolt/pull/11336#issuecomment-5040609790
