### PR TITLE
Update various window aggregation functions to expect the correct number of children

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -15154,6 +15154,44 @@ select * from t1 except (
 			},
 		},
 	},
+	{
+		Name: "Window aggregations with empty OVER clause",
+		SetUpScript: []string{
+			"CREATE TABLE t(id INT PRIMARY KEY, v INT);",
+			"INSERT INTO t VALUES (1,10),(2,20);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// https://github.com/dolthub/dolt/issues/11428
+				Query: "SELECT id, FIRST_VALUE(v) OVER () AS fv FROM t ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 10},
+					{2, 10},
+				},
+			},
+			{
+				Query: "SELECT id, LAST_VALUE(v) OVER () AS lv FROM t ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 20},
+					{2, 20},
+				},
+			},
+			{
+				Query: "SELECT id, LAG(v) OVER () AS l FROM t ORDER BY id;",
+				Expected: []sql.Row{
+					{1, nil},
+					{2, 10},
+				},
+			},
+			{
+				Query: "SELECT id, LEAD(v) OVER () AS l FROM t ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 20},
+					{2, nil},
+				},
+			},
+		},
+	},
 }
 
 var BrokenScriptTests = []ScriptTest{

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -766,6 +766,8 @@ func fixExprToScope(ctx *sql.Context, e sql.Expression, scopes ...*idxScope) sql
 		newScope.triggerScope = newScope.triggerScope || s.triggerScope
 		newScope.addScope(s)
 	}
+	// TODO: This causes errors to be swallowed, resulting in unexpected error or panics later down the line. But it
+	//  in same cases, we do want to swallow the error. Please see later TODOs.
 	ret, _, _ := transform.Expr(ctx, e, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 		switch e := e.(type) {
 		case *expression.GetField:

--- a/sql/expression/function/aggregation/window/first_value.go
+++ b/sql/expression/function/aggregation/window/first_value.go
@@ -122,7 +122,7 @@ func (f *FirstValue) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (f *FirstValue) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	expected := len(f.window.ToExpressions()) + 1
+	expected := f.window.ExpressionsLen() + 1
 	if len(children) != expected {
 		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), expected)
 	}

--- a/sql/expression/function/aggregation/window/first_value.go
+++ b/sql/expression/function/aggregation/window/first_value.go
@@ -122,8 +122,9 @@ func (f *FirstValue) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (f *FirstValue) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	if len(children) < 1 {
-		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 1)
+	expected := len(f.window.ToExpressions()) + 1
+	if len(children) != expected {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), expected)
 	}
 
 	nf := *f

--- a/sql/expression/function/aggregation/window/first_value.go
+++ b/sql/expression/function/aggregation/window/first_value.go
@@ -122,8 +122,8 @@ func (f *FirstValue) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (f *FirstValue) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	if len(children) < 2 {
-		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 2)
+	if len(children) < 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 1)
 	}
 
 	nf := *f

--- a/sql/expression/function/aggregation/window/lag.go
+++ b/sql/expression/function/aggregation/window/lag.go
@@ -163,8 +163,9 @@ func (l *Lag) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (l *Lag) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	if len(children) < len(l.ChildExpressions) {
-		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), len(l.ChildExpressions))
+	expected := len(l.window.ToExpressions()) + len(l.ChildExpressions)
+	if len(children) != expected {
+		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), expected)
 	}
 
 	nl := *l

--- a/sql/expression/function/aggregation/window/lag.go
+++ b/sql/expression/function/aggregation/window/lag.go
@@ -163,8 +163,8 @@ func (l *Lag) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (l *Lag) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	if len(children) < 2 {
-		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), 2)
+	if len(children) < len(l.ChildExpressions) {
+		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), len(l.ChildExpressions))
 	}
 
 	nl := *l

--- a/sql/expression/function/aggregation/window/lag.go
+++ b/sql/expression/function/aggregation/window/lag.go
@@ -163,7 +163,7 @@ func (l *Lag) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (l *Lag) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	expected := len(l.window.ToExpressions()) + len(l.ChildExpressions)
+	expected := l.window.ExpressionsLen() + len(l.ChildExpressions)
 	if len(children) != expected {
 		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), expected)
 	}

