### PR TITLE
bug fix: infer a bindvar's column type

### DIFF
--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -860,15 +860,14 @@ func (b *Builder) buildComparison(inScope *scope, c *ast.ComparisonExpr) sql.Exp
 }
 
 func hasColumnType(ctx *sql.Context, e sql.Expression) (sql.Type, bool) {
-	var typ sql.Type
-	sql.Inspect(ctx, e, func(ctx *sql.Context, e sql.Expression) bool {
-		if col, ok := e.(*expression.GetField); ok {
-			typ = col.Type(ctx)
-			return false
-		}
-		return true
-	})
-	return typ, typ != nil
+	if !e.Resolved() {
+		return nil, false
+	}
+	typ := e.Type(ctx)
+	if typ == nil || typ == types.Null {
+		return nil, false
+	}
+	return typ, true
 }
 
 func (b *Builder) buildCaseExpr(inScope *scope, e *ast.CaseExpr) sql.Expression {


### PR DESCRIPTION
Fix untyped bind-var type inference to use the comparison expression's own declared type instead of digging into its children. This means operators like `#>> (jsonb→text)` (from Doltgres) don't leak their operand's type onto the parameter.

Related to: https://github.com/dolthub/doltgresql/issues/3012