### PR TITLE
fix LOCATE to return character positions on multibyte strings

### DIFF
--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -1944,6 +1944,18 @@ var FunctionQueryTests = []QueryTest{
 		Expected: []sql.Row{{0}},
 	},
 	{
+		Query:    "select locate('ب', 'ااااب'), char_length('ااااب');",
+		Expected: []sql.Row{{5, 5}},
+	},
+	{
+		Query:    "select locate('a', 'ééa', 2);",
+		Expected: []sql.Row{{3}},
+	},
+	{
+		Query:    "select locate('e', 'café xe');",
+		Expected: []sql.Row{{7}},
+	},
+	{
 		Query: "select find_in_set('second row', s) from mytable;",
 		Expected: []sql.Row{
 			{0},

--- a/sql/expression/function/locate.go
+++ b/sql/expression/function/locate.go
@@ -17,15 +17,18 @@ package function
 import (
 	"fmt"
 	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/dolthub/vitess/go/sqltypes"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
-// Locate returns the position of the first occurrence of a substring in a string.
-// If the substring is not found within the original string, this function returns 0.
-// This function performs a case-insensitive search.
+// Locate returns the 1-based character position of the first occurrence of a
+// substring in a string, or 0 if not found. Positions are character-based.
 type Locate struct {
 	expression.NaryExpression
 }
@@ -87,6 +90,29 @@ func (l *Locate) DebugString(ctx *sql.Context) string {
 		return fmt.Sprintf("%s(%s,%s,%s)", l.FunctionName(), sql.DebugString(ctx, l.ChildExpressions[0]), sql.DebugString(ctx, l.ChildExpressions[1]), sql.DebugString(ctx, l.ChildExpressions[2]))
 	}
 	return ""
+}
+
+// isBinaryStringType is true for BINARY, VARBINARY, and BLOB only.
+// types.IsBinaryType also matches JSON/GEOMETRY/VECTOR, which LOCATE must fold.
+func isBinaryStringType(t sql.Type) bool {
+	if t == nil {
+		return false
+	}
+	switch t.Type() {
+	case sqltypes.Binary, sqltypes.VarBinary, sqltypes.Blob:
+		return true
+	default:
+		return false
+	}
+}
+
+func isAllASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
 }
 
 // Eval implements the sql.Expression interface.
@@ -162,22 +188,60 @@ func (l *Locate) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		}
 	}
 
-	// Edge cases that cannot be handled by strings.Index.
-	switch {
-	// Position 0 and negative positions don't exist.
-	case position <= 0 || (len(str) > 0 && position > len(str)):
-		return int32(0), nil
-	// Locate("", "") returns 1 if start is 1.
-	case len(substr) == 0 && len(str) == 0:
-		if position == 1 {
-			return int32(1), nil
+	caseSensitive := isBinaryStringType(l.ChildExpressions[0].Type(ctx)) ||
+		isBinaryStringType(l.ChildExpressions[1].Type(ctx))
+
+	// Fast path when every byte is a single character.
+	if isAllASCII(str) && isAllASCII(substr) {
+		switch {
+		case position <= 0 || position > len(str)+1:
+			return int32(0), nil
+		case len(substr) == 0:
+			return int32(position), nil
 		}
-		return int32(0), nil
+
+		haystack := str[position-1:]
+		needle := substr
+		if !caseSensitive {
+			haystack = strings.ToLower(haystack)
+			needle = strings.ToLower(needle)
+		}
+		res := strings.Index(haystack, needle)
+		if res == -1 {
+			return int32(0), nil
+		}
+		return int32(res + position), nil
 	}
 
-	res := strings.Index(strings.ToLower(str[position-1:]), strings.ToLower(substr))
+	strRunes := []rune(str)
+	substrRunes := []rune(substr)
+
+	// Out of range, or empty needle at a valid start (including len+1).
+	switch {
+	case position <= 0 || position > len(strRunes)+1:
+		return int32(0), nil
+	case len(substrRunes) == 0:
+		return int32(position), nil
+	}
+
+	haystack := strRunes[position-1:]
+	needle := substrRunes
+	if !caseSensitive {
+		haystack = runesToLower(haystack)
+		needle = runesToLower(needle)
+	}
+
+	res := findSubsequence(haystack, needle)
 	if res == -1 {
 		return int32(0), nil
 	}
-	return int32(res + position), nil
+	return int32(res + int64(position)), nil
+}
+
+func runesToLower(rs []rune) []rune {
+	out := make([]rune, len(rs))
+	for i, r := range rs {
+		out[i] = unicode.ToLower(r)
+	}
+	return out
 }

--- a/sql/expression/function/locate_test.go
+++ b/sql/expression/function/locate_test.go
@@ -17,6 +17,7 @@ package function
 import (
 	"testing"
 
+	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -96,9 +97,10 @@ func TestLocate(t *testing.T) {
 			Expected: 1,
 		},
 		{
-			Name:     "locate empty substring",
+			Name:     "locate empty substring start 1",
 			Substr:   "",
 			Str:      "locate",
+			Start:    intPtr(1),
 			Expected: 1,
 		},
 		{
@@ -112,6 +114,87 @@ func TestLocate(t *testing.T) {
 			Substr:   "",
 			Str:      "",
 			Start:    intPtr(2),
+			Expected: 0,
+		},
+		// #3649 multibyte positions
+		{
+			Name:     "locate arabic character position",
+			Substr:   "ب",
+			Str:      "ااااب",
+			Expected: 5,
+		},
+		{
+			Name:     "locate multi-char multibyte needle",
+			Substr:   "اب",
+			Str:      "ااااب",
+			Expected: 4,
+		},
+		{
+			Name:     "locate start counted in characters not bytes",
+			Substr:   "a",
+			Str:      "ééa",
+			Start:    intPtr(2),
+			Expected: 3,
+		},
+		{
+			Name:     "locate cafe character position",
+			Substr:   "e",
+			Str:      "café xe",
+			Expected: 7,
+		},
+		{
+			Name:     "locate empty substr with start on multibyte",
+			Substr:   "",
+			Str:      "ااااب",
+			Start:    intPtr(3),
+			Expected: 3,
+		},
+		{
+			Name:     "locate start past character length",
+			Substr:   "ب",
+			Str:      "ااااب",
+			Start:    intPtr(6),
+			Expected: 0,
+		},
+		{
+			Name:     "locate cross multibyte case fold",
+			Substr:   "É",
+			Str:      "xyzé",
+			Expected: 4,
+		},
+		{
+			Name:     "locate needle in empty with start past end",
+			Substr:   "a",
+			Str:      "",
+			Start:    intPtr(2),
+			Expected: 0,
+		},
+		{
+			Name:     "locate empty needle at len+1",
+			Substr:   "",
+			Str:      "abc",
+			Start:    intPtr(4),
+			Expected: 4,
+		},
+		{
+			Name:     "locate empty needle past len+1",
+			Substr:   "",
+			Str:      "abc",
+			Start:    intPtr(5),
+			Expected: 0,
+		},
+		{
+			Name:     "locate empty empty position 1",
+			Substr:   "",
+			Str:      "",
+			Start:    intPtr(1),
+			Expected: 1,
+		},
+		{
+			Name:     "locate non-empty start past end no match",
+			Substr:   "x",
+			Str:      "abc",
+			Start:    intPtr(4),
 			Expected: 0,
 		},
 	}
@@ -139,4 +222,95 @@ func TestLocate(t *testing.T) {
 			require.Equal(tt.Expected, result)
 		})
 	}
