### PR TITLE
Error out for undefined window names

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4008,6 +4008,8 @@ func TestNamedWindows(t *testing.T, harness Harness) {
 	RunQueryWithContext(t, e, harness, ctx, "INSERT INTO a VALUES (0,0,0), (1,1,0), (2,2,0), (3,0,0), (4,1,0), (5,3,0)")
 
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (order by z) order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil, nil)
+	// window names should not be case-sensitive
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW W1 as (order by z) order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (partition by z) order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil, nil)
 	// A named window with an ORDER BY but no explicit frame must default to a running (cumulative)
 	// frame, same as an equivalent inline OVER (...) clause -- not the full-partition frame. The
@@ -4034,6 +4036,9 @@ func TestNamedWindows(t *testing.T, harness Harness) {
 	AssertErr(t, e, harness, "SELECT sum(y) over (w1 order by x) FROM a WINDOW w1 as (order by z) order by x", nil, sql.ErrInvalidWindowInheritance)
 	AssertErr(t, e, harness, "SELECT sum(y) over (w1 rows unbounded preceding) FROM a WINDOW w1 as (range unbounded preceding) order by x", nil, sql.ErrInvalidWindowInheritance)
 	AssertErr(t, e, harness, "SELECT sum(y) over (w3) FROM a WINDOW w1 as (w2), w2 as (w3), w3 as (w1) order by x", nil, sql.ErrCircularWindowInheritance)
+	// https://github.com/dolthub/dolt/issues/11426
+	AssertErr(t, e, harness, "SELECT sum(y) over w AS s FROM a WINDOW w AS (missing ORDER BY x) ORDER BY x", nil, sql.ErrUnknownWindowName)
+	AssertErr(t, e, harness, "SELECT sum(y) over (w1) FROM a WINDOW w2 as (order by z) order by x", nil, sql.ErrUnknownWindowName)
 
 	// TODO parser needs to differentiate between window replacement and copying -- window frames can't be copied
 	// AssertErr(t, e, harness, "SELECT sum(y) over w FROM a WINDOW (w) as (partition by z order by x rows unbounded preceding) order by x", sql.ErrInvalidWindowInheritance)

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10501,6 +10501,11 @@ var ErrorQueries = []QueryErrorTest{
 		Query:       `select s from mytable group by s order by i`,
 		ExpectedErr: analyzererrors.ErrValidationGroupByOrderBy,
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/11426
+		Query:       `SELECT pk, SUM(c1) OVER w AS s FROM one_pk WINDOW w AS (missing ORDER BY pk) ORDER BY pk;`,
+		ExpectedErr: sql.ErrUnknownWindowName,
+	},
 }
 
 var BrokenErrorQueries = []QueryErrorTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10501,11 +10501,6 @@ var ErrorQueries = []QueryErrorTest{
 		Query:       `select s from mytable group by s order by i`,
 		ExpectedErr: analyzererrors.ErrValidationGroupByOrderBy,
 	},
-	{
-		// https://github.com/dolthub/dolt/issues/11426
-		Query:       `SELECT pk, SUM(c1) OVER w AS s FROM one_pk WINDOW w AS (missing ORDER BY pk) ORDER BY pk;`,
-		ExpectedErr: sql.ErrUnknownWindowName,
-	},
 }
 
 var BrokenErrorQueries = []QueryErrorTest{

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -769,7 +769,7 @@ var (
 	ErrCannotCopyWindowFrame = errors.NewKind("cannot copy window '%s' because it has a frame clause")
 
 	// ErrUnknownWindowName is returned when an over by clause references an unknown window definition
-	ErrUnknownWindowName = errors.NewKind("named window not found: '%s'")
+	ErrUnknownWindowName = errors.NewKind("Window name '%s' is not defined")
 
 	// ErrUnexpectedNilRow is returned when an invalid operation is applied to an empty row
 	ErrUnexpectedNilRow = errors.NewKind("unexpected nil row")

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -717,7 +717,11 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 	frame := b.NewFrame(fromScope, def.Frame)
 
 	windowDef := sql.NewWindowDefinition(partitions, sortConditions, frame, def.NameRef.Lowered(), def.Name.Lowered())
-	if ref, ok := fromScope.windowDefs[def.NameRef.Lowered()]; ok {
+	if nameRef := def.NameRef.Lowered(); nameRef != "" {
+		ref, ok := fromScope.windowDefs[nameRef]
+		if !ok {
+			b.handleErr(sql.ErrUnknownWindowName.New(nameRef))
+		}
 		// this is only safe if windows are built in topo order
 		windowDef = b.mergeWindowDefs(windowDef, ref)
 		// collapse dependencies if any reference this window

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -667,8 +667,11 @@ func (b *Builder) buildNamedWindows(fromScope *scope, window ast.Window) {
 		if ok, _ := seen[name]; ok {
 			b.handleErr(sql.ErrCircularWindowInheritance.New())
 		}
+		cur, ok := adj[name]
+		if !ok {
+			b.handleErr(sql.ErrUnknownWindowName.New(name))
+		}
 		seen[name] = true
-		cur := adj[name]
 		if ref := cur.NameRef.Lowered(); ref != "" {
 			dfs(ref)
 		}


### PR DESCRIPTION
fixes dolthub/dolt#11426

`ErrUnknownWindowName` was defined but never actually used anywhere. This PR updates the error message to better match MySQL and throws the error when a referenced window name has not actually be defined.