### PR TITLE
Fix EXISTS with select-list window functions (row-index error)

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -864,6 +864,62 @@ on w = 0;`,
 
 var JoinScriptTests = []ScriptTest{
 	{
+		// dolthub/dolt#11421: EXISTS with select-list window (ROW_NUMBER)
+		Name: "EXISTS with select-list window function",
+		SetUpScript: []string{
+			"CREATE TABLE t(id INT PRIMARY KEY, a INT);",
+			"CREATE TABLE u(x INT);",
+			"CREATE TABLE u2(x INT, y INT);",
+			"INSERT INTO t VALUES (1,1),(2,2),(3,3);",
+			"INSERT INTO u VALUES (1),(1),(2);",
+			"INSERT INTO u2 VALUES (1,10),(1,20),(2,30);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT id FROM t WHERE EXISTS (SELECT 1 FROM u WHERE u.x = t.a) ORDER BY id",
+				Expected: []sql.Row{
+					{1},
+					{2},
+				},
+			},
+			{
+				Query: "SELECT id FROM t WHERE EXISTS (SELECT ROW_NUMBER() OVER () FROM u WHERE u.x = t.a) ORDER BY id",
+				Expected: []sql.Row{
+					{1},
+					{2},
+				},
+			},
+			{
+				Query: "SELECT id FROM t WHERE NOT EXISTS (SELECT ROW_NUMBER() OVER () FROM u WHERE u.x = t.a) ORDER BY id",
+				Expected: []sql.Row{
+					{3},
+				},
+			},
+			// Multi-window EXISTS bodies (>=2 distinct partition schemes) silently returned wrong
+			// rows on main (1,2,3 / empty) instead of crashing; assert correct existence.
+			{
+				Query: "SELECT id FROM t WHERE EXISTS (SELECT ROW_NUMBER() OVER (PARTITION BY u2.y), RANK() OVER (ORDER BY u2.y) FROM u2 WHERE u2.x = t.a) ORDER BY id",
+				Expected: []sql.Row{
+					{1},
+					{2},
+				},
+			},
+			{
+				Query: "SELECT id FROM t WHERE NOT EXISTS (SELECT ROW_NUMBER() OVER (PARTITION BY u2.y), RANK() OVER (ORDER BY u2.y) FROM u2 WHERE u2.x = t.a) ORDER BY id",
+				Expected: []sql.Row{
+					{3},
+				},
+			},
+			// Uncorrelated NOT EXISTS + window: on main this panics (nil pointer in
+			// sql.EvaluateCondition via existsIter) via the len(joinFilters)==0 path;
+			// patched build correctly returns empty.
+			{
+				Query:    "SELECT id FROM t WHERE NOT EXISTS (SELECT ROW_NUMBER() OVER () FROM u) ORDER BY id",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
 		Name:        "Simple join query",
 		SetUpScript: []string{},
 		Assertions: []ScriptTestAssertion{

--- a/sql/analyzer/unnest_exists_subqueries.go
+++ b/sql/analyzer/unnest_exists_subqueries.go
@@ -106,6 +106,10 @@ func simplifyPartialJoinParents(n sql.Node) (sql.Node, bool) {
 		switch n := ret.(type) {
 		case *plan.Having:
 			return nil, false
+		case *plan.Window:
+			// Window functions are 1:1 row-preserving (empty child -> empty output; see
+			// sql/rowexec/rel_iters.go windowToIter), so stripping cannot change row existence.
+			ret = n.Children()[0]
 		case *plan.Project, *plan.GroupBy, *plan.Sort, *plan.Distinct, *plan.TopN, *plan.Limit:
 			// TODO: In most cases, it's necessary to remove *plan.Limit because child Filter nodes will have been
 			//  hoisted out. But what if Limit.Limit evals to 0? https://github.com/dolthub/dolt/issues/10493


### PR DESCRIPTION

Fixes: https://github.com/dolthub/dolt/issues/11421

Reported by [@Yibo-Dong](https://github.com/Yibo-Dong).

## Problem

A correlated `EXISTS` whose select list is a window expression (e.g. `ROW_NUMBER() OVER ()`) fails with an internal error:

```text
unable to find field with index 3 in row of 3 columns
This is a bug. Please file an issue here: https://github.com/dolthub/dolt/issues
```

The same query with `SELECT 1` (or any non-window projection) works. MySQL accepts the window form and returns the expected existence result.

This is **not crash-only**. Multi-window `EXISTS` bodies (two or more window functions with distinct partition schemes) return **silently wrong rows** on main — for example, with `u2(x,y)` rows `(1,10),(1,20),(2,30)` and `t` ids `1,2,3`:

```sql
SELECT id FROM t
WHERE EXISTS (
  SELECT ROW_NUMBER() OVER (PARTITION BY u2.y), RANK() OVER (ORDER BY u2.y)
  FROM u2 WHERE u2.x = t.a
)
ORDER BY id;
-- main (wrong): 1, 2, 3
-- correct / MySQL: 1, 2
```

`NOT EXISTS` of the same shape returns no rows on main instead of row `3`. Silent wrong results are the highest-priority maintainer concern for this fix.

Separately, the uncorrelated `NOT EXISTS ... OVER ()` shape panics the server on main (nil-pointer SIGSEGV at `sql/core.go:432` via `join_iters.go:433`). Panic outranks internal error.

### How to reproduce (crash shape)

```sql
CREATE TABLE t(id INT PRIMARY KEY, a INT);
CREATE TABLE u(x INT);
INSERT INTO t VALUES (1,1),(2,2),(3,3);
INSERT INTO u VALUES (1),(1),(2);

