### PR TITLE
Bump jsonpath and add new test for parsing JSON null.

### DIFF
--- a/enginetest/queries/json_table_queries.go
+++ b/enginetest/queries/json_table_queries.go
@@ -25,6 +25,18 @@ var JSONTableQueryTests = []QueryTest{
 		Expected: []sql.Row{},
 	},
 	{
+		Query:    "SELECT * FROM JSON_TABLE('null','$[*]' COLUMNS(x int path '$.a')) as t;",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT * FROM JSON_TABLE('null','$.b' COLUMNS(x int path '$.a')) as t;",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT * FROM JSON_TABLE('null','$' COLUMNS(x int path '$.a')) as t;",
+		Expected: []sql.Row{{nil}},
+	},
+	{
 		Query:    "SELECT * FROM JSON_TABLE('{}','$[*]' COLUMNS(x int path '$.a')) as t;",
 		Expected: []sql.Row{},
 	},

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/cockroachdb/apd/v3 v3.2.3
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 	github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83
-	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
+	github.com/dolthub/jsonpath v0.0.2-0.20260807003725-336cd89c1c76
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
 	github.com/dolthub/vitess v0.0.0-20260728212736-0542037326d7
 	github.com/go-sql-driver/mysql v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83 h1:FEMjCGEroD
 github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTEtT5tOBsCuCrlYnLRKpbJVJkDbrTRhwQ=
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
+github.com/dolthub/jsonpath v0.0.2-0.20260807003725-336cd89c1c76 h1:ZmLDDKnfbWc8VtOU/peSnUmUW8Z/Y6FEz4es6iCALvQ=
+github.com/dolthub/jsonpath v0.0.2-0.20260807003725-336cd89c1c76/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216 h1:JWkKRE4EHUcEVQCMRBej8DYxjYjRz/9MdF/NNQh0o70=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216/go.mod h1:e/FIZVvT2IR53HBCAo41NjqgtEnjMJGKca3Y/dAmZaA=
 github.com/dolthub/vitess v0.0.0-20260624214226-81d034e0fde8 h1:zmKLyRCTiNZnizO++sNXP1QW2bxLE2Y+WJAdu/hcu6s=


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/11394

Our jsonpath dependency wasn't properly parsing paths when the input object was a JSON null value.