### PR TITLE
Include `orderBy` in various window functions to return correct default framer

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3992,10 +3992,10 @@ func TestNamedWindows(t *testing.T, harness Harness) {
 	RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE a (x INTEGER PRIMARY KEY, y INTEGER, z INTEGER)")
 	RunQueryWithContext(t, e, harness, ctx, "INSERT INTO a VALUES (0,0,0), (1,1,0), (2,2,0), (3,0,0), (4,1,0), (5,3,0)")
 
-	// Expected values reflect this engine's DefaultFramer, which is ROWS UNBOUNDED PRECEDING TO
-	// CURRENT ROW (no RANGE peer-group tie handling), consistently applied whenever a window has
-	// an ORDER BY but no explicit frame -- whether inline or via a named window reference.
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (order by z) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(3)}, {float64(3)}, {float64(4)}, {float64(7)}}, nil, nil, nil)
+	// Every row in `a` has the same z value, so with the default RANGE BETWEEN UNBOUNDED
+	// PRECEDING AND CURRENT ROW frame, every row is in the same peer group and the frame
+	// spans the whole partition for each of them. Verified against MySQL 8/9.
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (order by z) order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (partition by z) order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil, nil)
 	// A named window with an ORDER BY but no explicit frame must default to a running (cumulative)
 	// frame, same as an equivalent inline OVER (...) clause -- not the full-partition frame. The

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3992,9 +3992,6 @@ func TestNamedWindows(t *testing.T, harness Harness) {
 	RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE a (x INTEGER PRIMARY KEY, y INTEGER, z INTEGER)")
 	RunQueryWithContext(t, e, harness, ctx, "INSERT INTO a VALUES (0,0,0), (1,1,0), (2,2,0), (3,0,0), (4,1,0), (5,3,0)")
 
-	// Every row in `a` has the same z value, so with the default RANGE BETWEEN UNBOUNDED
-	// PRECEDING AND CURRENT ROW frame, every row is in the same peer group and the frame
-	// spans the whole partition for each of them. Verified against MySQL 8/9.
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (order by z) order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (partition by z) order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil, nil)
 	// A named window with an ORDER BY but no explicit frame must default to a running (cumulative)

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -6875,9 +6875,6 @@ SELECT * FROM cte WHERE  d = 2;`,
 		},
 	},
 	{
-		// max(v3) is a running max within each v2 partition, ordered by pk: pk has no ties, so
-		// the default RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW frame is equivalent to a
-		// cumulative ROWS frame here. Verified against MySQL 8/9.
 		Query: "SELECT pk, row_number() over (partition by v2 order by pk ), max(v3) over (partition by v2 order by pk) FROM one_pk_three_idx ORDER BY pk",
 		Expected: []sql.Row{
 			{0, 1, 0},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -6875,13 +6875,16 @@ SELECT * FROM cte WHERE  d = 2;`,
 		},
 	},
 	{
+		// max(v3) is a running max within each v2 partition, ordered by pk: pk has no ties, so
+		// the default RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW frame is equivalent to a
+		// cumulative ROWS frame here. Verified against MySQL 8/9.
 		Query: "SELECT pk, row_number() over (partition by v2 order by pk ), max(v3) over (partition by v2 order by pk) FROM one_pk_three_idx ORDER BY pk",
 		Expected: []sql.Row{
-			{0, 1, 3},
-			{1, 2, 3},
+			{0, 1, 0},
+			{1, 2, 1},
 			{2, 1, 0},
 			{3, 1, 2},
-			{4, 3, 3},
+			{4, 3, 1},
 			{5, 4, 3},
 			{6, 1, 0},
 			{7, 1, 4},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -15023,6 +15023,78 @@ select * from t1 except (
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/11381
+		Name: "window aggregate functions with order by col",
+		SetUpScript: []string{
+			"CREATE TABLE t (id BIGINT, name VARCHAR(255));",
+			"INSERT INTO t VALUES (1,'a'),(2,'a'),(3,'a');",
+			"CREATE TABLE t2 (id BIGINT PRIMARY KEY, grp VARCHAR(10), val INT);",
+			"INSERT INTO t2 VALUES (1,'a',10), (2,'a',20), (3,'b',30), (4,'b',5), (5,'c',15), (6,'c',25);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id, SUM(id)  OVER (ORDER BY name) FROM t ORDER BY id;",
+				Expected: []sql.Row{{1, 6.0}, {2, 6.0}, {3, 6.0}},
+			},
+			{
+				Query:    "SELECT id, AVG(id)  OVER (ORDER BY name) FROM t ORDER BY id;",
+				Expected: []sql.Row{{1, 2.0}, {2, 2.0}, {3, 2.0}},
+			},
+			{
+				Query:    "SELECT id, COUNT(id)  OVER (ORDER BY name) FROM t ORDER BY id;",
+				Expected: []sql.Row{{1, 3}, {2, 3}, {3, 3}},
+			},
+			{
+				Query:    "SELECT id, MAX(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{{1, 20}, {2, 20}, {3, 30}, {4, 30}, {5, 30}, {6, 30}},
+			},
+			{
+				Query:    "SELECT id, MIN(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{{1, 10}, {2, 10}, {3, 5}, {4, 5}, {5, 5}, {6, 5}},
+			},
+			{
+				Query: "SELECT id, STDDEV_POP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 5.0}, {2, 5.0},
+					{3, 9.60143218483576}, {4, 9.60143218483576},
+					{5, 8.539125638299666}, {6, 8.539125638299666},
+				},
+			},
+			{
+				Query: "SELECT id, STDDEV_SAMP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 7.0710678118654755}, {2, 7.0710678118654755},
+					{3, 11.086778913041726}, {4, 11.086778913041726},
+					{5, 9.354143466934854}, {6, 9.354143466934854},
+				},
+			},
+			{
+				Query: "SELECT id, VAR_POP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 25.0}, {2, 25.0},
+					{3, 92.1875}, {4, 92.1875},
+					{5, 72.91666666666667}, {6, 72.91666666666667},
+				},
+			},
+			{
+				Query: "SELECT id, VAR_SAMP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 50.0}, {2, 50.0},
+					{3, 122.91666666666667}, {4, 122.91666666666667},
+					{5, 87.5}, {6, 87.5},
+				},
+			},
+			{
+				Query: "SELECT id, JSON_ARRAYAGG(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{
+					{1, types.MustJSON(`[10, 20]`)}, {2, types.MustJSON(`[10, 20]`)},
+					{3, types.MustJSON(`[10, 20, 30, 5]`)}, {4, types.MustJSON(`[10, 20, 30, 5]`)},
+					{5, types.MustJSON(`[10, 20, 30, 5, 15, 25]`)}, {6, types.MustJSON(`[10, 20, 30, 5, 15, 25]`)},
+				},
+			},
+		},
+	},
 }
 
 var BrokenScriptTests = []ScriptTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -15034,63 +15034,122 @@ select * from t1 except (
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "SELECT id, SUM(id)  OVER (ORDER BY name) FROM t ORDER BY id;",
-				Expected: []sql.Row{{1, 6.0}, {2, 6.0}, {3, 6.0}},
-			},
-			{
-				Query:    "SELECT id, AVG(id)  OVER (ORDER BY name) FROM t ORDER BY id;",
-				Expected: []sql.Row{{1, 2.0}, {2, 2.0}, {3, 2.0}},
-			},
-			{
-				Query:    "SELECT id, COUNT(id)  OVER (ORDER BY name) FROM t ORDER BY id;",
-				Expected: []sql.Row{{1, 3}, {2, 3}, {3, 3}},
-			},
-			{
-				Query:    "SELECT id, MAX(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
-				Expected: []sql.Row{{1, 20}, {2, 20}, {3, 30}, {4, 30}, {5, 30}, {6, 30}},
-			},
-			{
-				Query:    "SELECT id, MIN(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
-				Expected: []sql.Row{{1, 10}, {2, 10}, {3, 5}, {4, 5}, {5, 5}, {6, 5}},
-			},
-			{
-				Query: "SELECT id, STDDEV_POP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				// TODO: This test should work in Doltgres but it returns the wrong results.
+				//  https://github.com/dolthub/doltgresql/issues/3036
+				Dialect: "mysql",
+				Query:   "SELECT id, SUM(id)  OVER (ORDER BY name) FROM t ORDER BY id;",
 				Expected: []sql.Row{
-					{1, 5.0}, {2, 5.0},
-					{3, 9.60143218483576}, {4, 9.60143218483576},
-					{5, 8.539125638299666}, {6, 8.539125638299666},
+					{1, 6.0},
+					{2, 6.0},
+					{3, 6.0},
 				},
 			},
 			{
-				Query: "SELECT id, STDDEV_SAMP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				// TODO: This test should work in Doltgres but it returns the wrong results.
+				//  https://github.com/dolthub/doltgresql/issues/3036
+				Dialect: "mysql",
+				Query:   "SELECT id, AVG(id)  OVER (ORDER BY name) FROM t ORDER BY id;",
 				Expected: []sql.Row{
-					{1, 7.0710678118654755}, {2, 7.0710678118654755},
-					{3, 11.086778913041726}, {4, 11.086778913041726},
-					{5, 9.354143466934854}, {6, 9.354143466934854},
+					{1, 2.0},
+					{2, 2.0},
+					{3, 2.0},
 				},
 			},
 			{
-				Query: "SELECT id, VAR_POP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Query: "SELECT id, COUNT(id)  OVER (ORDER BY name) FROM t ORDER BY id;",
 				Expected: []sql.Row{
-					{1, 25.0}, {2, 25.0},
-					{3, 92.1875}, {4, 92.1875},
-					{5, 72.91666666666667}, {6, 72.91666666666667},
+					{1, 3},
+					{2, 3},
+					{3, 3},
 				},
 			},
 			{
-				Query: "SELECT id, VAR_SAMP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Query: "SELECT id, MAX(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
 				Expected: []sql.Row{
-					{1, 50.0}, {2, 50.0},
-					{3, 122.91666666666667}, {4, 122.91666666666667},
-					{5, 87.5}, {6, 87.5},
+					{1, 20},
+					{2, 20},
+					{3, 30},
+					{4, 30},
+					{5, 30},
+					{6, 30},
+				},
+			},
+			{
+				Query: "SELECT id, MIN(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 10},
+					{2, 10},
+					{3, 5},
+					{4, 5},
+					{5, 5},
+					{6, 5},
+				},
+			},
+			{
+				// TODO: This test should work in Doltgres but panics.
+				//  https://github.com/dolthub/doltgresql/issues/3038
+				Dialect: "mysql",
+				Query:   "SELECT id, STDDEV_POP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 5.0},
+					{2, 5.0},
+					{3, 9.60143218483576},
+					{4, 9.60143218483576},
+					{5, 8.539125638299666},
+					{6, 8.539125638299666},
+				},
+			},
+			{
+				// TODO: This test should work in Doltgres but panics.
+				//  https://github.com/dolthub/doltgresql/issues/3038
+				Dialect: "mysql",
+				Query:   "SELECT id, STDDEV_SAMP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 7.0710678118654755},
+					{2, 7.0710678118654755},
+					{3, 11.086778913041726},
+					{4, 11.086778913041726},
+					{5, 9.354143466934854},
+					{6, 9.354143466934854},
+				},
+			},
+			{
+				// TODO: This test should work in Doltgres but panics.
+				//  https://github.com/dolthub/doltgresql/issues/3038
+				Dialect: "mysql",
+				Query:   "SELECT id, VAR_POP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 25.0},
+					{2, 25.0},
+					{3, 92.1875},
+					{4, 92.1875},
+					{5, 72.91666666666667},
+					{6, 72.91666666666667},
+				},
+			},
+			{
+				// TODO: This test should work in Doltgres but panics.
+				//  https://github.com/dolthub/doltgresql/issues/3038
+				Dialect: "mysql",
+				Query:   "SELECT id, VAR_SAMP(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 50.0},
+					{2, 50.0},
+					{3, 122.91666666666667},
+					{4, 122.91666666666667},
+					{5, 87.5},
+					{6, 87.5},
 				},
 			},
 			{
 				Query: "SELECT id, JSON_ARRAYAGG(val) OVER (ORDER BY grp) FROM t2 ORDER BY id;",
 				Expected: []sql.Row{
-					{1, types.MustJSON(`[10, 20]`)}, {2, types.MustJSON(`[10, 20]`)},
-					{3, types.MustJSON(`[10, 20, 30, 5]`)}, {4, types.MustJSON(`[10, 20, 30, 5]`)},
-					{5, types.MustJSON(`[10, 20, 30, 5, 15, 25]`)}, {6, types.MustJSON(`[10, 20, 30, 5, 15, 25]`)},
+					{1, types.MustJSON(`[10, 20]`)},
+					{2, types.MustJSON(`[10, 20]`)},
+					{3, types.MustJSON(`[10, 20, 30, 5]`)},
+					{4, types.MustJSON(`[10, 20, 30, 5]`)},
+					{5, types.MustJSON(`[10, 20, 30, 5, 15, 25]`)},
+					{6, types.MustJSON(`[10, 20, 30, 5, 15, 25]`)},
 				},
 			},
 		},

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -59,7 +59,8 @@ func (b *baseWindowFunction) DefaultFramer() sql.WindowFramer {
 	if b.framer != nil {
 		return b.framer
 	}
-	if len(b.orderBy) < 0 {
+	
+	if len(b.orderBy) == 0 {
 		return NewPartitionFramer()
 	}
 

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -94,8 +94,9 @@ func (a *AnyValueAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf
 }
 
 type SumAgg struct {
-	expr   sql.Expression
-	framer sql.WindowFramer
+	expr    sql.Expression
+	framer  sql.WindowFramer
+	orderBy []sql.Expression
 	// use prefix sums to quickly calculate arbitrary frame sum within partition
 	prefixSum      []float64
 	partitionStart int
@@ -118,6 +119,10 @@ func (a *SumAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.Wind
 			return nil, err
 		}
 		na.framer = framer
+		return &na, nil
+	}
+	if w.OrderBy != nil {
+		na.orderBy = w.OrderBy.ToExpressions()
 	}
 	return &na, nil
 }
@@ -126,12 +131,13 @@ func (a *SumAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
 }
 
-// DefaultFramer returns a NewUnboundedPrecedingToCurrentRowFramer
+// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
+// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
 func (a *SumAgg) DefaultFramer() sql.WindowFramer {
 	if a.framer != nil {
 		return a.framer
 	}
-	return NewUnboundedPrecedingToCurrentRowFramer()
+	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *SumAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -191,8 +197,9 @@ func computePrefixSum(interval sql.WindowInterval, partitionStart int, prefixSum
 }
 
 type AvgAgg struct {
-	expr   sql.Expression
-	framer sql.WindowFramer
+	expr    sql.Expression
+	framer  sql.WindowFramer
+	orderBy []sql.Expression
 
 	// use prefix sums to quickly calculate arbitrary frame sum within partition
 	prefixSum []float64
@@ -218,6 +225,10 @@ func (a *AvgAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.Wind
 			return nil, err
 		}
 		na.framer = framer
+		return &na, nil
+	}
+	if w.OrderBy != nil {
+		na.orderBy = w.OrderBy.ToExpressions()
 	}
 	return &na, nil
 }
@@ -226,12 +237,13 @@ func (a *AvgAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
 }
 
-// DefaultFramer returns a NewUnboundedPrecedingToCurrentRowFramer
+// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
+// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
 func (a *AvgAgg) DefaultFramer() sql.WindowFramer {
 	if a.framer != nil {
 		return a.framer
 	}
-	return NewUnboundedPrecedingToCurrentRowFramer()
+	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *AvgAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -466,8 +478,9 @@ func (b *BitXorAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf s
 }
 
 type MaxAgg struct {
-	expr   sql.Expression
-	framer sql.WindowFramer
+	expr    sql.Expression
+	framer  sql.WindowFramer
+	orderBy []sql.Expression
 }
 
 func NewMaxAgg(e sql.Expression) *MaxAgg {
@@ -484,6 +497,10 @@ func (a *MaxAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.Wind
 			return nil, err
 		}
 		na.framer = framer
+		return &na, nil
+	}
+	if w.OrderBy != nil {
+		na.orderBy = w.OrderBy.ToExpressions()
 	}
 	return &na, nil
 }
@@ -492,12 +509,13 @@ func (a *MaxAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
 }
 
-// DefaultFramer returns a NewPartitionFramer
+// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
+// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
 func (a *MaxAgg) DefaultFramer() sql.WindowFramer {
 	if a.framer != nil {
 		return a.framer
 	}
-	return NewPartitionFramer()
+	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *MaxAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) error {
@@ -538,8 +556,9 @@ func (a *MaxAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buffer s
 }
 
 type MinAgg struct {
-	expr   sql.Expression
-	framer sql.WindowFramer
+	expr    sql.Expression
+	framer  sql.WindowFramer
+	orderBy []sql.Expression
 }
 
 func NewMinAgg(e sql.Expression) *MinAgg {
@@ -556,6 +575,10 @@ func (a *MinAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.Wind
 			return nil, err
 		}
 		na.framer = framer
+		return &na, nil
+	}
+	if w.OrderBy != nil {
+		na.orderBy = w.OrderBy.ToExpressions()
 	}
 	return &na, nil
 }
@@ -564,12 +587,13 @@ func (a *MinAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
 }
 
-// DefaultFramer returns a NewUnboundedPrecedingToCurrentRowFramer
+// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
+// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
 func (a *MinAgg) DefaultFramer() sql.WindowFramer {
 	if a.framer != nil {
 		return a.framer
 	}
-	return NewUnboundedPrecedingToCurrentRowFramer()
+	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *MinAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) error {
@@ -724,6 +748,26 @@ func (a *FirstAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buffer
 	return v, nil
 }
 
+// defaultRangeFramer returns the MySQL default frame for a window with an
+// ORDER BY and no explicit frame clause: RANGE BETWEEN UNBOUNDED PRECEDING
+// AND CURRENT ROW. Unlike a ROWS frame, this extends the frame's end to
+// include every row tied with the current row on the order by expression, so
+// that all peers in a tie produce the same aggregate result. With no ORDER
+// BY, MySQL's default frame is the entire partition.
+func defaultRangeFramer(orderBy []sql.Expression) sql.WindowFramer {
+	if len(orderBy) < 1 {
+		return NewPartitionFramer()
+	}
+
+	return &RangeUnboundedPrecedingToCurrentRowFramer{
+		rangeFramerBase{
+			orderBy:            orderBy[0],
+			unboundedPreceding: true,
+			endCurrentRow:      true,
+		},
+	}
+}
+
 type CountAgg struct {
 	expr      sql.Expression
 	framer    sql.WindowFramer
@@ -773,23 +817,13 @@ func (a *CountAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
 }
 
-// DefaultFramer returns a NewPartitionFramer
+// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
+// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
 func (a *CountAgg) DefaultFramer() sql.WindowFramer {
 	if a.framer != nil {
 		return a.framer
 	}
-
-	if a.orderBy == nil || len(a.orderBy) < 1 {
-		return NewPartitionFramer()
-	}
-
-	return &RangeUnboundedPrecedingToCurrentRowFramer{
-		rangeFramerBase{
-			orderBy:            a.orderBy[0],
-			unboundedPreceding: true,
-			endCurrentRow:      true,
-		},
-	}
+	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *CountAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -990,8 +1024,9 @@ func (a *GroupConcatAgg) filterToDistinct(ctx *sql.Context, buf sql.WindowBuffer
 }
 
 type WindowedJSONArrayAgg struct {
-	expr   sql.Expression
-	framer sql.WindowFramer
+	expr    sql.Expression
+	framer  sql.WindowFramer
+	orderBy []sql.Expression
 }
 
 func NewJsonArrayAgg(expr sql.Expression) *WindowedJSONArrayAgg {
@@ -1008,6 +1043,10 @@ func (a *WindowedJSONArrayAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinit
 			return nil, err
 		}
 		na.framer = framer
+		return &na, nil
+	}
+	if w.OrderBy != nil {
+		na.orderBy = w.OrderBy.ToExpressions()
 	}
 	return &na, nil
 }
@@ -1016,9 +1055,13 @@ func (a *WindowedJSONArrayAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
 }
 
-// DefaultFramer returns a NewUnboundedPrecedingToCurrentRowFramer
+// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
+// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
 func (a *WindowedJSONArrayAgg) DefaultFramer() sql.WindowFramer {
-	return NewUnboundedPrecedingToCurrentRowFramer()
+	if a.framer != nil {
+		return a.framer
+	}
+	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *WindowedJSONArrayAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -1507,6 +1550,7 @@ func (a *leadLagBase) Compute(ctx *sql.Context, interval sql.WindowInterval, buf
 type StdDevPopAgg struct {
 	expr           sql.Expression
 	framer         sql.WindowFramer
+	orderBy        []sql.Expression
 	prefixSum      []float64
 	nullCnt        []int
 	partitionStart int
@@ -1527,6 +1571,10 @@ func (s *StdDevPopAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sq
 			return nil, err
 		}
 		ns.framer = framer
+		return &ns, nil
+	}
+	if w.OrderBy != nil {
+		ns.orderBy = w.OrderBy.ToExpressions()
 	}
 	return &ns, nil
 }
@@ -1535,12 +1583,13 @@ func (s *StdDevPopAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, s.expr)
 }
 
-// DefaultFramer returns a NewUnboundedPrecedingToCurrentRowFramer
+// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
+// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
 func (s *StdDevPopAgg) DefaultFramer() sql.WindowFramer {
 	if s.framer != nil {
 		return s.framer
 	}
-	return NewUnboundedPrecedingToCurrentRowFramer()
+	return defaultRangeFramer(s.orderBy)
 }
 
 func (s *StdDevPopAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -1603,6 +1652,7 @@ func (s *StdDevPopAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, bu
 type StdDevSampAgg struct {
 	expr           sql.Expression
 	framer         sql.WindowFramer
+	orderBy        []sql.Expression
 	prefixSum      []float64
 	nullCnt        []int
 	partitionStart int
@@ -1623,6 +1673,10 @@ func (s *StdDevSampAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (s
 			return nil, err
 		}
 		ns.framer = framer
+		return &ns, nil
+	}
+	if w.OrderBy != nil {
+		ns.orderBy = w.OrderBy.ToExpressions()
 	}
 	return &ns, nil
 }
@@ -1631,12 +1685,13 @@ func (s *StdDevSampAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, s.expr)
 }
 
-// DefaultFramer returns a NewUnboundedPrecedingToCurrentRowFramer
+// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
+// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
 func (s *StdDevSampAgg) DefaultFramer() sql.WindowFramer {
 	if s.framer != nil {
 		return s.framer
 	}
-	return NewUnboundedPrecedingToCurrentRowFramer()
+	return defaultRangeFramer(s.orderBy)
 }
 
 func (s *StdDevSampAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -1677,6 +1732,7 @@ func (s *StdDevSampAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, b
 type VarPopAgg struct {
 	expr           sql.Expression
 	framer         sql.WindowFramer
+	orderBy        []sql.Expression
 	prefixSum      []float64
 	nullCnt        []int
 	partitionStart int
@@ -1697,6 +1753,10 @@ func (v *VarPopAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.W
 			return nil, err
 		}
 		ns.framer = framer
+		return &ns, nil
+	}
+	if w.OrderBy != nil {
+		ns.orderBy = w.OrderBy.ToExpressions()
 	}
 	return &ns, nil
 }
@@ -1705,12 +1765,13 @@ func (v *VarPopAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, v.expr)
 }
 
-// DefaultFramer returns a NewUnboundedPrecedingToCurrentRowFramer
+// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
+// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
 func (v *VarPopAgg) DefaultFramer() sql.WindowFramer {
 	if v.framer != nil {
 		return v.framer
 	}
-	return NewUnboundedPrecedingToCurrentRowFramer()
+	return defaultRangeFramer(v.orderBy)
 }
 
 func (v *VarPopAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -1751,6 +1812,7 @@ func (v *VarPopAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf s
 type VarSampAgg struct {
 	expr           sql.Expression
 	framer         sql.WindowFramer
+	orderBy        []sql.Expression
 	prefixSum      []float64
 	nullCnt        []int
 	partitionStart int
@@ -1771,6 +1833,10 @@ func (v *VarSampAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.
 			return nil, err
 		}
 		ns.framer = framer
+		return &ns, nil
+	}
+	if w.OrderBy != nil {
+		ns.orderBy = w.OrderBy.ToExpressions()
 	}
 	return &ns, nil
 }
@@ -1779,12 +1845,13 @@ func (v *VarSampAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, v.expr)
 }
 
-// DefaultFramer returns a NewUnboundedPrecedingToCurrentRowFramer
+// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
+// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
 func (v *VarSampAgg) DefaultFramer() sql.WindowFramer {
 	if v.framer != nil {
 		return v.framer
 	}
-	return NewUnboundedPrecedingToCurrentRowFramer()
+	return defaultRangeFramer(v.orderBy)
 }
 
 func (v *VarSampAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -59,7 +59,7 @@ func (b *baseWindowFunction) DefaultFramer() sql.WindowFramer {
 	if b.framer != nil {
 		return b.framer
 	}
-	
+
 	if len(b.orderBy) == 0 {
 		return NewPartitionFramer()
 	}

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -35,11 +35,42 @@ var _ sql.WindowFunction = (*CountAgg)(nil)
 var _ sql.WindowFunction = (*GroupConcatAgg)(nil)
 var _ sql.WindowFunction = (*WindowedJSONArrayAgg)(nil)
 var _ sql.WindowFunction = (*WindowedJSONObjectAgg)(nil)
+var _ sql.WindowFunction = (*StdDevPopAgg)(nil)
+var _ sql.WindowFunction = (*VarSampAgg)(nil)
 
 var _ sql.WindowFunction = (*PercentRank)(nil)
 var _ sql.WindowFunction = (*RowNumber)(nil)
 var _ sql.WindowFunction = (*Lag)(nil)
 var _ sql.WindowFunction = (*Lead)(nil)
+
+type baseWindowFunction struct {
+	expr    sql.Expression
+	framer  sql.WindowFramer
+	orderBy []sql.Expression
+}
+
+func newBaseWindowFunction(e sql.Expression) baseWindowFunction {
+	return baseWindowFunction{
+		expr: e,
+	}
+}
+
+func (b *baseWindowFunction) DefaultFramer() sql.WindowFramer {
+	if b.framer != nil {
+		return b.framer
+	}
+	if len(b.orderBy) < 0 {
+		return NewPartitionFramer()
+	}
+
+	return &RangeUnboundedPrecedingToCurrentRowFramer{
+		rangeFramerBase{
+			orderBy:            b.orderBy[0],
+			unboundedPreceding: true,
+			endCurrentRow:      true,
+		},
+	}
+}
 
 type AnyValueAgg struct {
 	expr   sql.Expression
@@ -94,9 +125,7 @@ func (a *AnyValueAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf
 }
 
 type SumAgg struct {
-	expr    sql.Expression
-	framer  sql.WindowFramer
-	orderBy []sql.Expression
+	baseWindowFunction
 	// use prefix sums to quickly calculate arbitrary frame sum within partition
 	prefixSum      []float64
 	partitionStart int
@@ -105,9 +134,9 @@ type SumAgg struct {
 
 func NewSumAgg(e sql.Expression) *SumAgg {
 	return &SumAgg{
-		partitionStart: -1,
-		partitionEnd:   -1,
-		expr:           e,
+		partitionStart:     -1,
+		partitionEnd:       -1,
+		baseWindowFunction: newBaseWindowFunction(e),
 	}
 }
 
@@ -129,15 +158,6 @@ func (a *SumAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.Wind
 
 func (a *SumAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
-}
-
-// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
-// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
-func (a *SumAgg) DefaultFramer() sql.WindowFramer {
-	if a.framer != nil {
-		return a.framer
-	}
-	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *SumAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -197,9 +217,7 @@ func computePrefixSum(interval sql.WindowInterval, partitionStart int, prefixSum
 }
 
 type AvgAgg struct {
-	expr    sql.Expression
-	framer  sql.WindowFramer
-	orderBy []sql.Expression
+	baseWindowFunction
 
 	// use prefix sums to quickly calculate arbitrary frame sum within partition
 	prefixSum []float64
@@ -213,7 +231,7 @@ type AvgAgg struct {
 
 func NewAvgAgg(e sql.Expression) *AvgAgg {
 	return &AvgAgg{
-		expr: e,
+		baseWindowFunction: newBaseWindowFunction(e),
 	}
 }
 
@@ -235,15 +253,6 @@ func (a *AvgAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.Wind
 
 func (a *AvgAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
-}
-
-// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
-// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
-func (a *AvgAgg) DefaultFramer() sql.WindowFramer {
-	if a.framer != nil {
-		return a.framer
-	}
-	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *AvgAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -436,7 +445,7 @@ func (b *BitXorAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, b.expr)
 }
 
-// DefaultFramer returns a NewUnboundedPrecedingToCurrentRowFramer
+// DefaultFramer returns a NewPartitionFramer
 func (b *BitXorAgg) DefaultFramer() sql.WindowFramer {
 	if b.framer != nil {
 		return b.framer
@@ -478,14 +487,12 @@ func (b *BitXorAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf s
 }
 
 type MaxAgg struct {
-	expr    sql.Expression
-	framer  sql.WindowFramer
-	orderBy []sql.Expression
+	baseWindowFunction
 }
 
 func NewMaxAgg(e sql.Expression) *MaxAgg {
 	return &MaxAgg{
-		expr: e,
+		baseWindowFunction: newBaseWindowFunction(e),
 	}
 }
 
@@ -507,15 +514,6 @@ func (a *MaxAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.Wind
 
 func (a *MaxAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
-}
-
-// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
-// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
-func (a *MaxAgg) DefaultFramer() sql.WindowFramer {
-	if a.framer != nil {
-		return a.framer
-	}
-	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *MaxAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) error {
@@ -556,14 +554,12 @@ func (a *MaxAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buffer s
 }
 
 type MinAgg struct {
-	expr    sql.Expression
-	framer  sql.WindowFramer
-	orderBy []sql.Expression
+	baseWindowFunction
 }
 
 func NewMinAgg(e sql.Expression) *MinAgg {
 	return &MinAgg{
-		expr: e,
+		baseWindowFunction: newBaseWindowFunction(e),
 	}
 }
 
@@ -585,15 +581,6 @@ func (a *MinAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.Wind
 
 func (a *MinAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
-}
-
-// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
-// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
-func (a *MinAgg) DefaultFramer() sql.WindowFramer {
-	if a.framer != nil {
-		return a.framer
-	}
-	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *MinAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) error {
@@ -748,31 +735,9 @@ func (a *FirstAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buffer
 	return v, nil
 }
 
-// defaultRangeFramer returns the MySQL default frame for a window with an
-// ORDER BY and no explicit frame clause: RANGE BETWEEN UNBOUNDED PRECEDING
-// AND CURRENT ROW. Unlike a ROWS frame, this extends the frame's end to
-// include every row tied with the current row on the order by expression, so
-// that all peers in a tie produce the same aggregate result. With no ORDER
-// BY, MySQL's default frame is the entire partition.
-func defaultRangeFramer(orderBy []sql.Expression) sql.WindowFramer {
-	if len(orderBy) < 1 {
-		return NewPartitionFramer()
-	}
-
-	return &RangeUnboundedPrecedingToCurrentRowFramer{
-		rangeFramerBase{
-			orderBy:            orderBy[0],
-			unboundedPreceding: true,
-			endCurrentRow:      true,
-		},
-	}
-}
-
 type CountAgg struct {
-	expr      sql.Expression
-	framer    sql.WindowFramer
+	baseWindowFunction
 	prefixSum []float64
-	orderBy   []sql.Expression
 	peerGroup sql.WindowInterval
 
 	pos            int
@@ -782,19 +747,14 @@ type CountAgg struct {
 
 func NewCountAgg(e sql.Expression) *CountAgg {
 	return &CountAgg{
-		partitionStart: -1,
-		partitionEnd:   -1,
-		expr:           e,
+		partitionStart:     -1,
+		partitionEnd:       -1,
+		baseWindowFunction: newBaseWindowFunction(e),
 	}
 }
 
 func NewCountDistinctAgg(e sql.Expression) *CountAgg {
-	e = expression.NewDistinctExpression(e)
-	return &CountAgg{
-		partitionStart: -1,
-		partitionEnd:   -1,
-		expr:           e,
-	}
+	return NewCountAgg(expression.NewDistinctExpression(e))
 }
 
 func (a *CountAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.WindowFunction, error) {
@@ -815,15 +775,6 @@ func (a *CountAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.Wi
 
 func (a *CountAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
-}
-
-// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
-// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
-func (a *CountAgg) DefaultFramer() sql.WindowFramer {
-	if a.framer != nil {
-		return a.framer
-	}
-	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *CountAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -1024,14 +975,12 @@ func (a *GroupConcatAgg) filterToDistinct(ctx *sql.Context, buf sql.WindowBuffer
 }
 
 type WindowedJSONArrayAgg struct {
-	expr    sql.Expression
-	framer  sql.WindowFramer
-	orderBy []sql.Expression
+	baseWindowFunction
 }
 
 func NewJsonArrayAgg(expr sql.Expression) *WindowedJSONArrayAgg {
 	return &WindowedJSONArrayAgg{
-		expr: expr,
+		baseWindowFunction: newBaseWindowFunction(expr),
 	}
 }
 
@@ -1053,15 +1002,6 @@ func (a *WindowedJSONArrayAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinit
 
 func (a *WindowedJSONArrayAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, a.expr)
-}
-
-// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
-// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
-func (a *WindowedJSONArrayAgg) DefaultFramer() sql.WindowFramer {
-	if a.framer != nil {
-		return a.framer
-	}
-	return defaultRangeFramer(a.orderBy)
 }
 
 func (a *WindowedJSONArrayAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -1548,9 +1488,7 @@ func (a *leadLagBase) Compute(ctx *sql.Context, interval sql.WindowInterval, buf
 }
 
 type StdDevPopAgg struct {
-	expr           sql.Expression
-	framer         sql.WindowFramer
-	orderBy        []sql.Expression
+	baseWindowFunction
 	prefixSum      []float64
 	nullCnt        []int
 	partitionStart int
@@ -1559,7 +1497,7 @@ type StdDevPopAgg struct {
 
 func NewStdDevPopAgg(e sql.Expression) *StdDevPopAgg {
 	return &StdDevPopAgg{
-		expr: e,
+		baseWindowFunction: newBaseWindowFunction(e),
 	}
 }
 
@@ -1583,15 +1521,6 @@ func (s *StdDevPopAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, s.expr)
 }
 
-// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
-// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
-func (s *StdDevPopAgg) DefaultFramer() sql.WindowFramer {
-	if s.framer != nil {
-		return s.framer
-	}
-	return defaultRangeFramer(s.orderBy)
-}
-
 func (s *StdDevPopAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
 	s.Dispose(ctx)
 	s.partitionStart = interval.Start
@@ -1601,7 +1530,7 @@ func (s *StdDevPopAgg) StartPartition(ctx *sql.Context, interval sql.WindowInter
 	return err
 }
 
-func computeStd2(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer, expr sql.Expression, m float64) (float64, error) {
+func computeStd(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer, expr sql.Expression, m float64) (float64, error) {
 	var v float64
 	for i := interval.Start; i < interval.End; i++ {
 		row := buf[i]
@@ -1641,7 +1570,7 @@ func (s *StdDevPopAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, bu
 	}
 
 	m := computePrefixSum(interval, s.partitionStart, s.prefixSum) / float64(nonNullCnt)
-	s2, err := computeStd2(ctx, interval, buf, s.expr, m)
+	s2, err := computeStd(ctx, interval, buf, s.expr, m)
 	if err != nil {
 		return nil, err
 	}
@@ -1650,9 +1579,7 @@ func (s *StdDevPopAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, bu
 }
 
 type StdDevSampAgg struct {
-	expr           sql.Expression
-	framer         sql.WindowFramer
-	orderBy        []sql.Expression
+	baseWindowFunction
 	prefixSum      []float64
 	nullCnt        []int
 	partitionStart int
@@ -1661,7 +1588,7 @@ type StdDevSampAgg struct {
 
 func NewStdDevSampAgg(e sql.Expression) *StdDevSampAgg {
 	return &StdDevSampAgg{
-		expr: e,
+		baseWindowFunction: newBaseWindowFunction(e),
 	}
 }
 
@@ -1683,15 +1610,6 @@ func (s *StdDevSampAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (s
 
 func (s *StdDevSampAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, s.expr)
-}
-
-// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
-// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
-func (s *StdDevSampAgg) DefaultFramer() sql.WindowFramer {
-	if s.framer != nil {
-		return s.framer
-	}
-	return defaultRangeFramer(s.orderBy)
 }
 
 func (s *StdDevSampAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -1721,7 +1639,7 @@ func (s *StdDevSampAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, b
 	}
 
 	m := computePrefixSum(interval, s.partitionStart, s.prefixSum) / float64(nonNullCnt)
-	s2, err := computeStd2(ctx, interval, buf, s.expr, m)
+	s2, err := computeStd(ctx, interval, buf, s.expr, m)
 	if err != nil {
 		return nil, err
 	}
@@ -1730,9 +1648,7 @@ func (s *StdDevSampAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, b
 }
 
 type VarPopAgg struct {
-	expr           sql.Expression
-	framer         sql.WindowFramer
-	orderBy        []sql.Expression
+	baseWindowFunction
 	prefixSum      []float64
 	nullCnt        []int
 	partitionStart int
@@ -1741,7 +1657,7 @@ type VarPopAgg struct {
 
 func NewVarPopAgg(e sql.Expression) *VarPopAgg {
 	return &VarPopAgg{
-		expr: e,
+		baseWindowFunction: newBaseWindowFunction(e),
 	}
 }
 
@@ -1763,15 +1679,6 @@ func (v *VarPopAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.W
 
 func (v *VarPopAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, v.expr)
-}
-
-// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
-// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
-func (v *VarPopAgg) DefaultFramer() sql.WindowFramer {
-	if v.framer != nil {
-		return v.framer
-	}
-	return defaultRangeFramer(v.orderBy)
 }
 
 func (v *VarPopAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -1801,7 +1708,7 @@ func (v *VarPopAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf s
 	}
 
 	m := computePrefixSum(interval, v.partitionStart, v.prefixSum) / float64(nonNullCnt)
-	s2, err := computeStd2(ctx, interval, buf, v.expr, m)
+	s2, err := computeStd(ctx, interval, buf, v.expr, m)
 	if err != nil {
 		return nil, err
 	}
@@ -1810,9 +1717,7 @@ func (v *VarPopAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf s
 }
 
 type VarSampAgg struct {
-	expr           sql.Expression
-	framer         sql.WindowFramer
-	orderBy        []sql.Expression
+	baseWindowFunction
 	prefixSum      []float64
 	nullCnt        []int
 	partitionStart int
@@ -1821,7 +1726,7 @@ type VarSampAgg struct {
 
 func NewVarSampAgg(e sql.Expression) *VarSampAgg {
 	return &VarSampAgg{
-		expr: e,
+		baseWindowFunction: newBaseWindowFunction(e),
 	}
 }
 
@@ -1843,15 +1748,6 @@ func (v *VarSampAgg) WithWindow(ctx *sql.Context, w *sql.WindowDefinition) (sql.
 
 func (v *VarSampAgg) Dispose(ctx *sql.Context) {
 	expression.Dispose(ctx, v.expr)
-}
-
-// DefaultFramer returns a NewPartitionFramer, or the RANGE UNBOUNDED
-// PRECEDING AND CURRENT ROW default frame when an ORDER BY is present.
-func (v *VarSampAgg) DefaultFramer() sql.WindowFramer {
-	if v.framer != nil {
-		return v.framer
-	}
-	return defaultRangeFramer(v.orderBy)
 }
 
 func (v *VarSampAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
@@ -1881,7 +1777,7 @@ func (v *VarSampAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf 
 	}
 
 	m := computePrefixSum(interval, v.partitionStart, v.prefixSum) / float64(nonNullCnt)
-	s2, err := computeStd2(ctx, interval, buf, v.expr, m)
+	s2, err := computeStd(ctx, interval, buf, v.expr, m)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes dolthub/dolt#11381

`baseWindowFunction` was created to avoid duplicating shared code and is intended to be extended to fully eliminate duplicated code for window functions.

Also updates tests that were asserting incorrect behavior (verified to match MySQL)

Some new test cases are skipped for Doltgres (see dolthub/doltgresql#3036 and dolthub/doltgresql#3038)