SELECT id FROM t
WHERE EXISTS (SELECT ROW_NUMBER() OVER () FROM u WHERE u.x = t.a)
ORDER BY id;
-- expected: 1, 2
```

## Root cause

`simplifyPartialJoinParents` in `sql/analyzer/unnest_exists_subqueries.go` strips nodes that do not affect existence (`Project`, `GroupBy`, `Sort`, `Distinct`, `TopN`, `Limit`) from the decorrelated EXISTS body before building the semi-join right side. It did **not** strip `*plan.Window`.

The `Window` node shrinks the right-side schema to the window outputs, while join-filter `GetField` indices still refer to pre-window column ids. Evaluation then hits an out-of-bounds `GetField` in `sql/expression/get_field.go` via the exists iterator — or, with multiple windows, can produce silently incorrect existence results.

## Fix

Treat `*plan.Window` like `*plan.Project` in `simplifyPartialJoinParents`: strip it when simplifying the EXISTS body. Window functions are 1:1 row-preserving (empty child → empty output), so existence does not depend on select-list window outputs.

`Filter` is not in the strip list, so the loop halts at any surviving `Filter`; correlated Filters are hoisted by `decorrelateOuterCols` and re-attached above the simplified node (`unnest_exists_subqueries.go:416-417`). A Filter with zero correlated conjuncts is left untouched (`:314-317` returns `SameTree`). `Having` bodies are separately rejected earlier (`case *plan.Having: return nil, false`). Stripping is therefore limited to pure select-list window projection wrappers.

## Tests

Enginetest script in `JoinScriptTests` (`enginetest/queries/join_queries.go`):

- Control: `EXISTS (SELECT 1 FROM u WHERE u.x = t.a)` → rows `1, 2`
- Bug (crash shape): `EXISTS (SELECT ROW_NUMBER() OVER () FROM u WHERE u.x = t.a)` → rows `1, 2`
- `NOT EXISTS` variant with the same window select list → row `3`
- Multi-window silent-corruption shape (distinct partition schemes on `u2`) → EXISTS `1, 2`; NOT EXISTS `3`
- Uncorrelated panic shape: `NOT EXISTS (SELECT ROW_NUMBER() OVER () FROM u)` → empty result (0 rows)

### Test plan

```bash
export CGO_CFLAGS="-I/opt/homebrew/opt/icu4c@78/include"
export CGO_CXXFLAGS="-I/opt/homebrew/opt/icu4c@78/include"
export CGO_LDFLAGS="-L/opt/homebrew/opt/icu4c@78/lib"

go test ./sql/analyzer/... -count=1
go test ./enginetest/... -count=1
```

- [x] Full suite re-run after this patch:

```text
$ go test ./sql/analyzer/... -count=1
ok  github.com/dolthub/go-mysql-server/sql/analyzer  0.457s

$ go test ./enginetest/... -count=1
ok  github.com/dolthub/go-mysql-server/enginetest              44.573s
ok  github.com/dolthub/go-mysql-server/enginetest/mysql_harness 1.047s
ok  github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup 0.205s
```

JoinQueries multi-window subtests (verbatim `-v`):

```text
--- PASS: TestJoinQueries/EXISTS_with_select-list_window_function (0.00s)
    --- PASS: .../SELECT_id_FROM_t_WHERE_EXISTS_(SELECT_1_FROM_u_WHERE_u.x_=_t.a)_ORDER_BY_id
    --- PASS: .../SELECT_id_FROM_t_WHERE_EXISTS_(SELECT_ROW_NUMBER()_OVER_()_FROM_u_WHERE_u.x_=_t.a)_ORDER_BY_id
    --- PASS: .../SELECT_id_FROM_t_WHERE_NOT_EXISTS_(SELECT_ROW_NUMBER()_OVER_()_FROM_u_WHERE_u.x_=_t.a)_ORDER_BY_id
    --- PASS: .../SELECT_id_FROM_t_WHERE_EXISTS_(SELECT_ROW_NUMBER()_OVER_(PARTITION_BY_u2.y),_RANK()_OVER_(ORDER_BY_u2.y)_FROM_u2_WHERE_u2.x_=_t.a)_ORDER_BY_id
    --- PASS: .../SELECT_id_FROM_t_WHERE_NOT_EXISTS_(SELECT_ROW_NUMBER()_OVER_(PARTITION_BY_u2.y),_RANK()_OVER_(ORDER_BY_u2.y)_FROM_u2_WHERE_u2.x_=_t.a)_ORDER_BY_id
```

## Limitations / follow-ups

- Fix is in go-mysql-server. Dolt consumers need a GMS dependency pin bump as a separate change.
- Only pure select-list windows are stripped. Bodies where a window feeds a `HAVING` above the Window still refuse unnest (`Having` returns `false`); that path was already conservative and is unchanged.
- LIMIT stripping is pre-existing (TODO at `unnest_exists_subqueries.go:114-115`, dolt#10493). With Window now stripped, `EXISTS(...window... LIMIT 0)` reaches that pre-existing hole (base hard-errors; patched returns rows where MySQL says empty) — same behavior as the existing `SELECT 1 LIMIT 0` shape; nothing new introduced, noted for completeness.

## Checklist

- [x] Minimal analyzer change (`*plan.Window` only)
- [x] Failing-before / passing-after enginetest for the issue query + NOT EXISTS + SELECT 1 control + multi-window silent-corruption shape
- [ ] CI green
- [ ] Dolt GMS pin bump (follow-up)