+}
+
+func TestLocateBinaryCaseSensitive(t *testing.T) {
+	require := require.New(t)
+	ctx := sql.NewEmptyContext()
+
+	f, err := NewLocate(ctx,
+		expression.NewGetField(0, types.Text, "substr", false),
+		expression.NewGetField(1, types.Blob, "str", false),
+	)
+	require.NoError(err)
+	result, err := f.Eval(ctx, sql.Row{"A", "xyza"})
+	require.NoError(err)
+	require.Equal(int32(0), result)
+
+	f, err = NewLocate(ctx,
+		expression.NewGetField(0, types.Text, "substr", false),
+		expression.NewGetField(1, types.LongText, "str", false),
+	)
+	require.NoError(err)
+	result, err = f.Eval(ctx, sql.Row{"A", "xyza"})
+	require.NoError(err)
+	require.Equal(int32(4), result)
+
+	f, err = NewLocate(ctx,
+		expression.NewGetField(0, types.Text, "substr", false),
+		expression.NewGetField(1, types.Blob, "str", false),
+	)
+	require.NoError(err)
+	result, err = f.Eval(ctx, sql.Row{"a", "xyza"})
+	require.NoError(err)
+	require.Equal(int32(4), result)
+
+	// binary needle
+	f, err = NewLocate(ctx,
+		expression.NewGetField(0, types.Blob, "substr", false),
+		expression.NewGetField(1, types.LongText, "str", false),
+	)
+	require.NoError(err)
+	result, err = f.Eval(ctx, sql.Row{"A", "xyza"})
+	require.NoError(err)
+	require.Equal(int32(0), result)
+
+	// 3-arg + binary haystack
+	f, err = NewLocate(ctx,
+		expression.NewGetField(0, types.Text, "substr", false),
+		expression.NewGetField(1, types.Blob, "str", false),
+		expression.NewGetField(2, types.Int32, "start", false),
+	)
+	require.NoError(err)
+	result, err = f.Eval(ctx, sql.Row{"a", "xyza", 3})
+	require.NoError(err)
+	require.Equal(int32(4), result)
+	result, err = f.Eval(ctx, sql.Row{"A", "xyza", 1})
+	require.NoError(err)
+	require.Equal(int32(0), result)
+
+	binType := types.MustCreateBinary(sqltypes.Binary, 4)
+	f, err = NewLocate(ctx,
+		expression.NewGetField(0, types.Text, "substr", false),
+		expression.NewGetField(1, binType, "str", false),
+	)
+	require.NoError(err)
+	result, err = f.Eval(ctx, sql.Row{"A", "xyza"})
+	require.NoError(err)
+	require.Equal(int32(0), result)
+
+	varbinType := types.MustCreateBinary(sqltypes.VarBinary, 16)
+	f, err = NewLocate(ctx,
+		expression.NewGetField(0, varbinType, "substr", false),
+		expression.NewGetField(1, types.LongText, "str", false),
+	)
+	require.NoError(err)
+	result, err = f.Eval(ctx, sql.Row{"A", "xyza"})
+	require.NoError(err)
+	require.Equal(int32(0), result)
+}
+
+func TestLocateJSONCaseInsensitive(t *testing.T) {
+	// JSON is not a binary string type; search stays case-insensitive.
+	require := require.New(t)
+	ctx := sql.NewEmptyContext()
+
+	f, err := NewLocate(ctx,
+		expression.NewGetField(0, types.Text, "substr", false),
+		expression.NewGetField(1, types.JSON, "str", false),
+	)
+	require.NoError(err)
+	result, err := f.Eval(ctx, sql.Row{"A", "xyza"})
+	require.NoError(err)
+	require.Equal(int32(4), result)
 }


