### PR TITLE
When comparing tuples for equality, widen each pair of input values.

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3165,6 +3165,10 @@ SELECT * FROM cte WHERE  d = 2;`,
 		Expected: []sql.Row{{false}},
 	},
 	{
+		Query:    "SELECT (1, 1) = (1.1, 1.1);",
+		Expected: []sql.Row{{false}},
+	},
+	{
 		Query:    `SELECT 'a' NOT IN ('b','c',null,'d')`,
 		Expected: []sql.Row{{nil}},
 		ExpectedColumns: sql.Schema{

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -229,9 +229,10 @@ func (c *comparison) evalLeftAndRight(ctx *sql.Context, row sql.Row) (interface{
 }
 
 func (c *comparison) castLeftAndRight(ctx *sql.Context, left, right any) (any, any, sql.Type, error) {
-	lTyp := c.Left().Type(ctx)
-	rTyp := c.Right().Type(ctx)
+	return castLeftAndRight(ctx, c.Left().Type(ctx), c.Right().Type(ctx), left, right)
+}
 
+func castLeftAndRight(ctx *sql.Context, lTyp, rTyp sql.Type, left, right any) (any, any, sql.Type, error) {
 	leftIsEnumOrSet := types.IsEnum(lTyp) || types.IsSet(lTyp)
 	rightIsEnumOrSet := types.IsEnum(rTyp) || types.IsSet(rTyp)
 
@@ -272,7 +273,20 @@ func (c *comparison) castLeftAndRight(ctx *sql.Context, left, right any) (any, a
 	}
 
 	if types.IsTuple(lTyp) && types.IsTuple(rTyp) {
-		return left, right, lTyp, nil
+		lTupleType, rTupleType := lTyp.(types.TupleType), rTyp.(types.TupleType)
+		l := make([]interface{}, len(lTupleType))
+		r := make([]interface{}, len(rTupleType))
+		leftTuple := left.([]interface{})
+		rightTuple := right.([]interface{})
+		mergedTupleType := make(types.TupleType, len(lTupleType))
+		for i, _ := range leftTuple {
+			var err error
+			l[i], r[i], mergedTupleType[i], err = castLeftAndRight(ctx, lTupleType[i], rTupleType[i], leftTuple[i], rightTuple[i])
+			if err != nil {
+				return nil, nil, nil, err
+			}
+		}
+		return l, r, mergedTupleType, nil
 	}
 
 	if types.IsTime(lTyp) || types.IsTime(rTyp) {


### PR DESCRIPTION
Previously, when comparing tuples, we would cast the right tuple to the type of the left tuple. This is inconsistent with MySQL, which considers each pair of values and converts them both to a widened type.

This resulted in us returning the incorrect result for the simple query:

```
SELECT (1, 1) = (1.1, 1.1);
```

Dolt would round both of the values on the right to integers prior to comparing them, evaluating to true. The correct behavior is to apply MySQL's [type conversion rules](https://dev.mysql.com/doc/refman/8.4/en/type-conversion.html) to each pair, which in this case would result in both integers being converted to decimals, and the tuples comparing unequal.