### PR TITLE
fix NULL handling in tuple comparisons (=, !=, list-IN)

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -9383,6 +9383,84 @@ from typestable`,
 		Expected:              []sql.Row{{math.NaN()}},
 		ExpectedWarningsCount: 2,
 	},
+	// NULL-in-tuple comparisons for = / != / IN, https://github.com/dolthub/dolt/issues/11024.
+	// Direct SELECTs (rather than WHERE-wrapped) so the assertions distinguish
+	// a definite `false` from an indeterminate `NULL`, since a WHERE clause
+	// filters out rows for both. Ordering operators (<, >, <=, >=) with NULL
+	// elements are a known separate case left as follow-up.
+	{
+		Query:    "SELECT (1, 2) = (NULL, 2)",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT (1, 2) = (NULL, 3)",
+		Expected: []sql.Row{{false}},
+	},
+	{
+		Query:    "SELECT (1, 2) != (NULL, 2)",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT (1, 2) != (NULL, 3)",
+		Expected: []sql.Row{{true}},
+	},
+	{
+		// Regression test for the ErrValueNotNil crash: converting the right
+		// tuple's values using the left NULL literal's static type.
+		Query:    "SELECT (NULL, 2) = (1, 2)",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT (1, null) in ((1, null))",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		// https://github.com/dolthub/dolt/issues/11024, jycor's IN-clause comment.
+		Query:    "SELECT (1, 1) in ((null, null))",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		// Mixed IN: indeterminate candidate before a definite match still yields true.
+		Query:    "SELECT (1, 1) IN ((NULL, NULL), (1, 1))",
+		Expected: []sql.Row{{true}},
+	},
+	{
+		// Three-element tuple: middle NULL with no definite difference → NULL.
+		Query:    "SELECT (1, 2, 3) = (1, NULL, 3)",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT (0, null) = (0, null)",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT (null, null) = (select null, null from dual)",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, null) in ((1, null))",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (0, null) = (0, null)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (null, null) = (select null, null from dual)",
+		Expected: []sql.Row{},
+	},
+	{
+		// Row-constructor IN-subquery: the hash-based lookup in
+		// plan.InSubquery.Eval finds a matching hash for (1, NULL) and then
+		// runs a confirming rTyp.Compare(left, val), which hits the same
+		// NULL-element indeterminacy as regular tuple comparisons.
+		Query:    "SELECT (1, NULL) IN (SELECT 1, NULL FROM dual)",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, NULL) IN (SELECT 1, NULL FROM dual)",
+		Expected: []sql.Row{},
+	},
 }
 
 var KeylessQueries = []QueryTest{
@@ -9496,20 +9574,6 @@ var BrokenQueries = []QueryTest{
 	},
 	{
 		Query: "SELECT json_value() FROM dual;", // syntax error
-	},
-	// Null-safe and type conversion tuple comparison is not correctly
-	// implemented yet.
-	{
-		Query:    "SELECT 1 FROM DUAL WHERE (1, null) in ((1, null))",
-		Expected: []sql.Row{},
-	},
-	{
-		Query:    "SELECT 1 FROM DUAL WHERE (0, null) = (0, null)",
-		Expected: []sql.Row{},
-	},
-	{
-		Query:    "SELECT 1 FROM DUAL WHERE (null, null) = (select null, null from dual)",
-		Expected: []sql.Row{},
 	},
 	// TODO: support nested recursive CTEs
 	{
@@ -9633,6 +9697,23 @@ FROM mytable;`,
 		Expected: []sql.Row{
 			{"DECIMAL"},
 		},
+	},
+	// https://github.com/dolthub/dolt/issues/11024 — row-constructor IN (SELECT ...) on the
+	// HASH-MISS path in plan.InSubquery.Eval still returns a definite `false` instead of NULL
+	// when no candidate row is an exact hash match but a candidate row has a NULL element that
+	// makes the comparison indeterminate rather than definitely unequal. The equivalent list-IN
+	// form (already fixed, see QueryTests above) gets this right: `SELECT (1, 5) IN ((1, NULL))`
+	// correctly returns NULL. This subquery-IN case is a KNOWN, disclosed follow-up — not fixed
+	// in the #11024 PR, which only fixes list-IN, not subquery-IN. Only the hash-HIT path (left
+	// tuple's hash exactly matches a candidate row's hash, e.g. `(1, NULL) IN (SELECT 1, NULL
+	// FROM dual)`) is fixed today, via InSubquery.Eval's confirming rTyp.Compare check.
+	{
+		Query:    "SELECT (1, 5) IN (SELECT 1, NULL FROM dual)",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT (1, 5) IN (SELECT * FROM (SELECT 1, NULL FROM dual UNION ALL SELECT 2, 3 FROM dual) t)",
+		Expected: []sql.Row{{nil}},
 	},
 }
 

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -33,14 +33,8 @@ type Comparer interface {
 	Right() sql.Expression
 }
 
-// ErrNilOperand ir returned if some or both of the comparison's operands is nil.
-//
-// This is an alias of sql.ErrNilOperand (the same *errors.Kind), not a
-// separately-defined Kind: TupleType.Compare in sql/types signals
-// element-wise NULL-indeterminacy using sql.ErrNilOperand (sql/types cannot
-// import sql/expression), and aliasing here means ErrNilOperand.Is(err)
-// keeps recognizing those errors identically to before, with zero change to
-// this package's exported surface.
+// ErrNilOperand is returned if some or both of the comparison's operands is nil.
+// Alias of sql.ErrNilOperand so sql/types can signal the same condition.
 var ErrNilOperand = sql.ErrNilOperand
 
 // PreciseComparison searches an expression tree for comparison
@@ -523,20 +517,8 @@ func (e *NullSafeEquals) Compare(ctx *sql.Context, row sql.Row) (int, error) {
 		return -1, nil
 	}
 