### PR DESCRIPTION
Fixes #3649

## Summary

`LOCATE()` was returning **byte offsets** instead of **character positions** on multibyte strings, and treated the optional start argument as a byte index (which can slice mid-rune). MySQL defines LOCATE as multibyte-safe: positions are counted in characters.

Reported by @LaPingvino with a clear repro and root-cause analysis (byte `strings.Index` + unconditional case folding). Credit for the semantics matrix (character positions, simple case fold for nonbinary args only, no full collation-weight search) goes to that write-up.

## Changes

- `sql/expression/function/locate.go`: convert haystack/needle to `[]rune`, count start and return values in characters, reuse the package's `findSubsequence` scanner, and apply simple case folding (`unicode.ToLower` per rune) only when neither argument is BINARY/VARBINARY/BLOB.
- ASCII fast path keeps `strings.Index` when both arguments are all-ASCII (bytes == characters), so common-case performance stays near the old path.
- Bounds guard: `start <= 0 || start > len+1` returns 0, which also fixes a pre-existing panic on `LOCATE('a','',2)` (base panics the same way — verified) and restores MySQL empty-needle parity for `LOCATE('','abc',4) → 4`.
- Unit tests for Arabic, multi-char multibyte needle, accented start-position, café, cross-multibyte case fold, empty-substr-on-multibyte, start past char length, BINARY/VARBINARY needle and haystack (including 3-arg), JSON still case-insensitive, and the bounds-guard cases above.
- Enginetest query rows covering the issue repro cases.

## Behavior change (deliberate)

The old code case-folded **unconditionally**, so `LOCATE` was case-insensitive even for binary arguments. This PR makes the search **case-sensitive when either argument is BINARY, VARBINARY, or BLOB**, matching MySQL — see the `LOCATE('A', BINARY 'xyza')` row below. Nonbinary behavior is unchanged (still case-insensitive). JSON/GEOMETRY/VECTOR are **not** treated as binary for this check (MySQL coerces JSON to a utf8mb4 string and folds).

## Test plan

- [x] `go test ./sql/expression/function/ -run TestLocate -count=1` — pass (all existing + new cases)
- [x] `go test ./sql/expression/function/... -count=1` — pass
- [x] `go test ./enginetest/... -count=1` — pass (enginetest ~47.6s; mysql_harness + scriptgen/setup also ok)

## Limitations / out of scope

- **Unicode normalization:** rune equality does no normalization, so a precomposed `é` needle does not match an NFD `e`+U+0301 haystack (verified: returns 0 vs 4 for precomposed-both); same class as other non-normalizing paths in the engine.
- **INSTR** is intentionally untouched (`#3650` covers separate INSTR defects).
- **Collation weights:** MySQL's `Item_func_locate` searches via collation weights, so under `utf8mb4_0900_ai_ci` MySQL can match accent-insensitively (e.g. `LOCATE('e','café')` → 4). GMS `LOCATE` is **not** collation-aware before or after this patch; simple rune folding is an approximation. Under GMS default `utf8mb4_0900_bin` (`sql/collations.go`) that means this path tends to **over-match** relative to a true weight search rather than under-match. `utf8mb4_bin` (case-sensitive nonbinary collation) still folds here — a pre-existing engine-wide limitation, not introduced by this change.
- Exotic per-collation case maps (Turkish İ, etc.) may still diverge from MySQL's collation tables in edge cases, same class of difference as other simple-fold paths in the engine.

## Before / after (issue repro)

| Query | Before (bug) | After (this PR) | MySQL |
|---|---|---|---|
| `LOCATE('ب','ااااب')` | 9 | **5** | 5 |
| `LOCATE('a','ééa',2)` | 7 (mid-rune slice risk) | **3** | 3 |
| `LOCATE('e','café xe')` | 8 | **7** | 7 |
| `LOCATE('A','xyza')` | 4 | 4 | 4 |
| `LOCATE('A', BINARY 'xyza')` | 4 (wrong fold) | **0** | 0 |
| `LOCATE('','abc',4)` | 0 (and base panics on some empty-haystack starts) | **4** | 4 |
