### PR TITLE
Fix ambiguous error for repeated window expressions in ORDER BY

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -15192,6 +15192,172 @@ select * from t1 except (
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/11418
+		Name: "repeated window expression in ORDER BY is not ambiguous",
+		SetUpScript: []string{
+			"CREATE TABLE t(id INT PRIMARY KEY, g INT, v INT NOT NULL);",
+			"INSERT INTO t VALUES (1, 0, 10), (2, 0, -2);",
+			"CREATE TABLE u(id INT PRIMARY KEY, g INT, v INT NOT NULL);",
+			"INSERT INTO u VALUES (1, 0, 100), (2, 0, 200);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `
+SELECT id, g,
+       SUM(v) OVER (
+         PARTITION BY g ORDER BY id ASC
+         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+       ) AS wf
+FROM t
+ORDER BY SUM(v) OVER (
+           PARTITION BY g ORDER BY id ASC
+           ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+         ), id;`,
+				Expected: []sql.Row{
+					{2, 0, float64(8)},
+					{1, 0, float64(10)},
+				},
+			},
+			{
+				Query: `
+SELECT id, g,
+       SUM(v) OVER (
+         PARTITION BY g ORDER BY id ASC
+         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+       ) AS wf
+FROM t
+ORDER BY wf, id;`,
+				Expected: []sql.Row{
+					{2, 0, float64(8)},
+					{1, 0, float64(10)},
+				},
+			},
+			// Cross-scope: identical window text in outer query and subquery must
+			// compute independently (different tables).
+			{
+				Query: `
+SELECT SUM(o.v) OVER (PARTITION BY o.g) AS a,
+       (SELECT SUM(o.v) OVER (PARTITION BY o.g) FROM u o LIMIT 1) AS s
+FROM t o
+ORDER BY a;`,
+				Expected: []sql.Row{
+					{float64(8), float64(300)},
+					{float64(8), float64(300)},
+				},
+			},
+			// Subquery-first select-list order: same cross-scope fixture as above
+			// with column order reversed (subquery then outer).
+			{
+				Query: `
+SELECT (SELECT SUM(o.v) OVER (PARTITION BY o.g) FROM u o LIMIT 1),
+       SUM(o.v) OVER (PARTITION BY o.g)
+FROM t o;`,
+				Expected: []sql.Row{
+					{float64(300), float64(8)},
+					{float64(300), float64(8)},
+				},
+			},
+			// Cross-scope same table: both scopes use alias o (identical window
+			// text); each scope's WHERE yields 10 vs -2 — false merge would share.
+			{
+				Query: `
+SELECT SUM(o.v) OVER (PARTITION BY o.g) AS a,
+       (SELECT SUM(o.v) OVER (PARTITION BY o.g) FROM t o WHERE o.id = 2) AS s
+FROM t o
+WHERE o.id = 1;`,
+				Expected: []sql.Row{
+					{float64(10), float64(-2)},
+				},
+			},
+			// Named window reused in ORDER BY via OVER w.
+			{
+				Query: `
+SELECT id, g,
+       SUM(v) OVER w AS wf
+FROM t
+WINDOW w AS (
+  PARTITION BY g ORDER BY id ASC
+  ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+)
+ORDER BY SUM(v) OVER w, id;`,
+				Expected: []sql.Row{
+					{2, 0, float64(8)},
+					{1, 0, float64(10)},
+				},
+			},
+			// Case-insensitive repeat of the window expression.
+			{
+				Query: `
+SELECT id, g,
+       SUM(v) OVER (
+         PARTITION BY g ORDER BY id ASC
+         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+       ) AS wf
+FROM t
+ORDER BY sum(v) over (
+           partition by g order by id asc
+           rows between unbounded preceding and current row
+         ), id;`,
+				Expected: []sql.Row{
+					{2, 0, float64(8)},
+					{1, 0, float64(10)},
+				},
+			},
+			// Whitespace-normalized repeat (extra spaces / newlines).
+			{
+				Query: `
+SELECT id, g,
+       SUM(v) OVER (PARTITION BY g ORDER BY id ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS wf
+FROM t
+ORDER BY SUM( v ) OVER (
+           PARTITION BY g
+           ORDER BY id ASC
+           ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+         ), id;`,
+				Expected: []sql.Row{
+					{2, 0, float64(8)},
+					{1, 0, float64(10)},
+				},
+			},
+			// DESC on the repeated window expression.
+			{
+				Query: `
+SELECT id, g,
+       SUM(v) OVER (
+         PARTITION BY g ORDER BY id ASC
+         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+       ) AS wf
+FROM t
+ORDER BY SUM(v) OVER (
+           PARTITION BY g ORDER BY id ASC
+           ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+         ) DESC, id;`,
+				Expected: []sql.Row{
+					{1, 0, float64(10)},
+					{2, 0, float64(8)},
+				},
+			},
+			// Wrapped SELECT occurrence; bare window repeat in ORDER BY.
+			{
+				Query: `
+SELECT id, g,
+       SUM(v) OVER (
+         PARTITION BY g ORDER BY id ASC
+         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+       ) + 1 AS wf
+FROM t
+ORDER BY SUM(v) OVER (
+           PARTITION BY g ORDER BY id ASC
+           ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+         ), id;`,
+				Expected: []sql.Row{
+					{2, 0, float64(9)},
+					{1, 0, float64(11)},
+				},
+			},
+		},
+	},
 }
 
 var BrokenScriptTests = []ScriptTest{

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -575,7 +575,16 @@ func (b *Builder) buildWindowFunc(inScope *scope, name string, e *ast.FuncExpr, 
 		win = w.WithWindow(b.ctx, def)
 	}
 
-	col := scopeColumn{col: strings.ToLower(win.String()), scalar: win, typ: win.Type(b.ctx), nullable: win.IsNullable(b.ctx)}
+	// Reuse a window only if it was already built in *this* scope. Do not call
+	// getExpr: it walks groupBy.outScope, CTEs, and parent scopes, which would
+	// falsely merge a subquery window that is textually identical to an outer
+	// window and skip registering the subquery's own windowFuncs entry.
+	winName := strings.ToLower(win.String())
+	if id, ok := inScope.exprs[winName]; ok {
+		return expression.NewGetFieldWithTable(int(id), 0, win.Type(b.ctx), "", "", winName, win.IsNullable(b.ctx))
+	}
+
+	col := scopeColumn{col: winName, scalar: win, typ: win.Type(b.ctx), nullable: win.IsNullable(b.ctx)}
 	id := inScope.newColumn(col)
 	col.id = id
 	win = win.WithId(sql.ColumnId(id)).(sql.WindowAdaptableExpression)


### PR DESCRIPTION

## Summary

Fixes [dolthub/dolt#11418](https://github.com/dolthub/dolt/issues/11418): when the same window function expression appears in both `SELECT` and `ORDER BY`, GMS wrongly rejects the query as an ambiguous column/alias.

MySQL accepts this form and returns the window result ordered by that expression. Ordering by the window's alias already works; only the repeated expression form failed.

### Root cause

`orderby.go` already has a `WindowAdaptableExpression` reuse arm that calls `fromScope.getExpr` when rewriting ORDER BY expressions. The real bug was earlier: `buildWindowFunc` always double-registered every call into `fromScope.cols` / `windowFuncs` under the lowercased window expression string, *before* that ORDER BY arm could reuse a single column. The second registration made `resolveColumn` raise `ErrAmbiguousColumnOrAliasName`.

This is **not** the same key space as aggregate reuse. `buildAggregateFunc` probes `gb.outScope` (the dedicated aggregate out-scope). Window functions register on the from-scope; a naive `getExpr` call is the wrong mirror because `getExpr` also walks `groupBy.outScope`, CTEs, and `s.parent` (see `scope.go`). That parent/CTE recursion caused a **cross-scope false merge**: a subquery window that is textually identical to an outer window would reuse the outer column id and never append its own `windowFuncs` entry, producing silent wrong results.

### Fix

In `buildWindowFunc`, after applying the window definition, probe **only** `inScope.exprs[winName]` (map access on the current scope — no parent/CTE recursion). If the expression was already built in this scope, return a `GetField` to that column; otherwise register a new window as before.

Side note (intentional, disclosed): two differently *named* windows that are otherwise identically specified (e.g. `WINDOW w1 AS (...), w2 AS (...)` with the same partition/order/frame) still merge via `String()`-identity of the resulting window expression. That is a safe optimization for mathematically identical windows, not a correctness bug.

### Test

Enginetest script for dolt#11418 covering:

- Issue query: repeated `SUM(...) OVER (...)` in `ORDER BY` (not ambiguous)
- Alias control: `ORDER BY wf`
- Cross-scope subquery with a different table (outer sum vs subquery sum must not false-merge), in both select-list orders (outer-first and subquery-first)
- Same-table subquery variant with identical alias/window text in both scopes
- Named window (`WINDOW w AS ...` with `OVER w` repeated in `ORDER BY`)
- Case-insensitive and whitespace-normalized repeats
- `DESC` on the repeated expression
- Wrapped SELECT occurrence (`SUM(...) OVER (...) + 1`) with bare window in `ORDER BY`

## Related

- Issue: https://github.com/dolthub/dolt/issues/11418 (reporter: **Yibo-Dong**)
- Maintainer note on the issue from **angelamayxie** pointed at validation / aggregation handling; for this specific error path the fix is planbuilder same-scope dedupe of identical window expressions (validation_rules Aggregation arm remains a separate gap for pure window funcs under ONLY_FULL_GROUP_BY).

## Checklist

- [x] New failing-before / passing-after enginetest for the bug (issue query + cross-scope + named/case/whitespace/DESC/wrapped variants)
- [x] Minimal change in planbuilder (scope-local `exprs` probe, not recursive `getExpr`)
- [ ] CI green

## Test plan

- [x] `gofmt` on changed Go files
- [x] `go test ./sql/planbuilder/...`
- [x] `go test ./enginetest/ -run 'TestScripts$'` (includes the new script cases)
- [x] `go test ./enginetest/ -run 'TestWindowFunctions$'`
- [ ] Full CI

## Limitations

- Does not extend `expressionReferencesOnlyGroupBys` to treat `sql.WindowAggregation` as a group-by leaf (maintainer's second suggestion). That is orthogonal to this ambiguous-name failure and can be a follow-up if pure window funcs still trip ONLY_FULL_GROUP_BY incorrectly.
- Identically-specified distinct named windows continue to share one planbuilder column via `String()` identity (safe; documented above).
