### PR TITLE
sql/types: trim whitespace before parsing date/datetime strings

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3655,6 +3655,14 @@ SELECT * FROM cte WHERE  d = 2;`,
 		Expected: []sql.Row{{uint64(20221111)}},
 	},
 	{
+		Query: "SELECT CAST(' 2024-01-01 ' AS DATE), CAST(CONCAT(' ', '2024-01-01') AS DATE), DATE(' 2024-01-01 ');",
+		Expected: []sql.Row{{
+			time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC),
+			"2024-01-01",
+		}},
+	},
+	{
 		Query:    "select '2022-11-19 11:53:45' & '2023-11-11 11:53:45';",
 		Expected: []sql.Row{{uint64(2022)}},
 	},

--- a/sql/types/datetime.go
+++ b/sql/types/datetime.go
@@ -313,6 +313,7 @@ func (t datetimeType) ConvertWithoutRangeCheck(ctx context.Context, v interface{
 	}
 	switch value := v.(type) {
 	case string:
+		value = strings.Trim(value, " \t\n\r\v\f")
 		if IsZeroTimestampStr(value) {
 			return ZeroTime, nil
 		}

--- a/sql/types/datetime_test.go
+++ b/sql/types/datetime_test.go
@@ -171,6 +171,10 @@ func TestDatetimeConvert(t *testing.T) {
 		{Date, "2010-06-03T12:12:12.000012Z", time.Date(2010, 6, 3, 0, 0, 0, 0, time.UTC), false},
 		{Date, "20100603", time.Date(2010, 6, 3, 0, 0, 0, 0, time.UTC), false},
 		{Date, "20100603121212", time.Date(2010, 6, 3, 0, 0, 0, 0, time.UTC), false},
+		{Date, " 2010-06-03", time.Date(2010, 6, 3, 0, 0, 0, 0, time.UTC), false},
+		{Date, "2010-06-03 ", time.Date(2010, 6, 3, 0, 0, 0, 0, time.UTC), false},
+		{Date, " 2010-06-03 ", time.Date(2010, 6, 3, 0, 0, 0, 0, time.UTC), false},
+		{Date, "\t2010-06-03\n", time.Date(2010, 6, 3, 0, 0, 0, 0, time.UTC), false},
 
 		{DatetimeMaxPrecision, nil, nil, false},
 		{DatetimeMaxPrecision, time.Date(2012, 12, 12, 12, 12, 12, 12, time.UTC),
@@ -183,6 +187,7 @@ func TestDatetimeConvert(t *testing.T) {
 		{DatetimeMaxPrecision, "2010-6-03", time.Date(2010, 6, 3, 0, 0, 0, 0, time.UTC), false},
 		{DatetimeMaxPrecision, "2010-06-03 12:12:12", time.Date(2010, 6, 3, 12, 12, 12, 0, time.UTC), false},
 		{DatetimeMaxPrecision, "2010-06-03 12:12:12.000012", time.Date(2010, 6, 3, 12, 12, 12, 12000, time.UTC), false},
+		{DatetimeMaxPrecision, " 2010-06-03 12:12:12.000012 ", time.Date(2010, 6, 3, 12, 12, 12, 12000, time.UTC), false},
 		{DatetimeMaxPrecision, "2010-06-03T12:12:12Z", time.Date(2010, 6, 3, 12, 12, 12, 0, time.UTC), false},
 		{DatetimeMaxPrecision, "2010-06-03T12:12:12.000012Z", time.Date(2010, 6, 3, 12, 12, 12, 12000, time.UTC), false},
 		{DatetimeMaxPrecision, "20100603", time.Date(2010, 6, 3, 0, 0, 0, 0, time.UTC), false},
@@ -287,6 +292,7 @@ func TestDatetimeConvert(t *testing.T) {
 		{Date, "0000-00-00 00:00:00", time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), false},
 		{Date, "0000-00-00.00:00:00", time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), false},
 		{Date, "00-00-00", time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), false},
+		{Date, " 0000-00-00 ", time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), false},
 
 		{Date, []byte{0}, nil, true},
 


### PR DESCRIPTION
MySQL trims leading and trailing whitespace before parsing a string
literal into a `DATE`/`DATETIME`/`TIMESTAMP` value. `datetimeType.ConvertWithoutRangeCheck`
(`sql/types/datetime.go`) did not, so passing a whitespace-padded string
through `CAST(... AS DATE)` or `DATE(...)` caused every layout in
`parseDatetime`'s `time.Parse` attempts to fail, and the caller silently
converted that parse failure into `NULL` (with a `1292` warning from the
`DATE()` path).

Fixes dolthub/dolt#11414, reported by @Yibo-Dong.

```sql
SELECT CAST('2024-01-01' AS DATE) AS plain_date,
       CAST(' 2024-01-01 ' AS DATE) AS spaced_date,
       CAST(CONCAT(' ', '2024-01-01') AS DATE) AS leading_date,
       DATE(' 2024-01-01 ') AS date_func;