-	lTyp, rTyp := e.Left().Type(ctx), e.Right().Type(ctx)
-
-	// Tuples get their own null-safe path: a NULL element is comparable to
-	// itself here (unlike regular =, where any NULL element makes the whole
-	// comparison indeterminate), so TupleType.Compare's ordinary NULL
-	// handling doesn't apply.
-	if lTup, ok := lTyp.(types.TupleType); ok {
-		if rTup, ok := rTyp.(types.TupleType); ok {
-			return compareTuplesNullSafe(ctx, lTup, rTup, left, right)
-		}
-	}
-
-	if types.TypesEqual(lTyp, rTyp) {
-		return lTyp.Compare(ctx, left, right)
+	if types.TypesEqual(e.Left().Type(ctx), e.Right().Type(ctx)) {
+		return e.Left().Type(ctx).Compare(ctx, left, right)
 	}
 
 	var compareType sql.Type
@@ -546,58 +528,6 @@ func (e *NullSafeEquals) Compare(ctx *sql.Context, row sql.Row) (int, error) {
 	}
 
 	return compareType.Compare(ctx, left, right)
-}
-
-// compareTuplesNullSafe implements <=> (NULL-safe equals) for tuple
-// operands. Unlike regular tuple comparison, a NULL element is treated as
-// comparable to itself: a (NULL, NULL) element pair counts as equal, and a
-// pair with exactly one NULL element is a definite mismatch, mirroring the
-// scalar <=> operator's element-wise semantics.
-func compareTuplesNullSafe(ctx *sql.Context, lTyp, rTyp types.TupleType, left, right any) (int, error) {
-	l, ok := left.([]interface{})
-	if !ok {
-		return 0, sql.ErrNotTuple.New(left)
-	}
-	r, ok := right.([]interface{})
-	if !ok {
-		return 0, sql.ErrNotTuple.New(right)
-	}
-	if len(l) != len(r) {
-		return 0, sql.ErrInvalidOperandColumns.New(len(l), len(r))
-	}
-
-	for i := range l {
-		if l[i] == nil && r[i] == nil {
-			continue
-		}
-		if l[i] == nil || r[i] == nil {
-			return 1, nil
-		}
-
-		et := lTyp[i]
-		if i < len(rTyp) && !lTyp[i].Equals(rTyp[i]) {
-			et = types.GetCompareType(lTyp[i], rTyp[i])
-		}
-
-		lv, _, err := et.Convert(ctx, l[i])
-		if err != nil {
-			return 0, err
-		}
-		rv, _, err := et.Convert(ctx, r[i])
-		if err != nil {
-			return 0, err
-		}
-
-		cmp, err := et.Compare(ctx, lv, rv)
-		if err != nil {
-			return 0, err
-		}
-		if cmp != 0 {
-			return cmp, nil
-		}
-	}
-
-	return 0, nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -34,8 +34,7 @@ type Comparer interface {
 }
 
 // ErrNilOperand is returned if some or both of the comparison's operands is nil.
-// Alias of sql.ErrNilOperand so sql/types can signal the same condition.
-var ErrNilOperand = sql.ErrNilOperand
+var ErrNilOperand = errors.NewKind("nil operand found in comparison")
 
 // PreciseComparison searches an expression tree for comparison
 // expressions that require a conversion or type promotion.
@@ -141,6 +140,9 @@ func (c *comparison) Compare(ctx *sql.Context, row sql.Row) (int, error) {
 	}
 
 	lTyp, rTyp := c.Left().Type(ctx), c.Right().Type(ctx)
+	if types.IsTuple(lTyp) && types.IsTuple(rTyp) {
+		return compareTuples(ctx, left, right, lTyp, rTyp)
+	}
 	if types.TypesEqual(lTyp, rTyp) {
 		return lTyp.Compare(ctx, left, right)
 	}
@@ -159,6 +161,41 @@ func (c *comparison) Compare(ctx *sql.Context, row sql.Row) (int, error) {
 		compareType = types.MustCreateString(stringCompareType.Type(), stringCompareType.Length(), collationPreference)
 	}
 	return compareType.Compare(ctx, l, r)
+}
+
+// compareTuples performs non-null-safe tuple comparison for = / != / IN.
+// Nilness is owned here: CompareTupleValues(..., earlyReturnOnNil=true) and
+// ErrNilOperand when the result is indeterminate.
+func compareTuples(ctx *sql.Context, left, right interface{}, lTyp, rTyp sql.Type) (int, error) {
+	l, ok := left.([]interface{})
+	if !ok {
+		return 0, sql.ErrNotTuple.New(left)
+	}
+	r, ok := right.([]interface{})
+	if !ok {
+		return 0, sql.ErrNotTuple.New(right)
+	}
+	if len(l) != len(r) {
+		return 0, sql.ErrInvalidOperandColumns.New(len(l), len(r))
+	}
+
+	elemTypes, ok := lTyp.(types.TupleType)
+	if !ok || len(elemTypes) != len(l) {
+		if rt, ok := rTyp.(types.TupleType); ok && len(rt) == len(l) {
+			elemTypes = rt
+		} else {
+			return 0, sql.ErrNotTuple.New(lTyp)
+		}
+	}
+
+	cmp, hasNil, err := types.CompareTupleValues(ctx, l, r, elemTypes, true)
+	if err != nil {
+		return 0, err
+	}
+	if hasNil && cmp == 0 {
+		return 0, ErrNilOperand.New()
+	}
+	return cmp, nil
 }
 
 // CompareValue the two given values using the types of the expressions in the comparison.

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -34,7 +34,14 @@ type Comparer interface {
 }
 
 // ErrNilOperand ir returned if some or both of the comparison's operands is nil.
