### PR TITLE
Combine `assignmentExprsToUpdateExprs` and `buildOnDupUpdateExprs`

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -2612,7 +2612,12 @@ var InsertDuplicateKeyKeyless = []ScriptTest{
 	},
 	{
 		// https://github.com/dolthub/dolt/issues/11389
-		Name: "insert on duplicate key update works with DEFAULT update value",
+		Name: "INSERT...ON DUPLICATE KEY UPDATE works with DEFAULT update value",
+		// TODO: This test should work in Doltgres. Even though standard Postgres doesn't support
+		//  ON DUPLICATE KEY UPDATE, it works in Doltgres. The problem is that Doltgres panics when DEFAULT is used
+		//  inside an ON UPDATE KEY UPDATE clause
+		//  https://github.com/dolthub/doltgresql/issues/3045
+		Dialect: "mysql",
 		SetUpScript: []string{
 			"CREATE TABLE t(id INT PRIMARY KEY, a INT DEFAULT 1);",
 			"INSERT INTO t VALUES (1, 5);",

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -2610,6 +2610,24 @@ var InsertDuplicateKeyKeyless = []ScriptTest{
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/11389
+		Name: "insert on duplicate key update works with DEFAULT update value",
+		SetUpScript: []string{
+			"CREATE TABLE t(id INT PRIMARY KEY, a INT DEFAULT 1);",
+			"INSERT INTO t VALUES (1, 5);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "INSERT INTO t(id) VALUES (1) ON DUPLICATE KEY UPDATE a = DEFAULT;",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "SELECT * from t;",
+				Expected: []sql.Row{{1, 1}},
+			},
+		},
+	},
 }
 
 var InsertErrorTests = []GenericErrorQueryTest{

--- a/sql/expression/default.go
+++ b/sql/expression/default.go
@@ -22,7 +22,8 @@ import (
 
 // DefaultColumn is a default expression of a column that is not yet resolved.
 // TODO: Rename to ColumnDefault. DefaultColumn implies this is a default column when really this is a column's default
-//  value.
+//
+//	value.
 type DefaultColumn struct {
 	name string
 }

--- a/sql/expression/default.go
+++ b/sql/expression/default.go
@@ -21,6 +21,8 @@ import (
 )
 
 // DefaultColumn is a default expression of a column that is not yet resolved.
+// TODO: Rename to ColumnDefault. DefaultColumn implies this is a default column when really this is a column's default
+//  value.
 type DefaultColumn struct {
 	name string
 }

--- a/sql/expression/default.go
+++ b/sql/expression/default.go
@@ -22,7 +22,7 @@ import (
 
 // DefaultColumn is a default expression of a column that is not yet resolved.
 // TODO: Rename to ColumnDefault. DefaultColumn implies this is a default column when really this is a column's default
-//  value.
+// value.
 type DefaultColumn struct {
 	name string
 }

--- a/sql/expression/default.go
+++ b/sql/expression/default.go
@@ -15,6 +15,8 @@
 package expression
 
 import (
+	"errors"
+
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
@@ -70,10 +72,8 @@ func (c *DefaultColumn) String() string {
 }
 
 // Eval implements the sql.Expression interface.
-// The function always panics!
 func (*DefaultColumn) Eval(ctx *sql.Context, r sql.Row) (interface{}, error) {
-	// TODO: return an error here instead of panicking
-	panic("default column is a placeholder node, but Eval was called")
+	return nil, errors.New("DEFAULT is a placeholder expression, but Eval was called")
 }
 
 // WithChildren implements the Expression interface.

--- a/sql/expression/default.go
+++ b/sql/expression/default.go
@@ -72,6 +72,7 @@ func (c *DefaultColumn) String() string {
 // Eval implements the sql.Expression interface.
 // The function always panics!
 func (*DefaultColumn) Eval(ctx *sql.Context, r sql.Row) (interface{}, error) {
+	// TODO: return an error here instead of panicking
 	panic("default column is a placeholder node, but Eval was called")
 }
 

--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -398,68 +398,6 @@ func isColumnUpdated(col *sql.Column, updateExprs []sql.Expression) bool {
 	return false
 }
 
-// TODO: consider combining this function with assignmentExprsToUpdateExprs since there's a lot of similar repeated code
-func (b *Builder) buildOnDupUpdateExprs(combinedScope, destScope *scope, schema sql.Schema, e ast.AssignmentExprs) *plan.UpdateExprs {
-	b.insertActive = true
-	defer func() {
-		b.insertActive = false
-	}()
-	updateExprs := make([]sql.Expression, len(e))
-	// todo(max): prevent aggregations in separate semantic walk step
-	var startAggCnt int
-	if combinedScope.groupBy != nil {
-		startAggCnt = len(combinedScope.groupBy.aggs)
-	}
-	var startWinCnt int
-	if combinedScope.windowFuncs != nil {
-		startWinCnt = len(combinedScope.windowFuncs)
-	}
-	for i, updateExpr := range e {
-		colName := b.buildOnDupLeft(destScope, updateExpr.Name)
-		innerExpr := b.buildScalar(combinedScope, updateExpr.Expr)
-
-		updateExprs[i] = expression.NewSetField(colName, innerExpr)
-		if combinedScope.groupBy != nil {
-			if len(combinedScope.groupBy.aggs) > startAggCnt {
-				err := sql.ErrAggregationUnsupported.New(updateExprs[i])
-				b.handleErr(err)
-			}
-		}
-		if combinedScope.windowFuncs != nil {
-			if len(combinedScope.windowFuncs) > startWinCnt {
-				err := sql.ErrWindowUnsupported.New(updateExprs[i])
-				b.handleErr(err)
-			}
-		}
-	}
-
-	return plan.NewUpdateExprs(b.addDependentUpdateExprs(destScope, schema, updateExprs), len(e))
-}
-
-func (b *Builder) buildOnDupLeft(inScope *scope, e ast.Expr) sql.Expression {
-	// expect col reference only
-	switch e := e.(type) {
-	case *ast.ColName:
-		dbName := strings.ToLower(e.Qualifier.DbQualifier.String())
-		tblName := strings.ToLower(e.Qualifier.Name.String())
-		colName := strings.ToLower(e.Name.String())
-		c, ok := inScope.resolveColumn(dbName, tblName, colName, true, false)
-		if !ok {
-			if tblName != "" && !inScope.hasTable(tblName) {
-				b.handleErr(sql.ErrTableNotFound.New(tblName))
-			} else if tblName != "" {
-				b.handleErr(sql.ErrTableColumnNotFound.New(tblName, colName))
-			}
-			b.handleErr(sql.ErrColumnNotFound.New(e))
-		}
-		return c.scalarGf()
-	default:
-		err := fmt.Errorf("invalid update target; expected column reference, found: %T", e)
-		b.handleErr(err)
-	}
-	return nil
-}
-
 func (b *Builder) buildDelete(inScope *scope, d *ast.Delete) (outScope *scope) {
 	// TODO: this shouldn't be called during ComPrepare or `PREPARE ... FROM ...` statements, but currently it is.
 	//   The end result is that the ComDelete counter is incremented during prepare statements, which is incorrect.

--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -136,7 +136,9 @@ func (b *Builder) buildInsert(inScope *scope, i *ast.Insert) (outScope *scope) {
 				combinedScope.newColumn(srcScope.cols[i])
 			}
 		}
-		onDupUpdateExprs = b.buildOnDupUpdateExprs(combinedScope, destScope, sch, ast.AssignmentExprs(i.OnDup))
+		b.insertActive = true
+		onDupUpdateExprs = b.assignmentExprsToUpdateExprs(combinedScope, destScope, sch, ast.AssignmentExprs(i.OnDup))
+		b.insertActive = false
 	}
 
 	ignore := false
@@ -279,8 +281,7 @@ func reorderSchema(names []string, schema sql.Schema) sql.Schema {
 	return newSch
 }
 
-// TODO: Consider combining this function with buildOnDupUpdateExprs since there's a lot of similar and repeated code
-func (b *Builder) assignmentExprsToUpdateExprs(inScope *scope, e ast.AssignmentExprs) *plan.UpdateExprs {
+func (b *Builder) assignmentExprsToUpdateExprs(inScope, destScope *scope, tableSch sql.Schema, e ast.AssignmentExprs) *plan.UpdateExprs {
 	// Make sure the assignment expressions don't reference hidden system columns
 	for _, expr := range e {
 		if sql.IsHiddenSystemColumn(expr.Name.Name.String()) {
@@ -298,10 +299,8 @@ func (b *Builder) assignmentExprsToUpdateExprs(inScope *scope, e ast.AssignmentE
 		startWinCnt = len(inScope.windowFuncs)
 	}
 
-	tableSch := b.resolveSchemaDefaults(inScope, inScope.node.Schema(b.ctx))
-
 	for i, updateExpr := range e {
-		colName := b.buildScalar(inScope, updateExpr.Name)
+		colName := b.buildScalar(destScope, updateExpr.Name)
 
 		innerExpr := b.buildScalar(inScope, updateExpr.Expr)
 		if gf, ok := colName.(*expression.GetField); ok {
@@ -356,7 +355,7 @@ func (b *Builder) assignmentExprsToUpdateExprs(inScope *scope, e ast.AssignmentE
 		}
 	}
 
-	return plan.NewUpdateExprs(b.addDependentUpdateExprs(inScope, tableSch, updateExprs), len(e))
+	return plan.NewUpdateExprs(b.addDependentUpdateExprs(destScope, tableSch, updateExprs), len(e))
 }
 
 // addDependentUpdateExprs adds update expressions for any generated columns and ON UPDATE expressions since their
@@ -545,7 +544,7 @@ func (b *Builder) buildUpdate(inScope *scope, u *ast.Update) (outScope *scope) {
 	_, foundJoin := outScope.node.(*plan.JoinNode)
 
 	// default expressions only resolve to target table
-	updateExprs := b.assignmentExprsToUpdateExprs(outScope, u.Exprs)
+	updateExprs := b.assignmentExprsToUpdateExprs(outScope, outScope, b.resolveSchemaDefaults(outScope, outScope.node.Schema(b.ctx)), u.Exprs)
 
 	b.buildWhere(outScope, u.Where)
 


### PR DESCRIPTION
Fixes dolthub/dolt#11389

This PR addresses a TODO that I had added to combine `assignExprsToUpdateExprs` and `buildOnDupUpdateExprs`, since these two functions did pretty much the same thing with a lot of repeated code. `buildOnDupUpdateExprs` was missing the step to resolve `DEFAULT` so it made more sense to combine the two functions that it did to rewrite that step.

This PR also replaces the panic in `DefaultColumn.Eval` with an error in an effort to reduce the number of panics in GMS and Dolt (dolthub/dolt#11299).