### PR TITLE
Fix panic when a RANGE window frame offset pushes a SET/ENUM order-by value outside its valid domain

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -1304,9 +1304,6 @@ var WindowRangeFramesScriptTests = []ScriptTest{
 		// RANGE frame arithmetic (offset applied to the order-by expression) on a SET order-by column can
 		// produce a value outside that SET's valid domain. https://github.com/dolthub/dolt/issues/11397
 		Name: "window range frames, SET order-by column",
-		// TODO: Skipped until the fix for dolt/go#11397 lands; without it, this panics instead of
-		//       returning the expected result (out-of-domain SET value breaks the window framer).
-		Skip: true,
 		// The SET syntax isn't supported in Postgres, so this script is restricted to the mysql dialect.
 		Dialect: "mysql",
 		SetUpScript: []string{

--- a/sql/expression/function/aggregation/window_framer.go
+++ b/sql/expression/function/aggregation/window_framer.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 //go:generate go run ../../../../optgen/cmd/optgen/main.go -out window_framer.og.go -pkg aggregation framer window_framer.go
@@ -457,6 +458,19 @@ func findInclusionBoundary(ctx *sql.Context, pos, searchStart, partitionEnd int,
 		return 0, err
 	}
 
+	// [expr]'s type is normally sufficient to compare [res] and [cur], since [cur] is
+	// usually just [expr] shifted by a same-typed offset (e.g. int+int, date+interval).
+	// SET and ENUM order-by columns are the exception: their arithmetic offset (e.g.
+	// `set_col + 1`) can legitimately land outside the column's valid domain, and
+	// SetType/EnumType's Compare rejects out-of-domain values since it's also used to
+	// validate storage. Range framing only needs numeric ordering here, so fall back to
+	// comparing using [inclusion]'s (numeric) type instead, mirroring the same Set/Enum
+	// fallback castLeftAndRight uses in expression/comparison.go.
+	compareType := expr.Type(ctx)
+	if types.IsSet(compareType) || types.IsEnum(compareType) {
+		compareType = inclusion.Type(ctx)
+	}
+
 	i := searchStart
 	cmp := unknown
 	for ; cmp < int(stopCond); i++ {
@@ -469,7 +483,7 @@ func findInclusionBoundary(ctx *sql.Context, pos, searchStart, partitionEnd int,
 			return 0, err
 		}
 
-		cmp, err = expr.Type(ctx).Compare(ctx, res, cur)
+		cmp, err = compareType.Compare(ctx, res, cur)
 		if err != nil {
 			return 0, err
 		}

--- a/sql/expression/function/aggregation/window_framer.go
+++ b/sql/expression/function/aggregation/window_framer.go
@@ -458,19 +458,7 @@ func findInclusionBoundary(ctx *sql.Context, pos, searchStart, partitionEnd int,
 		return 0, err
 	}
 
-	// [expr]'s type is normally sufficient to compare [res] and [cur], since [cur] is
-	// usually just [expr] shifted by a same-typed offset (e.g. int+int, date+interval).
-	// SET and ENUM order-by columns are the exception: their arithmetic offset (e.g.
-	// `set_col + 1`) can legitimately land outside the column's valid domain, and
-	// SetType/EnumType's Compare rejects out-of-domain values since it's also used to
-	// validate storage. Range framing only needs numeric ordering here, so fall back to
-	// comparing using [inclusion]'s (numeric) type instead, mirroring the same Set/Enum
-	// fallback castLeftAndRight uses in expression/comparison.go.
-	compareType := expr.Type(ctx)
-	if types.IsSet(compareType) || types.IsEnum(compareType) {
-		compareType = inclusion.Type(ctx)
-	}
-
+	compareType := types.GetCompareType(expr.Type(ctx), inclusion.Type(ctx))
 	i := searchStart
 	cmp := unknown
 	for ; cmp < int(stopCond); i++ {

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -273,6 +273,8 @@ func (i *WindowPartitionIter) compute(ctx *sql.Context) (sql.Row, error) {
 			if err != nil {
 				return nil, err
 			}
+		} else if err != nil {
+			return nil, err
 		}
 		v, err := agg.fn.Compute(ctx, interval, i.input)
 		if err != nil {


### PR DESCRIPTION
Also stops swallowing non-EOF framer errors that let it turn into an out-of-bounds index.

Fixes: https://github.com/dolthub/dolt/issues/11397