--- a/sql/expression/function/aggregation/window/last_value.go
+++ b/sql/expression/function/aggregation/window/last_value.go
@@ -122,8 +122,9 @@ func (f *LastValue) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (f *LastValue) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	if len(children) < 1 {
-		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 1)
+	expected := len(f.window.ToExpressions()) + 1
+	if len(children) != expected {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), expected)
 	}
 
 	nf := *f

--- a/sql/expression/function/aggregation/window/last_value.go
+++ b/sql/expression/function/aggregation/window/last_value.go
@@ -122,8 +122,8 @@ func (f *LastValue) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (f *LastValue) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	if len(children) < 2 {
-		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 2)
+	if len(children) < 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 1)
 	}
 
 	nf := *f

--- a/sql/expression/function/aggregation/window/last_value.go
+++ b/sql/expression/function/aggregation/window/last_value.go
@@ -122,7 +122,7 @@ func (f *LastValue) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (f *LastValue) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	expected := len(f.window.ToExpressions()) + 1
+	expected := f.window.ExpressionsLen() + 1
 	if len(children) != expected {
 		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), expected)
 	}

--- a/sql/expression/function/aggregation/window/lead.go
+++ b/sql/expression/function/aggregation/window/lead.go
@@ -162,8 +162,9 @@ func (l *Lead) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (l *Lead) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	if len(children) < len(l.ChildExpressions) {
-		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), len(l.ChildExpressions))
+	expected := len(l.window.ToExpressions()) + len(l.ChildExpressions)
+	if len(children) != expected {
+		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), expected)
 	}
 
 	nl := *l

--- a/sql/expression/function/aggregation/window/lead.go
+++ b/sql/expression/function/aggregation/window/lead.go
@@ -162,8 +162,8 @@ func (l *Lead) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (l *Lead) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	if len(children) < 2 {
-		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), 2)
+	if len(children) < len(l.ChildExpressions) {
+		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), len(l.ChildExpressions))
 	}
 
 	nl := *l

--- a/sql/expression/function/aggregation/window/lead.go
+++ b/sql/expression/function/aggregation/window/lead.go
@@ -162,7 +162,7 @@ func (l *Lead) Children() []sql.Expression {
 
 // WithChildren implements sql.Expression
 func (l *Lead) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	expected := len(l.window.ToExpressions()) + len(l.ChildExpressions)
+	expected := l.window.ExpressionsLen() + len(l.ChildExpressions)
 	if len(children) != expected {
 		return nil, sql.ErrInvalidChildrenNumber.New(l, len(children), expected)
 	}

--- a/sql/window.go
+++ b/sql/window.go
@@ -41,6 +41,10 @@ type WindowDefinition struct {
 	id          uint64
 }
 
+func (w *WindowDefinition) ExpressionsLen() int {
+	return len(w.OrderBy) + len(w.PartitionBy)
+}
+
 // ToExpressions converts the PartitionBy and OrderBy expressions to a single slice of expressions suitable for
 // manipulation by analyzer rules.
 func (w *WindowDefinition) ToExpressions() []Expression {
@@ -57,7 +61,7 @@ func (w *WindowDefinition) FromExpressions(ctx *Context, children []Expression) 
 		return nil, nil
 	}
 
-	if len(children) != len(w.OrderBy)+len(w.PartitionBy) {
+	if len(children) != w.ExpressionsLen() {
 		return nil, ErrInvalidChildrenNumber.New(w, len(children), len(w.OrderBy)+len(w.PartitionBy))
 	}
 


### PR DESCRIPTION
Fixes dolthub/dolt#11428

Some window functions were expecting the wrong number of child expressions, thus incorrectly throwing an error. However, this error was getting swallowed and going unnoticed during `fixExprToScope`, which is intentional due to errors being falsely triggered for dual tables or subqueries but does lead to unintentional consequences. As a result, child expressions were not getting properly updated during `fixExprToScope`, leading to a panic.

This PR updates `WithChildren` for those window functions to expect the correct number of children.