### PR TITLE
fix: GROUP_CONCAT concatenates all expressions per row

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4298,6 +4298,12 @@ CREATE TABLE tab3 (
 
 			"create table nulls(pk int)",
 			"INSERT INTO nulls VALUES (NULL)",
+
+			// multi-expression GROUP_CONCAT (dolthub/dolt#11427)
+			"CREATE TABLE t_multi(id INT PRIMARY KEY, a VARCHAR(10), b VARCHAR(10))",
+			"INSERT INTO t_multi VALUES (1,'x','1'),(2,'y','2')",
+			"CREATE TABLE t_multi_null(id INT PRIMARY KEY, a VARCHAR(10), b VARCHAR(10))",
+			"INSERT INTO t_multi_null VALUES (1,'x','1'),(2,'y',NULL),(3,'z','3')",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -4375,6 +4381,24 @@ CREATE TABLE tab3 (
 			{
 				Query:    "SELECT group_concat(attribute order by attribute separator '') FROM t WHERE o_id=2 ORDER BY attribute",
 				Expected: []sql.Row{{"colorfabric"}},
+			},
+			// multi-expression GROUP_CONCAT (dolthub/dolt#11427): concatenate all exprs per row
+			{
+				Query:    `SELECT GROUP_CONCAT(a,b ORDER BY id SEPARATOR '|') AS gc FROM t_multi;`,
+				Expected: []sql.Row{{"x1|y2"}},
+			},
+			{
+				Query:    `SELECT GROUP_CONCAT(a,b ORDER BY id) AS gc FROM t_multi;`,
+				Expected: []sql.Row{{"x1,y2"}},
+			},
+			{
+				Query:    `SELECT GROUP_CONCAT(a,b,a ORDER BY id SEPARATOR '|') AS gc FROM t_multi;`,
+				Expected: []sql.Row{{"x1x|y2y"}},
+			},
+			// any NULL expression skips the row (MySQL CONCAT semantics)
+			{
+				Query:    `SELECT GROUP_CONCAT(a,b ORDER BY id SEPARATOR '|') AS gc FROM t_multi_null;`,
+				Expected: []sql.Row{{"x1|z3"}},
 			},
 		},
 	},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4382,7 +4382,6 @@ CREATE TABLE tab3 (
 				Query:    "SELECT group_concat(attribute order by attribute separator '') FROM t WHERE o_id=2 ORDER BY attribute",
 				Expected: []sql.Row{{"colorfabric"}},
 			},
