### PR TITLE
Use `buildScalar` to get `GetField` expression for `ON UPDATE` columns

### DIFF
--- a/enginetest/queries/update_queries.go
+++ b/enginetest/queries/update_queries.go
@@ -1945,4 +1945,28 @@ var OnUpdateExprScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/11346
+		Name: "ON UPDATE works with CTE",
+		SetUpScript: []string{
+			"CREATE TABLE t2 (id VARCHAR(64) PRIMARY KEY, val INT, updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP);",
+			"INSERT INTO t2 (id,val) VALUES ('a',1);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select * from t2",
+				Expected: []sql.Row{{"a", 1, Jan1Noon}},
+			},
+			{
+				Query: "WITH r(id) AS (SELECT 'a') UPDATE t2 SET val=2 WHERE id IN (SELECT id FROM r);",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}},
+				},
+			},
+			{
+				Query:    "select * from t2",
+				Expected: []sql.Row{{"a", 2, Dec15_1_30}},
+			},
+		},
+	},
 }

--- a/sql/columndefault.go
+++ b/sql/columndefault.go
@@ -21,6 +21,7 @@ import (
 // ColumnDefaultValue is an expression representing the default value of a column. May represent both a default literal
 // and a default expression. A nil pointer of this type represents an implicit default value and is thus valid, so all
 // method calls will return without error.
+// TODO: This needs a better name because it's not always the default value. It can also be a generated or ON UPDATE value
 type ColumnDefaultValue struct {
 	// Expression is the expression representing this default value
 	Expr Expression

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -1821,6 +1821,7 @@ func partitionTableColumns(sch sql.Schema) [][2]int {
 	return ret
 }
 
+// TODO: This needs a better name because it's not always the default value. It can also be a generated or ON UPDATE value
 func (b *Builder) resolveColumnDefaultExpression(inScope *scope, columnDef *sql.Column, colDefault *sql.ColumnDefaultValue) *sql.ColumnDefaultValue {
 	if colDefault == nil || colDefault.Expr == nil {
 		return colDefault

--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -358,25 +358,19 @@ func (b *Builder) assignmentExprsToUpdateExprs(inScope *scope, e ast.AssignmentE
 // values still need to be updated despite not being part of an explicit update expression
 func (b *Builder) addDependentUpdateExprs(inScope *scope, schema sql.Schema, updateExprs []sql.Expression) []sql.Expression {
 	if len(schema) > 0 {
-		tabId := inScope.tables[strings.ToLower(schema[0].Source)]
-		for i, col := range schema {
+		for _, col := range schema {
+			var generated *sql.ColumnDefaultValue
 			if col.Generated != nil {
-				colGf := expression.NewGetFieldWithTable(i+1, int(tabId), col.Type, col.DatabaseSource, col.Source, col.Name, col.Nullable)
-				generated := b.resolveColumnDefaultExpression(inScope, col, col.Generated)
-				updateExprs = append(updateExprs, expression.NewSetField(colGf, assignColumnIndexes(b.ctx, generated, schema)))
+				generated = b.resolveColumnDefaultExpression(inScope, col, col.Generated)
 			} else if col.OnUpdate != nil {
 				// don't add if column is already being updated
 				if !isColumnUpdated(col, updateExprs) {
-					colGf := b.buildScalar(inScope, &ast.ColName{
-						Name: ast.NewColIdent(col.Name),
-						Qualifier: ast.TableName{
-							Name:        ast.NewTableIdent(col.Source),
-							DbQualifier: ast.NewTableIdent(col.DatabaseSource),
-						},
-					})
-					onUpdate := b.resolveColumnDefaultExpression(inScope, col, col.OnUpdate)
-					updateExprs = append(updateExprs, expression.NewSetField(colGf, assignColumnIndexes(b.ctx, onUpdate, schema)))
+					generated = b.resolveColumnDefaultExpression(inScope, col, col.OnUpdate)
 				}
+			}
+			if generated != nil {
+				colExpr := b.buildColumnExpr(inScope, col.Name, col.Source, col.DatabaseSource)
+				updateExprs = append(updateExprs, expression.NewSetField(colExpr, assignColumnIndexes(b.ctx, generated, schema)))
 			}
 		}
 	}

--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -364,11 +364,16 @@ func (b *Builder) addDependentUpdateExprs(inScope *scope, schema sql.Schema, upd
 				colGf := expression.NewGetFieldWithTable(i+1, int(tabId), col.Type, col.DatabaseSource, col.Source, col.Name, col.Nullable)
 				generated := b.resolveColumnDefaultExpression(inScope, col, col.Generated)
 				updateExprs = append(updateExprs, expression.NewSetField(colGf, assignColumnIndexes(b.ctx, generated, schema)))
-			}
-			if col.OnUpdate != nil {
+			} else if col.OnUpdate != nil {
 				// don't add if column is already being updated
 				if !isColumnUpdated(col, updateExprs) {
-					colGf := expression.NewGetFieldWithTable(i+1, int(tabId), col.Type, col.DatabaseSource, col.Source, col.Name, col.Nullable)
+					colGf := b.buildScalar(inScope, &ast.ColName{
+						Name: ast.NewColIdent(col.Name),
+						Qualifier: ast.TableName{
+							Name:        ast.NewTableIdent(col.Source),
+							DbQualifier: ast.NewTableIdent(col.DatabaseSource),
+						},
+					})
 					onUpdate := b.resolveColumnDefaultExpression(inScope, col, col.OnUpdate)
 					updateExprs = append(updateExprs, expression.NewSetField(colGf, assignColumnIndexes(b.ctx, onUpdate, schema)))
 				}

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -503,6 +503,16 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 	return nil
 }
 
+func (b *Builder) buildColumnExpr(inScope *scope, colName, tableName, dbName string) sql.Expression {
+	return b.buildScalar(inScope, &ast.ColName{
+		Name: ast.NewColIdent(colName),
+		Qualifier: ast.TableName{
+			Name:        ast.NewTableIdent(tableName),
+			DbQualifier: ast.NewTableIdent(dbName),
+		},
+	})
+}
+
 func (b *Builder) buildInjectedExpr(inScope *scope, v ast.InjectedExpr) sql.Expression {
 	if err := b.cat.AuthorizationHandler().HandleAuth(b.ctx, b.authQueryState, v.Auth); err != nil && b.authEnabled {
 		b.handleErr(err)


### PR DESCRIPTION
fixes dolthub/dolt#11346

Building the `GetField` expression for a column using its index in a table was causing indexing issues when there was also a CTE. Instead, we need to build the the `GetField` using `buildScalar` to properly resolve the column within the scope.