### PR TITLE
fix: SET-typed ORDER BY in RANGE window frames panics on boundary arithmetic (dolthub/dolt#11397)

### DIFF
--- a/sql/types/set.go
+++ b/sql/types/set.go
@@ -114,21 +114,81 @@ func MustCreateSetType(values []string, collation sql.CollationID) sql.SetType {
 }
 
 // Compare implements Type interface.
+// orderingValue returns the raw bit-field magnitude of v for ordering/comparison purposes.
+// Unlike Convert, it does not require v to be a legal combination of this SET's members —
+// only strings still go through that strict validation, since a bare string has no other
+// meaningful numeric interpretation. Numeric inputs are used as-is.
+//
+// This matters for range-frame window arithmetic (e.g. `ORDER BY set_col RANGE BETWEEN
+// CURRENT ROW AND 1 FOLLOWING`): the "+1" boundary is a synthetic comparison bound, never a
+// value that will be stored, and can legitimately exceed the set's max valid bit-field (e.g.
+// max value 7 for a 3-member set, +1 = 8) without that making the comparison meaningless —
+// 8 still orders correctly above every real member combination.
+func (t SetType) orderingValue(ctx context.Context, v interface{}) (uint64, error) {
+	switch value := v.(type) {
+	case string:
+		ai, _, err := t.Convert(ctx, value)
+		if err != nil {
+			return 0, err
+		}
+		return ai.(uint64), nil
+	case []byte:
+		return t.orderingValue(ctx, string(value))
+	case int:
+		return uint64(value), nil
+	case uint:
+		return uint64(value), nil
+	case int8:
+		return uint64(value), nil
+	case uint8:
+		return uint64(value), nil
+	case int16:
+		return uint64(value), nil
+	case uint16:
+		return uint64(value), nil
+	case int32:
+		return uint64(value), nil
+	case uint32:
+		return uint64(value), nil
+	case int64:
+		return uint64(value), nil
+	case uint64:
+		return value, nil
+	case float32:
+		// Round rather than truncate: the arithmetic that reaches here (e.g. a
+		// window frame's `orderBy + N`) can produce a float type even for an
+		// exact integer input/offset pair, and truncation would silently pull
+		// an exact boundary like 8.0 down to 7 on any tiny float representation
+		// wobble. This does not fix float64's inherent precision ceiling for
+		// SET values near or above 2^53 (SET supports up to 64 members) — that
+		// is a pre-existing limitation of routing SET arithmetic through
+		// Arithmetic's float64 fallback type, out of scope for this fix.
+		return uint64(math.Round(float64(value))), nil
+	case float64:
+		return uint64(math.Round(value)), nil
+	case *apd.Decimal:
+		return DecimalIntPartUint64(value), nil
+	}
+	ai, _, err := t.Convert(ctx, v)
+	if err != nil {
+		return 0, err
+	}
+	return ai.(uint64), nil
+}
+
 func (t SetType) Compare(ctx context.Context, a interface{}, b interface{}) (int, error) {
 	if hasNulls, res := CompareNulls(a, b); hasNulls {
 		return res, nil
 	}
 
-	ai, _, err := t.Convert(ctx, a)
+	au, err := t.orderingValue(ctx, a)
 	if err != nil {
 		return 0, err
 	}
-	bi, _, err := t.Convert(ctx, b)
+	bu, err := t.orderingValue(ctx, b)
 	if err != nil {
 		return 0, err
 	}
-	au := ai.(uint64)
-	bu := bi.(uint64)
 
 	// If there's an empty string in the set, empty strings should match both 0 and an empty string bit field
 	if emptyStringBitField, ok := t.emptyStringBitField(); ok {

--- a/sql/types/set_test.go
+++ b/sql/types/set_test.go
@@ -64,6 +64,49 @@ func TestSetCompare(t *testing.T) {
 	}
 }
 
+// TestSetCompareOutOfRangeNumeric covers dolthub/dolt#11397: a numeric value
+// used purely for comparison (e.g. window-frame RANGE boundary arithmetic
+// like `order_by_set_col + 1`) can legitimately exceed the SET's maximum
+// valid bit-field (e.g. 7 for a 3-member set, +1 = 8) without that making
+// the comparison an error — 8 is not a real member combination, but it
+// still orders correctly above every value that is.
+func TestSetCompareOutOfRangeNumeric(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	typ := MustCreateSetType([]string{"x", "y", "z"}, sql.Collation_Default)
+
+	tests := []struct {
+		name        string
+		val1        interface{}
+		val2        interface{}
+		expectedCmp int
+	}{
+		{"max valid value vs out-of-range +1", uint64(7), uint64(8), -1},
+		{"out-of-range vs max valid value", uint64(8), uint64(7), 1},
+		{"in-range value vs out-of-range value", uint64(3), uint64(8), -1},
+		{"same out-of-range value", uint64(8), uint64(8), 0},
+		{"int type out-of-range", 8, uint64(7), 1},
+		{"float64 type out-of-range", float64(8), uint64(7), 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmp, err := typ.Compare(ctx, test.val1, test.val2)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedCmp, cmp)
+		})
+	}
+}
+
+// TestSetCompareOutOfRangeStringStillErrors confirms the fix for #11397
+// doesn't loosen validation for strings — a string must still name real
+// set members, since a string has no other meaningful interpretation.
+func TestSetCompareOutOfRangeStringStillErrors(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	typ := MustCreateSetType([]string{"x", "y", "z"}, sql.Collation_Default)
+	_, err := typ.Compare(ctx, "not-a-real-member", uint64(1))
+	require.Error(t, err)
+}
+
 func TestSetCompareErrors(t *testing.T) {
 	ctx := sql.NewEmptyContext()
 	tests := []struct {


### PR DESCRIPTION
Hi! Same honest context as always: I'm not a developer by trade — I run an evidence-gated
verification workflow (["the Nkama way"](https://github.com/donkk11/nkama-fact-benchmark):
no claim counts unless there's a checkable artifact behind it — a real repro, a real test,
a real diff). This issue was filed against `dolthub/dolt`
([dolthub/dolt#11397](https://github.com/dolthub/dolt/issues/11397)), but I traced it down
to here — the panic is in this repo's window-frame code, dolt just calls it. AI-assisted,
then independently cross-checked. Please review critically; if it's not the right fix, no
hard feelings closing it.

**The bug.** `RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING` panics with
`index out of range [2] with length 2` when the `ORDER BY` column is a `SET` type.
Reproduced against a real built binary, not just in isolation — this is the exact repro
from the dolt issue:

```sql
CREATE TABLE t(id INT PRIMARY KEY, g INT, s SET('x','y','z'), m INT, v INT NOT NULL);
INSERT INTO t VALUES (1, 0, 'x,y', 3, 10), (2, 0, 'x,y,z', 7, 20);
SELECT id, SUM(v) OVER (PARTITION BY g ORDER BY s ASC RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING) AS wf
FROM t ORDER BY id;
```

**Root cause, traced live, not guessed.** `SetType.Compare()` unconditionally routes both
operands through `Convert()`, which rejects any numeric value above the SET's max valid
bit-field (7 for a 3-member set). But the RANGE frame's boundary arithmetic (`order_by + 1`
for `1 FOLLOWING`) produces a synthetic comparison-only value — here, `7 + 1 = 8` — that's
never meant to be stored, only compared against. `Convert()` correctly refuses to treat `8`
as a real 3-member SET combination and errors. That error isn't `io.EOF`, so the caller in
`WindowPartitionIter.compute()` — which only branches on `io.EOF` — silently drops it and
keeps iterating past the partition's real row count, eventually indexing past the end of a
fixed-size slice. The panic is a downstream symptom; the actual bug is that a legitimate
comparison-only value gets forced through storage-validity rules that were never meant to
apply to it.

**The fix.** Added `SetType.orderingValue()`: for numeric inputs, it returns the raw
magnitude directly for ordering purposes, skipping the storage-domain check; for
string/`[]byte` inputs, it still routes through the full strict `Convert()` validation,
since a string has no other meaningful interpretation and typo'd member names must still
error. `Compare()` calls this instead of `Convert()` directly. Nothing about `INSERT`/`UPDATE`
validation changes — only comparison.

**Verification, honestly.** Reproduced the original panic against a real built `dolt`
binary first. After the fix: exact match to the issue's expected output (`id=1→wf=10`,
`id=2→wf=20`), no panic. Full `go test ./sql/...` clean, no regressions. Added
`TestSetCompareOutOfRangeNumeric` and `TestSetCompareOutOfRangeStringStillErrors` to
`sql/types/set_test.go`.

Then a second, independent model reviewed it critically. One of its four claims — that the
`emptyStringBitField` special-case logic would break — didn't hold up against the actual
test suite (still passes; I checked rather than took its word for it). One claim was real:
float-to-uint64 truncation in the new code could nudge an exact boundary value down by 1 on
float imprecision — fixed with `math.Round`. One residual, honest limitation I'm not
claiming to have solved: SET supports up to 64 members, and float64 loses exact-integer
precision above 2^53 — a pre-existing property of how this arithmetic path types SET
operations as float64, out of scope for this specific fix, noted in a code comment.

Diff: `sql/types/set.go` (+the new method, ~15 lines changed in `Compare`) and
`sql/types/set_test.go` (new tests). Happy to adjust naming, split the test cases
differently, or take this in a different direction if you'd rather fix it upstream in the
arithmetic type-inference layer instead.