-var ErrNilOperand = errors.NewKind("nil operand found in comparison")
+//
+// This is an alias of sql.ErrNilOperand (the same *errors.Kind), not a
+// separately-defined Kind: TupleType.Compare in sql/types signals
+// element-wise NULL-indeterminacy using sql.ErrNilOperand (sql/types cannot
+// import sql/expression), and aliasing here means ErrNilOperand.Is(err)
+// keeps recognizing those errors identically to before, with zero change to
+// this package's exported surface.
+var ErrNilOperand = sql.ErrNilOperand
 
 // PreciseComparison searches an expression tree for comparison
 // expressions that require a conversion or type promotion.
@@ -517,6 +524,17 @@ func (e *NullSafeEquals) Compare(ctx *sql.Context, row sql.Row) (int, error) {
 	}
 
 	lTyp, rTyp := e.Left().Type(ctx), e.Right().Type(ctx)
+
+	// Tuples get their own null-safe path: a NULL element is comparable to
+	// itself here (unlike regular =, where any NULL element makes the whole
+	// comparison indeterminate), so TupleType.Compare's ordinary NULL
+	// handling doesn't apply.
+	if lTup, ok := lTyp.(types.TupleType); ok {
+		if rTup, ok := rTyp.(types.TupleType); ok {
+			return compareTuplesNullSafe(ctx, lTup, rTup, left, right)
+		}
+	}
+
 	if types.TypesEqual(lTyp, rTyp) {
 		return lTyp.Compare(ctx, left, right)
 	}
@@ -528,6 +546,58 @@ func (e *NullSafeEquals) Compare(ctx *sql.Context, row sql.Row) (int, error) {
 	}
 
 	return compareType.Compare(ctx, left, right)