-			// multi-expression GROUP_CONCAT (dolthub/dolt#11427): concatenate all exprs per row
 			{
 				Query:    `SELECT GROUP_CONCAT(a,b ORDER BY id SEPARATOR '|') AS gc FROM t_multi;`,
 				Expected: []sql.Row{{"x1|y2"}},
@@ -4395,7 +4394,6 @@ CREATE TABLE tab3 (
 				Query:    `SELECT GROUP_CONCAT(a,b,a ORDER BY id SEPARATOR '|') AS gc FROM t_multi;`,
 				Expected: []sql.Row{{"x1x|y2y"}},
 			},
-			// any NULL expression skips the row (MySQL CONCAT semantics)
 			{
 				Query:    `SELECT GROUP_CONCAT(a,b ORDER BY id SEPARATOR '|') AS gc FROM t_multi_null;`,
 				Expected: []sql.Row{{"x1|z3"}},

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -260,6 +260,12 @@ func (g *groupConcatBuffer) Update(ctx *sql.Context, originalRow sql.Row) error 
 	if skip {
 		return nil
 	}
+	// Aggregate path historically skipped empty-string concatenations. Keep that
+	// pre-existing behavior here (not in the shared helper) so the window path
+	// can include empty strings, matching MySQL / the old filterToDistinct path.
+	if len(vs) == 0 {
+		return nil
+	}
 
 	// Get the current array of rows and the map
 	// Check if distinct is active if so look at and update our map
@@ -355,6 +361,11 @@ func evalExprs(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (sql.Row, 
 // evalSelectExprsForGroupConcat evaluates GROUP_CONCAT select expressions for one
 // input row. MySQL concatenates every expression per row (same as CONCAT). If any
 // expression is NULL, the row is skipped (https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html#function_group-concat).
+//
+// skip is true only for NULL contributions or when there are no select expressions.
+// Empty-string results are returned with skip=false so callers can decide:
+// the aggregate Update path skips them (pre-existing), while the window path
+// includes them (MySQL / historical window behavior).
 func evalSelectExprsForGroupConcat(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (string, sql.Type, bool, error) {
 	if len(exprs) == 0 {
 		return "", types.Text, true, nil
@@ -396,9 +407,5 @@ func evalSelectExprsForGroupConcat(ctx *sql.Context, exprs []sql.Expression, row
 		}
 	}
 
-	vs := sb.String()
-	if len(vs) == 0 {
-		return "", retType, true, nil
-	}
-	return vs, retType, false, nil
+	return sb.String(), retType, false, nil
 }

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -252,56 +252,13 @@ type groupConcatBuffer struct {
 
 // Update implements the AggregationBuffer interface.
 func (g *groupConcatBuffer) Update(ctx *sql.Context, originalRow sql.Row) error {
-	evalRow, retType, err := evalExprs(ctx, g.gc.selectExprs, originalRow)
+	vs, retType, skip, err := evalSelectExprsForGroupConcat(ctx, g.gc.selectExprs, originalRow)
 	if err != nil {
 		return err
 	}
-
 	g.gc.returnType = retType
-
-	// Skip if this is a null row
-	if evalRow == nil {
+	if skip {
 		return nil
-	}
-
-	var v interface{}
-	var vs string
-	if types.IsBlobType(retType) {
-		v, _, err = types.Blob.Convert(ctx, evalRow[0])
-		if err != nil {
-			return err
-		}
-		vb, _, err := sql.Unwrap[[]byte](ctx, v)
-		if err != nil {
-			return err
-		}
-		vs = string(vb)
-		if len(vs) == 0 {
-			return nil
-		}
-	} else {
-		// Use type-aware conversion for enum types
-		if len(g.gc.selectExprs) > 0 {
-			vs, _, err = types.ConvertToCollatedString(ctx, evalRow[0], g.gc.selectExprs[0].Type(ctx))
-			if err != nil {
-				return err
-			}
-			if vs == "" {
-				return nil
-			}
-		} else {
-			v, _, err = types.LongText.Convert(ctx, evalRow[0])
-			if err != nil {
-				return err
-			}
-			if v == nil {
-				return nil
-			}
-			vs, _, err = sql.Unwrap[string](ctx, v)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	// Get the current array of rows and the map
@@ -393,4 +350,55 @@ func evalExprs(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (sql.Row, 
 	}
 
 	return result, retType, nil
+}
+
+// evalSelectExprsForGroupConcat evaluates GROUP_CONCAT select expressions for one
+// input row. MySQL concatenates every expression per row (same as CONCAT). If any
+// expression is NULL, the row is skipped (https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html#function_group-concat).
+func evalSelectExprsForGroupConcat(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (string, sql.Type, bool, error) {
+	if len(exprs) == 0 {
+		return "", types.Text, true, nil
+	}
+
+	evalRow, retType, err := evalExprs(ctx, exprs, row)
+	if err != nil {
+		return "", nil, false, err
+	}
+
+	// Any NULL expression skips the row contribution (CONCAT semantics).
+	for _, v := range evalRow {
+		if v == nil {
+			return "", retType, true, nil
+		}
+	}
+
+	var sb strings.Builder
+	if types.IsBlobType(retType) {
+		for _, v := range evalRow {
+			converted, _, err := types.Blob.Convert(ctx, v)
+			if err != nil {
+				return "", nil, false, err
+			}
+			vb, _, err := sql.Unwrap[[]byte](ctx, converted)
+			if err != nil {
+				return "", nil, false, err
+			}
+			sb.Write(vb)
+		}
+	} else {
+		for i, v := range evalRow {
+			// Use type-aware conversion for enum types
+			part, _, err := types.ConvertToCollatedString(ctx, v, exprs[i].Type(ctx))
+			if err != nil {
+				return "", nil, false, err
+			}
+			sb.WriteString(part)
+		}
+	}
+
+	vs := sb.String()
+	if len(vs) == 0 {
+		return "", retType, true, nil
+	}
+	return vs, retType, false, nil
 }

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -260,9 +260,7 @@ func (g *groupConcatBuffer) Update(ctx *sql.Context, originalRow sql.Row) error 
 	if skip {
 		return nil
 	}
-	// Aggregate path historically skipped empty-string concatenations. Keep that
-	// pre-existing behavior here (not in the shared helper) so the window path
-	// can include empty strings, matching MySQL / the old filterToDistinct path.
+	// Aggregate path skips empty strings (window path includes them; MySQL-aligned).
 	if len(vs) == 0 {
 		return nil
 	}
@@ -358,14 +356,8 @@ func evalExprs(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (sql.Row, 
 	return result, retType, nil
 }
 
-// evalSelectExprsForGroupConcat evaluates GROUP_CONCAT select expressions for one
-// input row. MySQL concatenates every expression per row (same as CONCAT). If any
-// expression is NULL, the row is skipped (https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html#function_group-concat).
-//
-// skip is true only for NULL contributions or when there are no select expressions.
-// Empty-string results are returned with skip=false so callers can decide:
-// the aggregate Update path skips them (pre-existing), while the window path
-// includes them (MySQL / historical window behavior).
+// evalSelectExprsForGroupConcat: MySQL multi-expr CONCAT per row; NULL skips (https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html#function_group-concat).
+// skip only for NULL/no-exprs; empty strings returned so callers decide.
 func evalSelectExprsForGroupConcat(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (string, sql.Type, bool, error) {
 	if len(exprs) == 0 {
 		return "", types.Text, true, nil
@@ -376,7 +368,6 @@ func evalSelectExprsForGroupConcat(ctx *sql.Context, exprs []sql.Expression, row
 		return "", nil, false, err
 	}
 
-	// Any NULL expression skips the row contribution (CONCAT semantics).
 	for _, v := range evalRow {
 		if v == nil {
 			return "", retType, true, nil

--- a/sql/expression/function/aggregation/group_concat_test.go
+++ b/sql/expression/function/aggregation/group_concat_test.go
@@ -73,6 +73,57 @@ func TestGroupConcat_PastMaxLen(t *testing.T) {
 	require.Equal(t, int(maxLen), len(rs))
 }
 
+// Validates multi-expression GROUP_CONCAT concatenates all exprs per row (MySQL parity).
+// See dolthub/dolt#11427.
+func TestGroupConcat_MultipleExpressions(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	// GROUP_CONCAT(a, b ORDER BY id SEPARATOR '|') over rows (x,1), (y,2) => "x1|y2"
+	gc := NewGroupConcat(
+		"",
+		nil,
+		"|",
+		[]sql.Expression{
+			expression.NewGetField(1, types.LongText, "a", true),
+			expression.NewGetField(2, types.LongText, "b", true),
+		},
+		1024,
+	)
+	buf, err := gc.NewBuffer(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, buf.Update(ctx, sql.Row{int64(1), "x", "1"}))
+	require.NoError(t, buf.Update(ctx, sql.Row{int64(2), "y", "2"}))
+
+	result, err := buf.Eval(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "x1|y2", result)
+}
+
+// Validates a NULL in any expression skips that row (CONCAT / MySQL semantics).
+func TestGroupConcat_MultipleExpressionsNullSkipped(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	gc := NewGroupConcat(
+		"",
+		nil,
+		"|",
+		[]sql.Expression{
+			expression.NewGetField(1, types.LongText, "a", true),
+			expression.NewGetField(2, types.LongText, "b", true),
+		},
+		1024,
+	)
+	buf, err := gc.NewBuffer(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, buf.Update(ctx, sql.Row{int64(1), "x", "1"}))
+	require.NoError(t, buf.Update(ctx, sql.Row{int64(2), "y", nil}))
+	require.NoError(t, buf.Update(ctx, sql.Row{int64(3), "z", "3"}))
+
+	result, err := buf.Eval(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "x1|z3", result)
+}
+
 // Validate that group_concat returns the correct return type
 func TestGroupConcat_ReturnType(t *testing.T) {
 	ctx := sql.NewEmptyContext()

--- a/sql/expression/function/aggregation/group_concat_test.go
+++ b/sql/expression/function/aggregation/group_concat_test.go
@@ -124,6 +124,57 @@ func TestGroupConcat_MultipleExpressionsNullSkipped(t *testing.T) {
 	require.Equal(t, "x1|z3", result)
 }
 
+// Aggregate Update path historically skips empty-string concatenations.
+func TestGroupConcat_AggregateSkipsEmptyString(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	gc := NewGroupConcat(
+		"",
+		nil,
+		"|",
+		[]sql.Expression{
+			expression.NewGetField(1, types.LongText, "a", true),
+		},
+		1024,
+	)
+	buf, err := gc.NewBuffer(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, buf.Update(ctx, sql.Row{int64(1), "x"}))
+	require.NoError(t, buf.Update(ctx, sql.Row{int64(2), ""}))
+	require.NoError(t, buf.Update(ctx, sql.Row{int64(3), "z"}))
+
+	result, err := buf.Eval(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "x|z", result)
+}
+
+// Window path includes empty-string contributions (MySQL + historical
+// filterToDistinct behavior). Regression guard for the shared-helper refactor.
+func TestGroupConcat_WindowIncludesEmptyString(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	gc := NewGroupConcat(
+		"",
+		nil,
+		"|",
+		[]sql.Expression{
+			expression.NewGetField(1, types.LongText, "a", true),
+		},
+		1024,
+	)
+	agg := NewGroupConcatAgg(gc)
+	rows := sql.WindowBuffer{
+		sql.Row{int64(1), "x"},
+		sql.Row{int64(2), ""},
+		sql.Row{int64(3), "z"},
+	}
+	interval := sql.WindowInterval{Start: 0, End: len(rows)}
+	require.NoError(t, agg.StartPartition(ctx, interval, rows))
+	result, err := agg.Compute(ctx, interval, rows)
+	require.NoError(t, err)
+	// Empty string sits between separators: "x||z"
+	require.Equal(t, "x||z", result)
+}
+
 // Validate that group_concat returns the correct return type
 func TestGroupConcat_ReturnType(t *testing.T) {
 	ctx := sql.NewEmptyContext()

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -944,34 +944,15 @@ func (a *GroupConcatAgg) filterToDistinct(ctx *sql.Context, buf sql.WindowBuffer
 	rows := make([]sql.Row, 0)
 	distinct := make(map[string]struct{}, 0)
 	for _, row := range buf {
-		evalRow, retType, err := evalExprs(ctx, a.gc.selectExprs, row)
+		vs, retType, skip, err := evalSelectExprsForGroupConcat(ctx, a.gc.selectExprs, row)
 		if err != nil {
 			return nil, nil, err
 		}
 
 		a.gc.returnType = retType
-
-		// Skip if this is a null row
-		if evalRow == nil {
+		if skip {
 			continue
 		}
-
-		var v interface{}
-		if retType == types.Blob {
-			v, _, err = types.Blob.Convert(ctx, evalRow[0])
-		} else {
-			v, _, err = types.LongText.Convert(ctx, evalRow[0])
-		}
-
-		if err != nil {
-			return nil, nil, err
-		}
-
-		if v == nil {
-			continue
-		}
-
-		vs := v.(string)
 
 		// Get the current array of rows and the map
 		// Check if distinct is active if so look at and update our map


### PR DESCRIPTION
MySQL concatenates every expression for each row in
`GROUP_CONCAT(expr1, expr2, ...)` before applying the row separator. The
aggregate only used the first expression, so:

```sql
CREATE TABLE t(id INT PRIMARY KEY, a VARCHAR(10), b VARCHAR(10));
INSERT INTO t VALUES (1,'x','1'),(2,'y','2');
SELECT GROUP_CONCAT(a,b ORDER BY id SEPARATOR '|') AS gc FROM t;
```

returned `x|y` instead of MySQL's `x1|y2`.

Reported by @Yibo-Dong in dolthub/dolt#11427.

## Root cause

`groupConcatBuffer.Update` (and the window-function path
`GroupConcatAgg.filterToDistinct`) evaluated all select expressions via
`evalExprs`, then converted only `evalRow[0]` to the string that was
stored for later separator joining.

## Fix

Shared helper `evalSelectExprsForGroupConcat` concatenates every
expression per row (same semantics as `CONCAT`). If any expression is
`NULL`, the row is skipped, matching MySQL docs:

https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html#function_group-concat

(`NULL` values are omitted from the result; multi-arg form follows
`CONCAT`, so any NULL arg drops the whole row contribution.)

Empty-string skip is intentionally **not** in the shared helper: the
aggregate `Update` path keeps its pre-existing empty-string skip; the
window path includes empty strings (MySQL + historical
`filterToDistinct` behavior).

## Behavior notes

- **Blob detection (window path):** widened from `retType == types.Blob`
  to `types.IsBlobType(retType)` so blob subtypes are handled consistently.
- **Non-blob conversion:** uses `ConvertToCollatedString`, so ENUM values
  render as labels in window `GROUP_CONCAT` (not numeric ordinals).
- **Latent panic fix:** the old window blob branch did `v.(string)` on
  `[]byte`, which would panic; the refactor uses proper blob conversion.
- **Empty-string skip (aggregate path only):** pre-existing on the
  aggregate `Update` path — not introduced by this change — and arguably
  non-MySQL (MySQL includes empty strings). Left unchanged to minimize
  behavior churn; possible maintainer follow-up.
- **Window path empty strings:** included (regression fixed in r2). Unit
  test: `TestGroupConcat_WindowIncludesEmptyString`.
- **DISTINCT keys:** keyed on the full concatenated string, matching
  MySQL DISTINCT-on-result semantics. Note that multi-expr pairs such as
  `('a','bc')` and `('ab','c')` produce the same key (`abc`) and collide —
  flagged for maintainer attention.

## Test plan

- Unit tests:
  - `TestGroupConcat_MultipleExpressions` → `"x1|y2"`
  - `TestGroupConcat_MultipleExpressionsNullSkipped` → `"x1|z3"`
  - `TestGroupConcat_AggregateSkipsEmptyString` → `"x|z"`
  - `TestGroupConcat_WindowIncludesEmptyString` → `"x||z"`
- Enginetest (`Group Concat Queries` + full `TestScripts`):
  - multi-expr + custom separator
  - multi-expr default separator
  - three expressions
  - NULL in second expression skips that row
- Commands (ICU cgo env as needed for this machine):

```
go test ./sql/expression/function/aggregation/... -count=1
go test ./enginetest/ -count=1 -run TestScripts
gofmt -l sql/expression/function/aggregation/group_concat.go \
  sql/expression/function/aggregation/window_functions.go \
  sql/expression/function/aggregation/group_concat_test.go
```

All green.

Note: after merge, dolthub/dolt#11427 remains open until Dolt bumps its
go-mysql-server pin.
