### PR TITLE
Adding a new `TimeDeltaExpression` interface 

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3957,28 +3957,43 @@ func TestWindowRangeFrames(t *testing.T, harness Harness) {
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by y range between current row and unbounded following) FROM a order by x`, []sql.Row{{float64(0)}, {float64(2)}, {float64(2)}, {float64(0)}, {float64(2)}, {float64(3)}}, nil, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by y range between current row and current row) FROM a order by x`, []sql.Row{{float64(0)}, {float64(2)}, {float64(2)}, {float64(0)}, {float64(2)}, {float64(3)}}, nil, nil, nil)
 
+	// Integrators whose parser/frame arithmetic doesn't support a given interval query can opt out via
+	// SkippingHarness rather than forfeiting the whole test.
+	testIntervalQuery := func(query string, expected []sql.Row) {
+		if sh, ok := harness.(SkippingHarness); ok && sh.SkipQueryTest(query) {
+			return
+		}
+		TestQueryWithContext(t, ctx, e, harness, query, expected, nil, nil, nil)
+	}
+
 	// fixed frame size, 3 days
+	//
+	// These queries use MySQL's bare numeric interval literal ("interval 1 DAY"), which isn't valid syntax
+	// for Postgres (Postgres requires a quoted quantity: "interval '1' DAY"). The equivalent
+	// quoted-quantity form is exercised below against table c.
 	RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE b (x INTEGER PRIMARY KEY, y INTEGER, z INTEGER, date DATE)")
 	RunQueryWithContext(t, e, harness, ctx, "INSERT INTO b VALUES (0,0,0,'2022-01-26'), (1,0,0,'2022-01-27'), (2,0,0, '2022-01-28'), (3,1,0,'2022-01-29'), (4,1,0,'2022-01-30'), (5,3,0,'2022-01-31')")
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by date range between interval 2 DAY preceding and interval 1 DAY preceding) FROM b order by x`, []sql.Row{{nil}, {float64(0)}, {float64(0)}, {float64(0)}, {float64(1)}, {float64(2)}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by date range between interval 1 DAY preceding and interval 1 DAY following) FROM b order by x`, []sql.Row{{float64(0)}, {float64(0)}, {float64(1)}, {float64(2)}, {float64(5)}, {float64(4)}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by date range between interval 1 DAY following and interval 2 DAY following) FROM b order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(2)}, {float64(4)}, {float64(3)}, {nil}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by date range interval 1 DAY preceding) FROM b order by x`, []sql.Row{{float64(0)}, {float64(0)}, {float64(0)}, {float64(1)}, {float64(2)}, {float64(4)}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by date range between interval 1 DAY preceding and current row) FROM b order by x`, []sql.Row{{float64(0)}, {float64(0)}, {float64(0)}, {float64(1)}, {float64(2)}, {float64(4)}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by date range between interval 1 DAY preceding and unbounded following) FROM b order by x`, []sql.Row{{float64(5)}, {float64(5)}, {float64(5)}, {float64(5)}, {float64(5)}, {float64(4)}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by date range between unbounded preceding and interval 1 DAY following) FROM b order by x`, []sql.Row{{float64(0)}, {float64(0)}, {float64(1)}, {float64(2)}, {float64(5)}, {float64(5)}}, nil, nil, nil)
+	testIntervalQuery(`SELECT sum(y) over (partition by z order by date range between interval 2 DAY preceding and interval 1 DAY preceding) FROM b order by x`, []sql.Row{{nil}, {float64(0)}, {float64(0)}, {float64(0)}, {float64(1)}, {float64(2)}})
+	testIntervalQuery(`SELECT sum(y) over (partition by z order by date range between interval 1 DAY preceding and interval 1 DAY following) FROM b order by x`, []sql.Row{{float64(0)}, {float64(0)}, {float64(1)}, {float64(2)}, {float64(5)}, {float64(4)}})
+	testIntervalQuery(`SELECT sum(y) over (partition by z order by date range between interval 1 DAY following and interval 2 DAY following) FROM b order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(2)}, {float64(4)}, {float64(3)}, {nil}})
+	testIntervalQuery(`SELECT sum(y) over (partition by z order by date range interval 1 DAY preceding) FROM b order by x`, []sql.Row{{float64(0)}, {float64(0)}, {float64(0)}, {float64(1)}, {float64(2)}, {float64(4)}})
+	testIntervalQuery(`SELECT sum(y) over (partition by z order by date range between interval 1 DAY preceding and current row) FROM b order by x`, []sql.Row{{float64(0)}, {float64(0)}, {float64(0)}, {float64(1)}, {float64(2)}, {float64(4)}})
+	testIntervalQuery(`SELECT sum(y) over (partition by z order by date range between interval 1 DAY preceding and unbounded following) FROM b order by x`, []sql.Row{{float64(5)}, {float64(5)}, {float64(5)}, {float64(5)}, {float64(5)}, {float64(4)}})
+	testIntervalQuery(`SELECT sum(y) over (partition by z order by date range between unbounded preceding and interval 1 DAY following) FROM b order by x`, []sql.Row{{float64(0)}, {float64(0)}, {float64(1)}, {float64(2)}, {float64(5)}, {float64(5)}})
 
 	// variable range size, 1 or many days
+	//
+	// These queries compute RANGE frame boundaries as a DATE column offset by an INTERVAL.
 	RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE c (x INTEGER PRIMARY KEY, y INTEGER, z INTEGER, date DATE)")
 	RunQueryWithContext(t, e, harness, ctx, "INSERT INTO c VALUES (0,0,0,'2022-01-26'), (1,0,0,'2022-01-26'), (2,0,0, '2022-01-26'), (3,1,0,'2022-01-27'), (4,1,0,'2022-01-29'), (5,3,0,'2022-01-30'), (6,0,0, '2022-02-03'), (7,1,0,'2022-02-03'), (8,1,0,'2022-02-04'), (9,3,0,'2022-02-04')")
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by date range between interval '2' DAY preceding and interval '1' DAY preceding) FROM c order by x`, []sql.Row{{nil}, {nil}, {nil}, {float64(0)}, {float64(1)}, {float64(1)}, {nil}, {nil}, {float64(1)}, {float64(1)}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by date range between interval '1' DAY preceding and interval '1' DAY following) FROM c order by x`, []sql.Row{{float64(1)}, {float64(1)}, {float64(1)}, {float64(1)}, {float64(4)}, {float64(4)}, {float64(5)}, {float64(5)}, {float64(5)}, {float64(5)}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by date range between interval '1' DAY preceding and current row) FROM c order by x`, []sql.Row{{float64(0)}, {float64(0)}, {float64(0)}, {float64(1)}, {float64(1)}, {float64(4)}, {float64(1)}, {float64(1)}, {float64(5)}, {float64(5)}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT avg(y) over (partition by z order by date range between interval '1' DAY preceding and unbounded following) FROM c order by x`, []sql.Row{{float64(1)}, {float64(1)}, {float64(1)}, {float64(1)}, {float64(3) / float64(2)}, {float64(3) / float64(2)}, {float64(5) / float64(4)}, {float64(5) / float64(4)}, {float64(5) / float64(4)}, {float64(5) / float64(4)}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by date range between unbounded preceding and interval '1' DAY following) FROM c order by x`, []sql.Row{{float64(1)}, {float64(1)}, {float64(1)}, {float64(1)}, {float64(5)}, {float64(5)}, {float64(10)}, {float64(10)}, {float64(10)}, {float64(10)}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT count(y) over (partition by z order by date range between interval '1' DAY following and interval '2' DAY following) FROM c order by x`, []sql.Row{{1}, {1}, {1}, {1}, {1}, {0}, {2}, {2}, {0}, {0}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT count(y) over (partition by z order by date range between interval '1' DAY preceding and interval '2' DAY following) FROM c order by x`, []sql.Row{{4}, {4}, {4}, {5}, {2}, {2}, {4}, {4}, {4}, {4}}, nil, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, "SELECT sum(y) over (partition by z order by date range interval 'e' DAY preceding) FROM c order by x", []sql.Row{{float64(0)}, {float64(0)}, {float64(0)}, {float64(1)}, {float64(1)}, {float64(3)}, {float64(1)}, {float64(1)}, {float64(4)}, {float64(4)}}, nil, nil, nil)
+	testIntervalQuery(`SELECT sum(y) over (partition by z order by date range between interval '2' DAY preceding and interval '1' DAY preceding) FROM c order by x`, []sql.Row{{nil}, {nil}, {nil}, {float64(0)}, {float64(1)}, {float64(1)}, {nil}, {nil}, {float64(1)}, {float64(1)}})
+	testIntervalQuery(`SELECT sum(y) over (partition by z order by date range between interval '1' DAY preceding and interval '1' DAY following) FROM c order by x`, []sql.Row{{float64(1)}, {float64(1)}, {float64(1)}, {float64(1)}, {float64(4)}, {float64(4)}, {float64(5)}, {float64(5)}, {float64(5)}, {float64(5)}})
+	testIntervalQuery(`SELECT sum(y) over (partition by z order by date range between interval '1' DAY preceding and current row) FROM c order by x`, []sql.Row{{float64(0)}, {float64(0)}, {float64(0)}, {float64(1)}, {float64(1)}, {float64(4)}, {float64(1)}, {float64(1)}, {float64(5)}, {float64(5)}})
+	testIntervalQuery(`SELECT avg(y) over (partition by z order by date range between interval '1' DAY preceding and unbounded following) FROM c order by x`, []sql.Row{{float64(1)}, {float64(1)}, {float64(1)}, {float64(1)}, {float64(3) / float64(2)}, {float64(3) / float64(2)}, {float64(5) / float64(4)}, {float64(5) / float64(4)}, {float64(5) / float64(4)}, {float64(5) / float64(4)}})
+	testIntervalQuery(`SELECT sum(y) over (partition by z order by date range between unbounded preceding and interval '1' DAY following) FROM c order by x`, []sql.Row{{float64(1)}, {float64(1)}, {float64(1)}, {float64(1)}, {float64(5)}, {float64(5)}, {float64(10)}, {float64(10)}, {float64(10)}, {float64(10)}})
+	testIntervalQuery(`SELECT count(y) over (partition by z order by date range between interval '1' DAY following and interval '2' DAY following) FROM c order by x`, []sql.Row{{1}, {1}, {1}, {1}, {1}, {0}, {2}, {2}, {0}, {0}})
+	testIntervalQuery(`SELECT count(y) over (partition by z order by date range between interval '1' DAY preceding and interval '2' DAY following) FROM c order by x`, []sql.Row{{4}, {4}, {4}, {5}, {2}, {2}, {4}, {4}, {4}, {4}})
+	testIntervalQuery("SELECT sum(y) over (partition by z order by date range interval 'e' DAY preceding) FROM c order by x", []sql.Row{{float64(0)}, {float64(0)}, {float64(0)}, {float64(1)}, {float64(1)}, {float64(3)}, {float64(1)}, {float64(1)}, {float64(4)}, {float64(4)}})
 
 	AssertErr(t, e, harness, "SELECT sum(y) over (partition by z range between unbounded preceding and interval '1' DAY following) FROM c order by x", nil, aggregation.ErrRangeInvalidOrderBy)
 }

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -337,7 +337,7 @@ func (a *Arithmetic) evalLeftRight(ctx *sql.Context, row sql.Row) (interface{}, 
 	var lval, rval interface{}
 	var err error
 
-	if i, ok := a.LeftChild.(*Interval); ok {
+	if i, ok := a.LeftChild.(TimeDeltaExpression); ok {
 		lval, err = i.EvalDelta(ctx, row)
 		if err != nil {
 			return nil, nil, err
@@ -349,7 +349,7 @@ func (a *Arithmetic) evalLeftRight(ctx *sql.Context, row sql.Row) (interface{}, 
 		}
 	}
 
-	if i, ok := a.RightChild.(*Interval); ok {
+	if i, ok := a.RightChild.(TimeDeltaExpression); ok {
 		rval, err = i.EvalDelta(ctx, row)
 		if err != nil {
 			return nil, nil, err
@@ -396,7 +396,7 @@ func (a *Arithmetic) convertLeftRight(ctx *sql.Context, left interface{}, right 
 }
 
 func isInterval(expr sql.Expression) bool {
-	_, ok := expr.(*Interval)
+	_, ok := expr.(TimeDeltaExpression)
 	return ok
 }
 

--- a/sql/expression/interval.go
+++ b/sql/expression/interval.go
@@ -28,6 +28,17 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
+// TimeDeltaExpression is implemented by any expression whose evaluated value represents a time delta that
+// can be added to or subtracted from a date/time value via *TimeDelta. In the GMS package, Interval
+// satisfies this interface; other integrators' interval-like expressions can implement it, too.
+type TimeDeltaExpression interface {
+	sql.Expression
+
+	// EvalDelta evaluates this expression and returns a TimeDelta that can be used to do arithmetic
+	// on interval values.
+	EvalDelta(ctx *sql.Context, row sql.Row) (*TimeDelta, error)
+}
+
 // Interval defines a time duration.
 type Interval struct {
 	UnaryExpressionStub
@@ -35,6 +46,7 @@ type Interval struct {
 }
 
 var _ sql.Expression = (*Interval)(nil)
+var _ TimeDeltaExpression = (*Interval)(nil)
 var _ sql.CollationCoercible = (*Interval)(nil)
 
 // NewInterval creates a new interval expression.

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -732,6 +732,16 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 	return windowDef
 }
 
+// windowDisplayName returns a human-readable label for a window definition, for use in error
+// messages. Anonymous windows (an inline OVER (w ...) clause rather than a named WINDOW w AS (...))
+// have no name of their own, so they fall back to a generic label.
+func windowDisplayName(def *sql.WindowDefinition) string {
+	if def.Name != "" {
+		return def.Name
+	}
+	return "OVER clause"
+}
+
 // mergeWindowDefs combines the attributes of two window definitions or returns
 // an error if the two are incompatible. [def] should have a reference to
 // [ref] through [def.Ref], and the return value drops the reference to indicate
@@ -744,7 +754,7 @@ func (b *Builder) mergeWindowDefs(def, ref *sql.WindowDefinition) *sql.WindowDef
 	var orderBy sql.SortConditions
 	switch {
 	case len(def.OrderBy) > 0 && len(ref.OrderBy) > 0:
-		err := sql.ErrInvalidWindowInheritance.New("", "", "both contain order by clause")
+		err := sql.ErrInvalidWindowInheritance.New(windowDisplayName(def), def.Ref, "both contain order by clause")
 		b.handleErr(err)
 	case len(def.OrderBy) > 0:
 		orderBy = def.OrderBy
@@ -756,7 +766,7 @@ func (b *Builder) mergeWindowDefs(def, ref *sql.WindowDefinition) *sql.WindowDef
 	var partitionBy []sql.Expression
 	switch {
 	case len(def.PartitionBy) > 0 && len(ref.PartitionBy) > 0:
-		err := sql.ErrInvalidWindowInheritance.New("", "", "both contain partition by clause")
+		err := sql.ErrInvalidWindowInheritance.New(windowDisplayName(def), def.Ref, "both contain partition by clause")
 		b.handleErr(err)
 	case len(def.PartitionBy) > 0:
 		partitionBy = def.PartitionBy
@@ -783,7 +793,7 @@ func (b *Builder) mergeWindowDefs(def, ref *sql.WindowDefinition) *sql.WindowDef
 			df := def.Frame.String()
 			rf := ref.Frame.String()
 			if df != rf {
-				err := sql.ErrInvalidWindowInheritance.New("", "", "both contain different frame clauses")
+				err := sql.ErrInvalidWindowInheritance.New(windowDisplayName(def), def.Ref, "both contain different frame clauses")
 				b.handleErr(err)
 			}
 			frame = def.Frame

--- a/sql/types/typecheck.go
+++ b/sql/types/typecheck.go
@@ -15,10 +15,29 @@
 package types
 
 import (
+	"reflect"
+	"slices"
+
 	"github.com/dolthub/vitess/go/sqltypes"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )
+
+// extendedTypeKindIn reports whether t is a GMS sql.ExtendedType (an integrator's own type, e.g. a
+// Doltgres type) whose zero Go value's kind is one of kinds. Integrator types aren't comparable to this
+// package's sentinel sql.Type values (Float64, Int32, etc.), so IsFloat/IsSigned/IsUnsigned fall back to
+// this to recognize them by their underlying Go representation instead.
+func extendedTypeKindIn(t sql.Type, kinds ...reflect.Kind) bool {
+	et, ok := t.(sql.ExtendedType)
+	if !ok {
+		return false
+	}
+	zero := et.Zero()
+	if zero == nil {
+		return false
+	}
+	return slices.Contains(kinds, reflect.TypeOf(zero).Kind())
+}
 
 // IsBoolean checks if t is a boolean type.
 func IsBoolean(t sql.Type) bool {
@@ -67,7 +86,7 @@ func IsBit(t sql.Type) bool {
 
 // IsFloat checks if t is float type.
 func IsFloat(t sql.Type) bool {
-	return t == Float32 || t == Float64
+	return t == Float32 || t == Float64 || extendedTypeKindIn(t, reflect.Float32, reflect.Float64)
 }
 
 // IsInteger checks if t is an integer type.
@@ -123,7 +142,8 @@ func IsSigned(t sql.Type) bool {
 	if svt, ok := t.(sql.SystemVariableType); ok {
 		t = svt.UnderlyingType()
 	}
-	return t == Int8 || t == Int16 || t == Int24 || t == Int32 || t == Int64 || t == Boolean
+	return t == Int8 || t == Int16 || t == Int24 || t == Int32 || t == Int64 || t == Boolean ||
+		extendedTypeKindIn(t, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Bool)
 }
 
 // IsText checks if t is a CHAR, VARCHAR, TEXT, BINARY, VARBINARY, or BLOB (including TEXT and BLOB variants).
@@ -238,7 +258,8 @@ func IsUnsigned(t sql.Type) bool {
 	if svt, ok := t.(sql.SystemVariableType); ok {
 		t = svt.UnderlyingType()
 	}
-	return t == Uint8 || t == Uint16 || t == Uint24 || t == Uint32 || t == Uint64
+	return t == Uint8 || t == Uint16 || t == Uint24 || t == Uint32 || t == Uint64 ||
+		extendedTypeKindIn(t, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64)
 }
 
 // IsYear checks if t is a year type.


### PR DESCRIPTION
Allows window interval arithmetic to work properly with Doltgres' implementation.