+}
+
+// compareTuplesNullSafe implements <=> (NULL-safe equals) for tuple
+// operands. Unlike regular tuple comparison, a NULL element is treated as
+// comparable to itself: a (NULL, NULL) element pair counts as equal, and a
+// pair with exactly one NULL element is a definite mismatch, mirroring the
+// scalar <=> operator's element-wise semantics.
+func compareTuplesNullSafe(ctx *sql.Context, lTyp, rTyp types.TupleType, left, right any) (int, error) {
+	l, ok := left.([]interface{})
+	if !ok {
+		return 0, sql.ErrNotTuple.New(left)
+	}
+	r, ok := right.([]interface{})
+	if !ok {
+		return 0, sql.ErrNotTuple.New(right)
+	}
+	if len(l) != len(r) {
+		return 0, sql.ErrInvalidOperandColumns.New(len(l), len(r))
+	}
+
+	for i := range l {
+		if l[i] == nil && r[i] == nil {
+			continue
+		}
+		if l[i] == nil || r[i] == nil {
+			return 1, nil
+		}
+
+		et := lTyp[i]
+		if i < len(rTyp) && !lTyp[i].Equals(rTyp[i]) {
+			et = types.GetCompareType(lTyp[i], rTyp[i])
+		}
+
+		lv, _, err := et.Convert(ctx, l[i])
+		if err != nil {
+			return 0, err
+		}
+		rv, _, err := et.Convert(ctx, r[i])
+		if err != nil {
+			return 0, err
+		}
+
+		cmp, err := et.Compare(ctx, lv, rv)
+		if err != nil {
+			return 0, err
+		}
+		if cmp != 0 {
+			return cmp, nil
+		}
+	}
+
+	return 0, nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -109,8 +109,7 @@ func (in *InTuple) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		cmpExpr := newComparison(lLit, NewLiteral(rVal, rType))
 		res, cErr := cmpExpr.Compare(ctx, nil)
 		if cErr != nil {
-			// Nested NULL tuple elements surface as ErrNilOperand from Compare.
-			if sql.ErrNilOperand.Is(cErr) {
+			if ErrNilOperand.Is(cErr) {
 				rHasNull = true
 			}
 			continue

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -109,11 +109,7 @@ func (in *InTuple) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		cmpExpr := newComparison(lLit, NewLiteral(rVal, rType))
 		res, cErr := cmpExpr.Compare(ctx, nil)
 		if cErr != nil {
-			// A nested tuple element containing a NULL (e.g. `(1,1) IN
-			// ((NULL,NULL))`) evaluates to a non-nil slice with nil members, so
-			// the rVal == nil check above doesn't catch it. Compare signals
-			// that indeterminacy via ErrNilOperand; treat it the same as a
-			// directly-NULL right element instead of silently skipping it.
+			// Nested NULL tuple elements surface as ErrNilOperand from Compare.
 			if sql.ErrNilOperand.Is(cErr) {
 				rHasNull = true
 			}

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -109,6 +109,14 @@ func (in *InTuple) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		cmpExpr := newComparison(lLit, NewLiteral(rVal, rType))
 		res, cErr := cmpExpr.Compare(ctx, nil)
 		if cErr != nil {
+			// A nested tuple element containing a NULL (e.g. `(1,1) IN
+			// ((NULL,NULL))`) evaluates to a non-nil slice with nil members, so
+			// the rVal == nil check above doesn't catch it. Compare signals
+			// that indeterminacy via ErrNilOperand; treat it the same as a
+			// directly-NULL right element instead of silently skipping it.
+			if sql.ErrNilOperand.Is(cErr) {
+				rHasNull = true
+			}
 			continue
 		}
 		if res == 0 {

--- a/sql/expression/tuple_compare_test.go
+++ b/sql/expression/tuple_compare_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// Drives comparison.Compare for tuple operands through the real entry point
+// (newComparison + Compare), proving expression-owned ErrNilOperand semantics.
+func TestComparison_TupleNullEquality(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+
+	eq := NewEquals(
+		NewLiteral([]interface{}{int64(1), int64(2)}, types.CreateTuple(types.Int64, types.Int64)),
+		NewLiteral([]interface{}{nil, int64(2)}, types.CreateTuple(types.Int64, types.Int64)),
+	)
+	v, err := eq.Eval(ctx, nil)
+	require.NoError(t, err)
+	require.Nil(t, v) // SQL NULL
+
+	eqFalse := NewEquals(
+		NewLiteral([]interface{}{int64(1), int64(2)}, types.CreateTuple(types.Int64, types.Int64)),
+		NewLiteral([]interface{}{nil, int64(3)}, types.CreateTuple(types.Int64, types.Int64)),
+	)
+	v, err = eqFalse.Eval(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, false, v)
+
+	// Operand swap crash regression: (NULL,2)=(1,2)
+	eqSwap := NewEquals(
+		NewLiteral([]interface{}{nil, int64(2)}, types.CreateTuple(types.Null, types.Int64)),
+		NewLiteral([]interface{}{int64(1), int64(2)}, types.CreateTuple(types.Int64, types.Int64)),
+	)
+	v, err = eqSwap.Eval(ctx, nil)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	eqTrue := NewEquals(
+		NewLiteral([]interface{}{int64(1), int64(2)}, types.CreateTuple(types.Int64, types.Int64)),
+		NewLiteral([]interface{}{int64(1), int64(2)}, types.CreateTuple(types.Int64, types.Int64)),
+	)
+	v, err = eqTrue.Eval(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, true, v)
+}

--- a/sql/plan/insubquery.go
+++ b/sql/plan/insubquery.go
@@ -118,6 +118,15 @@ func (in *InSubquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 		cmp, err := rTyp.Compare(ctx, left, val)
 		if err != nil {
+			// A hash match doesn't guarantee value equality (e.g. a row-
+			// constructor tuple whose hash matched but which has a NULL
+			// element makes the confirming Compare indeterminate rather than
+			// a real error). Treat that the same way the IN-list path
+			// (InTuple.Eval) and the five comparison operators do: an
+			// indeterminate comparison means the overall result is unknown.
+			if sql.ErrNilOperand.Is(err) {
+				return nil, nil
+			}
 			return nil, err
 		}
 

--- a/sql/plan/insubquery.go
+++ b/sql/plan/insubquery.go
@@ -118,12 +118,6 @@ func (in *InSubquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 		cmp, err := rTyp.Compare(ctx, left, val)
 		if err != nil {
-			// A hash match doesn't guarantee value equality (e.g. a row-
-			// constructor tuple whose hash matched but which has a NULL
-			// element makes the confirming Compare indeterminate rather than
-			// a real error). Treat that the same way the IN-list path
-			// (InTuple.Eval) and the five comparison operators do: an
-			// indeterminate comparison means the overall result is unknown.
 			if sql.ErrNilOperand.Is(err) {
 				return nil, nil
 			}

--- a/sql/plan/insubquery.go
+++ b/sql/plan/insubquery.go
@@ -116,11 +116,23 @@ func (in *InSubquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			return false, nil
 		}
 
+		if tup, ok := rTyp.(types.TupleType); ok {
+			lVals, lok := left.([]interface{})
+			rVals, rok := val.([]interface{})
+			if lok && rok && len(lVals) == len(rVals) && len(lVals) == len(tup) {
+				cmp, hasNil, cErr := types.CompareTupleValues(ctx, lVals, rVals, tup, true)
+				if cErr != nil {
+					return nil, cErr
+				}
+				if hasNil && cmp == 0 {
+					return nil, nil
+				}
+				return cmp == 0, nil
+			}
+		}
+
 		cmp, err := rTyp.Compare(ctx, left, val)
 		if err != nil {
-			if sql.ErrNilOperand.Is(err) {
-				return nil, nil
-			}
 			return nil, err
 		}
 

--- a/sql/type.go
+++ b/sql/type.go
@@ -42,6 +42,16 @@ var (
 	// ErrConvertToSQL is returned when Convert failed.
 	// It makes an error less verbose comparing to what spf13/cast returns.
 	ErrConvertToSQL = errors.NewKind("incompatible conversion to SQL type: '%v'->%s")
+
+	// ErrNilOperand is returned by a Type's Compare implementation when the
+	// comparison is indeterminate because one of the operands is NULL (e.g. a
+	// NULL tuple element). It lives in this base package, rather than in
+	// sql/expression where it originated, so that sql/types (which cannot
+	// import sql/expression) can also signal indeterminate comparisons with
+	// it; sql/expression.ErrNilOperand is an alias of this exact Kind so
+	// existing errors.Is-style checks (ErrNilOperand.Is(err)) keep working
+	// unchanged for both packages.
+	ErrNilOperand = errors.NewKind("nil operand found in comparison")
 )
 
 const (

--- a/sql/type.go
+++ b/sql/type.go
@@ -43,14 +43,9 @@ var (
 	// It makes an error less verbose comparing to what spf13/cast returns.
 	ErrConvertToSQL = errors.NewKind("incompatible conversion to SQL type: '%v'->%s")
 
-	// ErrNilOperand is returned by a Type's Compare implementation when the
-	// comparison is indeterminate because one of the operands is NULL (e.g. a
-	// NULL tuple element). It lives in this base package, rather than in
-	// sql/expression where it originated, so that sql/types (which cannot
-	// import sql/expression) can also signal indeterminate comparisons with
-	// it; sql/expression.ErrNilOperand is an alias of this exact Kind so
-	// existing errors.Is-style checks (ErrNilOperand.Is(err)) keep working
-	// unchanged for both packages.
+	// ErrNilOperand is returned by Compare when a comparison is indeterminate
+	// because an operand is NULL (e.g. a NULL tuple element). Defined here so
+	// sql/types can return it without importing sql/expression.
 	ErrNilOperand = errors.NewKind("nil operand found in comparison")
 )
 

--- a/sql/type.go
+++ b/sql/type.go
@@ -42,11 +42,6 @@ var (
 	// ErrConvertToSQL is returned when Convert failed.
 	// It makes an error less verbose comparing to what spf13/cast returns.
 	ErrConvertToSQL = errors.NewKind("incompatible conversion to SQL type: '%v'->%s")
-
-	// ErrNilOperand is returned by Compare when a comparison is indeterminate
-	// because an operand is NULL (e.g. a NULL tuple element). Defined here so
-	// sql/types can return it without importing sql/expression.
-	ErrNilOperand = errors.NewKind("nil operand found in comparison")
 )
 
 const (

--- a/sql/types/tuple.go
+++ b/sql/types/tuple.go
@@ -38,9 +38,54 @@ func CreateTuple(types ...sql.Type) sql.Type {
 	return TupleType(types)
 }
 
-// Compare compares two tuples element-by-element. A definite non-equal
-// element pair short-circuits. If every non-NULL pair matches but at least
-// one element is NULL, returns sql.ErrNilOperand (SQL NULL for = / != / IN).
+// CompareTupleValues compares two same-size tuples element-by-element.
+// Callers must ensure len(left) == len(right) == len(elemTypes).
+//
+// earlyReturnOnNil controls nil-element handling:
+//   - true: a nil on either side is not passed to Type.Compare; hasNil is set
+//     and the walk continues so a later definite mismatch still short-circuits.
+//     Expression comparison maps (cmp==0 && hasNil) to SQL NULL / ErrNilOperand.
+//   - false: nil elements are compared via the element type's Compare
+//     (type-level path; does not own SQL-NULL semantics).
+func CompareTupleValues(ctx context.Context, left, right []interface{}, elemTypes TupleType, earlyReturnOnNil bool) (cmp int, hasNil bool, err error) {
+	for i := range left {
+		if left[i] == nil || right[i] == nil {
+			if earlyReturnOnNil {
+				hasNil = true
+				continue
+			}
+			cmp, err = elemTypes[i].Compare(ctx, left[i], right[i])
+			if err != nil {
+				return 0, hasNil, err
+			}
+			if cmp != 0 {
+				return cmp, hasNil, nil
+			}
+			continue
+		}
+
+		lv, _, err := elemTypes[i].Convert(ctx, left[i])
+		if err != nil {
+			return 0, hasNil, err
+		}
+		rv, _, err := elemTypes[i].Convert(ctx, right[i])
+		if err != nil {
+			return 0, hasNil, err
+		}
+
+		cmp, err = elemTypes[i].Compare(ctx, lv, rv)
+		if err != nil {
+			return 0, hasNil, err
+		}
+		if cmp != 0 {
+			return cmp, hasNil, nil
+		}
+	}
+	return 0, hasNil, nil
+}
+
+// Compare implements sql.Type. Nilness / SQL-NULL semantics for equality-style
+// operators are owned by the expression package via CompareTupleValues(..., true).
 func (t TupleType) Compare(ctx context.Context, a interface{}, b interface{}) (int, error) {
 	if hasNulls, res := CompareNulls(a, b); hasNulls {
 		return res, nil
@@ -54,46 +99,9 @@ func (t TupleType) Compare(ctx context.Context, a interface{}, b interface{}) (i
 	if !ok {
 		return 0, sql.ErrNotTuple.New(b)
 	}
-	if len(left) != len(t) {
-		return 0, sql.ErrInvalidColumnNumber.New(len(t), len(left))
-	}
-	if len(right) != len(t) {
-		return 0, sql.ErrInvalidColumnNumber.New(len(t), len(right))
-	}
 
-	var sawNull bool
-	for i := range left {
-		if left[i] == nil || right[i] == nil {
-			// Skip convert/compare: a NULL literal's type can make Convert of
-			// the non-NULL side fail with ErrValueNotNil.
-			sawNull = true
-			continue
-		}
-
-		lv, _, err := t[i].Convert(ctx, left[i])
-		if err != nil {
-			return 0, err
-		}
-		rv, _, err := t[i].Convert(ctx, right[i])
-		if err != nil {
-			return 0, err
-		}
-
-		cmp, err := t[i].Compare(ctx, lv, rv)
-		if err != nil {
-			return 0, err
-		}
-
-		if cmp != 0 {
-			return cmp, nil
-		}
-	}
-
-	if sawNull {
-		return 0, sql.ErrNilOperand.New()
-	}
-
-	return 0, nil
+	cmp, _, err := CompareTupleValues(ctx, left, right, t, false)
+	return cmp, err
 }
 
 func (t TupleType) Convert(ctx context.Context, v interface{}) (interface{}, sql.ConvertInRange, error) {

--- a/sql/types/tuple.go
+++ b/sql/types/tuple.go
@@ -38,25 +38,65 @@ func CreateTuple(types ...sql.Type) sql.Type {
 	return TupleType(types)
 }
 
+// Compare implements the Type interface for equality-style tuple comparison
+// (=, !=, IN). A definite (non-NULL, non-equal) difference at any position is
+// returned immediately, so it dominates NULLs encountered earlier or later —
+// matching MySQL for equality: (1,2)=(NULL,3) is false, not NULL. If no
+// definite difference is found but at least one element pair was
+// indeterminate, Compare returns sql.ErrNilOperand so callers treat the whole
+// comparison as SQL NULL (see comparison.go).
+//
+// Ordering operators (<, >, <=, >=) share this path today. MySQL's
+// left-to-right row-constructor ordering differs when a NULL sits in a more
+// significant position than the first definite difference (e.g. (1,2)>(NULL,1)
+// is NULL in MySQL). That separate ordering semantics is intentionally left
+// as a follow-up; this Compare is correct for = / != / list-IN (IN with a
+// literal tuple list, e.g. `x IN ((1,2),(3,4))`). BETWEEN desugars to a pair
+// of <=/>= comparisons, so it inherits the same ordering gap. Row-constructor
+// IN (SELECT ...) has a separate, narrower residual gap on its hash-miss path
+// — see plan.InSubquery.Eval and https://github.com/dolthub/dolt/issues/11024.
 func (t TupleType) Compare(ctx context.Context, a interface{}, b interface{}) (int, error) {
 	if hasNulls, res := CompareNulls(a, b); hasNulls {
 		return res, nil
 	}
 
-	a, _, err := t.Convert(ctx, a)
-	if err != nil {
-		return 0, err
+	left, ok := a.([]interface{})
+	if !ok {
+		return 0, sql.ErrNotTuple.New(a)
+	}
+	right, ok := b.([]interface{})
+	if !ok {
+		return 0, sql.ErrNotTuple.New(b)
+	}
+	if len(left) != len(t) {
+		return 0, sql.ErrInvalidColumnNumber.New(len(t), len(left))
+	}
+	if len(right) != len(t) {
+		return 0, sql.ErrInvalidColumnNumber.New(len(t), len(right))
 	}
 
-	b, _, err = t.Convert(ctx, b)
-	if err != nil {
-		return 0, err
-	}
-
-	left := a.([]interface{})
-	right := b.([]interface{})
+	var sawNull bool
 	for i := range left {
-		cmp, err := t[i].Compare(ctx, left[i], right[i])
+		if left[i] == nil || right[i] == nil {
+			// This element's contribution is indeterminate. Do not attempt to
+			// convert or compare it: the two sides may have come from operand
+			// types that only agree in this position because one of them is a
+			// NULL literal (types.Null), and converting the non-NULL side
+			// against that NULL type would fail with ErrValueNotNil.
+			sawNull = true
+			continue
+		}
+
+		lv, _, err := t[i].Convert(ctx, left[i])
+		if err != nil {
+			return 0, err
+		}
+		rv, _, err := t[i].Convert(ctx, right[i])
+		if err != nil {
+			return 0, err
+		}
+
+		cmp, err := t[i].Compare(ctx, lv, rv)
 		if err != nil {
 			return 0, err
 		}
@@ -64,6 +104,10 @@ func (t TupleType) Compare(ctx context.Context, a interface{}, b interface{}) (i
 		if cmp != 0 {
 			return cmp, nil
 		}
+	}
+
+	if sawNull {
+		return 0, sql.ErrNilOperand.New()
 	}
 
 	return 0, nil

--- a/sql/types/tuple.go
+++ b/sql/types/tuple.go
@@ -39,7 +39,8 @@ func CreateTuple(types ...sql.Type) sql.Type {
 }
 
 // CompareTupleValues compares two same-size tuples element-by-element.
-// Callers must ensure len(left) == len(right) == len(elemTypes).
+// Rejects length mismatches (left/right/elemTypes) with ErrInvalidColumnNumber
+// so a shorter left cannot false-equal and a longer left cannot index OOB.
 //
 // earlyReturnOnNil controls nil-element handling:
 //   - true: a nil on either side is not passed to Type.Compare; hasNil is set
@@ -48,6 +49,13 @@ func CreateTuple(types ...sql.Type) sql.Type {
 //   - false: nil elements are compared via the element type's Compare
 //     (type-level path; does not own SQL-NULL semantics).
 func CompareTupleValues(ctx context.Context, left, right []interface{}, elemTypes TupleType, earlyReturnOnNil bool) (cmp int, hasNil bool, err error) {
+	if len(left) != len(elemTypes) {
+		return 0, false, sql.ErrInvalidColumnNumber.New(len(elemTypes), len(left))
+	}
+	if len(right) != len(elemTypes) {
+		return 0, false, sql.ErrInvalidColumnNumber.New(len(elemTypes), len(right))
+	}
+
 	for i := range left {
 		if left[i] == nil || right[i] == nil {
 			if earlyReturnOnNil {

--- a/sql/types/tuple.go
+++ b/sql/types/tuple.go
@@ -38,23 +38,9 @@ func CreateTuple(types ...sql.Type) sql.Type {
 	return TupleType(types)
 }
 
-// Compare implements the Type interface for equality-style tuple comparison
-// (=, !=, IN). A definite (non-NULL, non-equal) difference at any position is
-// returned immediately, so it dominates NULLs encountered earlier or later —
-// matching MySQL for equality: (1,2)=(NULL,3) is false, not NULL. If no
-// definite difference is found but at least one element pair was
-// indeterminate, Compare returns sql.ErrNilOperand so callers treat the whole
-// comparison as SQL NULL (see comparison.go).
-//
-// Ordering operators (<, >, <=, >=) share this path today. MySQL's
-// left-to-right row-constructor ordering differs when a NULL sits in a more
-// significant position than the first definite difference (e.g. (1,2)>(NULL,1)
-// is NULL in MySQL). That separate ordering semantics is intentionally left
-// as a follow-up; this Compare is correct for = / != / list-IN (IN with a
-// literal tuple list, e.g. `x IN ((1,2),(3,4))`). BETWEEN desugars to a pair
-// of <=/>= comparisons, so it inherits the same ordering gap. Row-constructor
-// IN (SELECT ...) has a separate, narrower residual gap on its hash-miss path
-// — see plan.InSubquery.Eval and https://github.com/dolthub/dolt/issues/11024.
+// Compare compares two tuples element-by-element. A definite non-equal
+// element pair short-circuits. If every non-NULL pair matches but at least
+// one element is NULL, returns sql.ErrNilOperand (SQL NULL for = / != / IN).
 func (t TupleType) Compare(ctx context.Context, a interface{}, b interface{}) (int, error) {
 	if hasNulls, res := CompareNulls(a, b); hasNulls {
 		return res, nil
@@ -78,11 +64,8 @@ func (t TupleType) Compare(ctx context.Context, a interface{}, b interface{}) (i
 	var sawNull bool
 	for i := range left {
 		if left[i] == nil || right[i] == nil {
-			// This element's contribution is indeterminate. Do not attempt to
-			// convert or compare it: the two sides may have come from operand
-			// types that only agree in this position because one of them is a
-			// NULL literal (types.Null), and converting the non-NULL side
-			// against that NULL type would fail with ErrValueNotNil.
+			// Skip convert/compare: a NULL literal's type can make Convert of
+			// the non-NULL side fail with ErrValueNotNil.
 			sawNull = true
 			continue
 		}

--- a/sql/types/tuple_compare_test.go
+++ b/sql/types/tuple_compare_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Exercises the shipped CompareTupleValues helper (nicktobey #3640 design):
+// shared element walk for type-level Compare and expression equality.
+func TestCompareTupleValues_EqualityNilSemantics(t *testing.T) {
+	ctx := context.Background()
+	elem := TupleType{Int64, Int64}
+
+	// (1,2)=(NULL,2) → cmp 0, hasNil true (indeterminate for expression layer)
+	cmp, hasNil, err := CompareTupleValues(ctx, []interface{}{int64(1), int64(2)}, []interface{}{nil, int64(2)}, elem, true)
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+	require.True(t, hasNil)
+
+	// (1,2)=(NULL,3) → definite mismatch dominates nil
+	cmp, hasNil, err = CompareTupleValues(ctx, []interface{}{int64(1), int64(2)}, []interface{}{nil, int64(3)}, elem, true)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, cmp)
+	require.True(t, hasNil)
+
+	// (NULL,2)=(1,2) — no Convert-through-Null crash; indeterminate
+	cmp, hasNil, err = CompareTupleValues(ctx, []interface{}{nil, int64(2)}, []interface{}{int64(1), int64(2)}, elem, true)
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+	require.True(t, hasNil)
+
+	// (1,2)=(1,2) equal, no nil
+	cmp, hasNil, err = CompareTupleValues(ctx, []interface{}{int64(1), int64(2)}, []interface{}{int64(1), int64(2)}, elem, true)
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+	require.False(t, hasNil)
+
+	// (1,2)=(1,3) unequal, no nil
+	cmp, hasNil, err = CompareTupleValues(ctx, []interface{}{int64(1), int64(2)}, []interface{}{int64(1), int64(3)}, elem, true)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, cmp)
+	require.False(t, hasNil)
+}
+
+func TestCompareTupleValues_TypePathNoNilOwnership(t *testing.T) {
+	ctx := context.Background()
+	elem := TupleType{Int64, Int64}
+
+	// earlyReturnOnNil=false: type-level path does not report hasNil for equality
+	cmp, hasNil, err := CompareTupleValues(ctx, []interface{}{int64(1), int64(2)}, []interface{}{int64(1), int64(2)}, elem, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+	require.False(t, hasNil)
+
+	// TupleType.Compare uses the shared helper with earlyReturnOnNil=false
+	tt := TupleType{Int64, Int64}
+	cmp, err = tt.Compare(ctx, []interface{}{int64(1), int64(2)}, []interface{}{int64(1), int64(2)})
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+
+	cmp, err = tt.Compare(ctx, []interface{}{int64(1), int64(2)}, []interface{}{int64(1), int64(9)})
+	require.NoError(t, err)
+	require.NotEqual(t, 0, cmp)
+}

--- a/sql/types/tuple_compare_test.go
+++ b/sql/types/tuple_compare_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // Exercises the shipped CompareTupleValues helper (nicktobey #3640 design):
@@ -77,4 +79,39 @@ func TestCompareTupleValues_TypePathNoNilOwnership(t *testing.T) {
 	cmp, err = tt.Compare(ctx, []interface{}{int64(1), int64(2)}, []interface{}{int64(1), int64(9)})
 	require.NoError(t, err)
 	require.NotEqual(t, 0, cmp)
+}
+
+// Length mismatches must error — not false-equal (short left) or panic (long left).
+func TestCompareTupleValues_LengthMismatch(t *testing.T) {
+	ctx := context.Background()
+	elem := TupleType{Int64, Int64}
+
+	// Shorter left vs 2-element type: must not return cmp=0,err=nil
+	cmp, hasNil, err := CompareTupleValues(ctx, []interface{}{int64(1)}, []interface{}{int64(1), int64(2)}, elem, true)
+	require.Error(t, err)
+	require.True(t, sql.ErrInvalidColumnNumber.Is(err))
+	require.Equal(t, 0, cmp)
+	require.False(t, hasNil)
+
+	// Longer left: must error, not index OOB panic
+	cmp, hasNil, err = CompareTupleValues(ctx, []interface{}{int64(1), int64(2), int64(3)}, []interface{}{int64(1), int64(2)}, elem, true)
+	require.Error(t, err)
+	require.True(t, sql.ErrInvalidColumnNumber.Is(err))
+	require.Equal(t, 0, cmp)
+	require.False(t, hasNil)
+
+	// Shorter right
+	_, _, err = CompareTupleValues(ctx, []interface{}{int64(1), int64(2)}, []interface{}{int64(1)}, elem, false)
+	require.Error(t, err)
+	require.True(t, sql.ErrInvalidColumnNumber.Is(err))
+
+	// TupleType.Compare path
+	tt := TupleType{Int64, Int64}
+	_, err = tt.Compare(ctx, []interface{}{int64(1)}, []interface{}{int64(1), int64(2)})
+	require.Error(t, err)
+	require.True(t, sql.ErrInvalidColumnNumber.Is(err))
+
+	_, err = tt.Compare(ctx, []interface{}{int64(1), int64(2), int64(3)}, []interface{}{int64(1), int64(2)})
+	require.Error(t, err)
+	require.True(t, sql.ErrInvalidColumnNumber.Is(err))
 }


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/11024

## Summary

`SELECT (1, 2) = (NULL, 2)` returns `false` today instead of `NULL`, and the same comparison with the operands swapped, `SELECT (NULL, 2) = (1, 2)`, throws a hard error (`value not nil: 1`) instead of returning `NULL`. Both violate MySQL's row-constructor NULL semantics for equality. Reported in dolthub/dolt#11024 by @nicktobey, with an additional `IN`-clause case (`(1, 1) IN ((NULL, NULL))`) called out by @jycor in a follow-up comment.

This PR scopes the fix to **equality-style** operators only: `=`, `!=`, and **list-IN** (`x IN ((...), (...))`, a literal tuple list on the right). Ordering operators (`<`, `>`, `<=`, `>=`) share `TupleType.Compare` today but have distinct MySQL left-to-right NULL semantics; those are **not** claimed fixed here and are left as a documented follow-up.

## The bugs

1. **`sql/types/tuple.go` `TupleType.Compare`** compared tuples element-by-element but never checked whether an element was NULL first. A NULL element fell through to `nullType.Compare`, which unconditionally returns `0` — documented as an ordering convenience, not an equality claim. That silently turned "this element is unknown" into "this element is equal", which is why `(1,2)=(NULL,2)` came out `false`.

2. **The crash case, same function.** Before the per-element loop, the old code ran *both* tuples through `t.Convert` using a single type array `t`. For `(NULL, 2) = (1, 2)`, `t` is the left tuple's type (`[Null, Int64]`), so converting the right side's values calls `Null.Convert(1)`, which throws `ErrValueNotNil` (`sql/types/null.go:32`).

3. **`sql/expression/in.go` `InTuple.Eval`** tracked `rHasNull` via `rType == types.Null` and `rVal == nil`. Neither catches a right element that is itself a *tuple* containing NULLs — `(1, 1) IN ((NULL, NULL))` evaluates to a non-nil `[]interface{}{nil, nil}`, so the flag was never set and the loop fell through to `false`.

4. **`sql/plan/insubquery.go` `InSubquery.Eval`** (hash-hit path) treated any error from its confirming `Compare` as fatal. Once `TupleType.Compare` began returning `sql.ErrNilOperand`, `(1, NULL) IN (SELECT 1, NULL FROM dual)` went from silently-wrong to an uncaught runtime error.

## The fix

`TupleType.Compare` now walks elements itself and skips conversion entirely for any pair where either side is NULL — which also sidesteps the `ErrValueNotNil` crash, since the mismatched NULL-typed element is never fed through `Convert`. A definite (non-NULL, non-equal) difference at any position returns immediately and dominates NULLs seen elsewhere, matching MySQL for equality: `(1,2)=(NULL,3)` is `false`, not `NULL`. If the loop finishes with no definite difference but saw at least one NULL, it returns `sql.ErrNilOperand`.

That sentinel had to move. It previously lived in `sql/expression/comparison.go`, but `sql/types` cannot import `sql/expression`. It now lives in `sql/type.go` (base `sql` package, already imported by both), and `expression.ErrNilOperand` is a plain alias — same `*errors.Kind` pointer, so `ErrNilOperand.Is(err)` behaves identically for every existing caller. The comparison operators already special-case `ErrNilOperand.Is(err)` as "return SQL NULL", so **Equals/NotEquals needed no operator-body change**.

`NullSafeEquals` (`<=>`) needed a carve-out: two pre-existing tests assert `(1,null) <=> (1,null)` is true, which is the opposite of NULL-is-indeterminate. Since `<=>` on tuples is a distinct semantic, it now has its own `compareTuplesNullSafe` helper rather than delegating to `TupleType.Compare`.

Length-mismatch errors now report the actually-mismatched side rather than always using `len(left)`.

## Known gaps, deliberately not fixed here

**Ordering operators.** `<`, `>`, `<=`, `>=` need a separate left-to-right path: MySQL returns NULL when the first undecided position is NULL even if a later position differs definitely. Empirically on this branch, `(1,2) > (NULL,1)` still yields `true` (MySQL: NULL). Some ordering rows *incidentally* return NULL now via the same signal — that is a side effect, not a fix. `BETWEEN` desugars to `<=`/`>=` and inherits the same gap.

**Row-constructor `IN (SELECT ...)`, hash-miss path.** `InSubquery.Eval` only gets the correct NULL when the left tuple's hash matches a candidate row's. On a miss, a candidate row with a NULL in some-but-not-all columns still yields a definite `false`. Counterexample: `SELECT (1, 5) IN (SELECT 1, NULL FROM dual)` returns `false`, while the equivalent list form `SELECT (1, 5) IN ((1, NULL))` (fixed here) correctly returns `NULL`. Both counterexamples ship as `BrokenQueries` entries so the gap is machine-visible rather than merely described.

## Blast radius

`sql/plan/insubquery.go:119` calls `TupleType.Compare` (via `Subquery.Type()` returning a `TupleType` for multi-column row-constructor IN) — that is bug 4 above, fixed here. I re-grepped the other `.Compare(ctx, ...)` call sites (`memory/`, `sql/range_*.go`, `sql/stats/`, `sql/rowexec/`, rest of `sql/plan/`); those operate on schema column types, which are never `TupleType` at runtime. I had missed the insubquery site on a first pass, so a reviewer who knows this codebase should sanity-check that sweep rather than take my word for it.

## Testing

- Three queries moved out of `BrokenQueries` into `QueryTests` (they now pass), plus new coverage for `=`, `!=`, list-IN, nested-NULL tuples, and the operand-swap crash.
- `go test ./enginetest/ -run TestQueries` passes; `./sql/types/` and `./sql/expression/` pass.
- Revert-proof: with the fix reverted but the new tests kept, the suite fails with exactly the reported symptoms — `(1,2)=(NULL,2)` → `false`, `(0,null)=(0,null)` → `true`, `(1,1) in ((null,null))` → `false`.
- Rebased on `main` @ `d844f6cf5`.

## Note

@nicktobey — I noticed #3541 is open in adjacent territory (index scans for tuple equality / set membership). There is no file overlap with this change, but since it makes the planner build index scans for tuple equality, it seemed worth flagging that this PR changes what tuple equality *returns* when a NULL is involved, in case the two need to agree. Happy to rework or drop this if you'd rather fold it into your own work on #11024.