```

Before this change, `spaced_date`, `leading_date`, and `date_func` were
all `NULL`; MySQL returns `2024-01-01` for all four columns.

## Root cause

`ConvertWithoutRangeCheck`'s `case string:` branch (`sql/types/datetime.go`)
passed the raw string straight into `IsZeroTimestampStr` and `parseDatetime`.
None of the fixed layouts in `TimestampDatetimeLayouts` that `parseDatetime`
tries via `time.Parse` tolerate leading/trailing whitespace, so parsing
failed and `ConvertWithoutRangeCheck` returned `ErrConvertingToTime`. Both
`CAST(... AS DATE/DATETIME/TIMESTAMP)` (via `datetimeType.Convert` ->
`ConvertToTime` -> `ConvertWithoutRangeCheck`) and the `DATE()` function
(via its `getDate` helper, which calls the same `ConvertWithoutRangeCheck`)
go through this one function, so a single fix covers both.

## Fix

Trim the string at the top of the `case string:` branch, before the
zero-timestamp check and before `parseDatetime`, so downstream parsing
behaves the same as MySQL. Uses `strings.Trim(value, " \t\n\r\v\f")`
rather than `strings.TrimSpace` deliberately: MySQL's `my_isspace` only
treats ASCII whitespace as significant for this purpose, while Go's
`unicode.IsSpace` (what `TrimSpace` uses) also strips Unicode whitespace
(e.g. U+00A0 NO-BREAK SPACE) that MySQL does not trim and would reject.

## Test plan

- Added padded-string cases to the existing `TestDatetimeConvert` table
  in `sql/types/datetime_test.go`, matching the repo's own test-table
  style for this function: `Date` with leading (`" 2010-06-03"`),
  trailing (`"2010-06-03 "`), and surrounding (`" 2010-06-03 "`,
  `"\t2010-06-03\n"`) whitespace; a `DatetimeMaxPrecision` case with a
  fractional-second value padded on both sides; and a padded zero-date
  case (`" 0000-00-00 "`) to pin the trim-before-`IsZeroTimestampStr`
  ordering.
- Added an end-to-end `enginetest` query case (`enginetest/queries/queries.go`)
  reproducing the exact issue repro: `CAST(' 2024-01-01 ' AS DATE)`,
  `CAST(CONCAT(' ', '2024-01-01') AS DATE)`, and `DATE(' 2024-01-01 ')`,
  all asserting the correct (non-NULL) date.
- Verified all 6 new `TestDatetimeConvert` cases and the new `TestQueries`
  case fail without the fix, then pass with it (reverted the fix,
  confirmed 6 `--- FAIL:` lines plus the query-test failure, restored the
  fix, confirmed all pass).
  Note on the trailing-only case (`"2010-06-03 "`): the *value* MySQL
  expects is recoverable even pre-fix, because `parseDatetime`'s
  `findDatetimeEnd` loop shrinks the parse window and finds a match on
  `"2010-06-03"`. But that path also returns a non-nil `ErrTruncatedIncorrect`
  alongside the (correct) value, and the test harness's
  `require.NoError(t, err)` treats that as a failure — so this case is
  genuinely red pre-fix under the existing assertion style, not just
  wrong-by-value. Confirmed by isolating this single case against the
  pre-fix code with the real test harness (not a value-only probe).

Commands run (from a go-mysql-server worktree, `CGO_ENABLED=0`, `-tags
gms_pure_go` to avoid the icu4c/cgo regex dependency, matching how this
package already gates cgo-free builds):

```
go test -tags gms_pure_go ./sql/types/... -run TestDatetimeConvert -v
go test -tags gms_pure_go ./sql/types/... -count=1 -timeout 10m
go test -tags gms_pure_go ./enginetest/... -run "TestQueries$" -timeout 20m
gofmt -l sql/types/datetime.go sql/types/datetime_test.go enginetest/queries/queries.go
go vet -tags gms_pure_go ./sql/types/...
```

All green:

```
ok  	github.com/dolthub/go-mysql-server/sql/types	0.649s
ok  	github.com/dolthub/go-mysql-server/sql/types/jsontests	1.196s
ok  	github.com/dolthub/go-mysql-server/enginetest	12.393s
```

`gofmt` and `go vet` report no issues on the changed files.
