### PR TITLE
Handle negative start positions in `LOCATE` function

### DIFF
--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -1935,6 +1935,15 @@ var FunctionQueryTests = []QueryTest{
 		Expected: []sql.Row{{7}, {8}, {7}},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/11393
+		Query:    "select locate('a', 'abc', -1);",
+		Expected: []sql.Row{{0}},
+	},
+	{
+		Query:    "select locate('a', 'abc', 0);",
+		Expected: []sql.Row{{0}},
+	},
+	{
 		Query: "select find_in_set('second row', s) from mytable;",
 		Expected: []sql.Row{
 			{0},

--- a/sql/expression/function/locate.go
+++ b/sql/expression/function/locate.go
@@ -164,8 +164,8 @@ func (l *Locate) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	// Edge cases that cannot be handled by strings.Index.
 	switch {
-	// Position 0 doesn't exist.
-	case position == 0 || (len(str) > 0 && position > len(str)):
+	// Position 0 and negative positions don't exist.
+	case position <= 0 || (len(str) > 0 && position > len(str)):
 		return int32(0), nil
 	// Locate("", "") returns 1 if start is 1.
 	case len(substr) == 0 && len(str) == 0:

--- a/sql/expression/function/locate_test.go
+++ b/sql/expression/function/locate_test.go
@@ -83,6 +83,13 @@ func TestLocate(t *testing.T) {
 			Expected: 0,
 		},
 		{
+			Name:     "locate with negative start",
+			Substr:   "o",
+			Str:      "locate",
+			Start:    intPtr(-1),
+			Expected: 0,
+		},
+		{
 			Name:     "locate empty substring",
 			Substr:   "",
 			Str:      "locate",


### PR DESCRIPTION
fixes dolthub/dolt#11393