### PR TITLE
fix: treat empty PARTITION/ORDER BY as one window partition/peer group

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3906,6 +3906,67 @@ func TestWindowFunctions(t *testing.T, harness Harness) {
 		{1, 0, 1},
 		{1, 1, 1},
 	}, nil, nil, nil)
+
+	// dolthub/dolt#11409: literal/star-only window args can project zero columns;
+	// empty PARTITION BY / ORDER BY must still form a single partition/peer group.
+	RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE litwin (x int, g int)")
+	RunQueryWithContext(t, e, harness, ctx, "INSERT INTO litwin VALUES (1, 1), (2, 1), (3, 2)")
+
+	TestQueryWithContext(t, ctx, e, harness, `SELECT COUNT(*) OVER () FROM litwin`, []sql.Row{
+		{int64(3)},
+		{int64(3)},
+		{int64(3)},
+	}, nil, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT SUM(1) OVER () FROM litwin`, []sql.Row{
+		{float64(3)},
+		{float64(3)},
+		{float64(3)},
+	}, nil, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT COUNT(0) OVER () FROM litwin`, []sql.Row{
+		{int64(3)},
+		{int64(3)},
+		{int64(3)},
+	}, nil, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT x, COUNT(*) OVER () FROM litwin ORDER BY x`, []sql.Row{
+		{1, int64(3)},
+		{2, int64(3)},
+		{3, int64(3)},
+	}, nil, nil, nil)
+	// Ranking peers with empty ORDER BY: one peer group for the whole partition.
+	TestQueryWithContext(t, ctx, e, harness, `SELECT RANK() OVER () FROM litwin`, []sql.Row{
+		{uint64(1)},
+		{uint64(1)},
+		{uint64(1)},
+	}, nil, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT DENSE_RANK() OVER () FROM litwin`, []sql.Row{
+		{uint64(1)},
+		{uint64(1)},
+		{uint64(1)},
+	}, nil, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT PERCENT_RANK() OVER () FROM litwin`, []sql.Row{
+		{float64(0)},
+		{float64(0)},
+		{float64(0)},
+	}, nil, nil, nil)
+	// Literal PARTITION BY is non-empty; zero-width path must still form one partition.
+	// Mutation-sensitive: base returns 1,1,1 without the isNewPartition fix.
+	TestQueryWithContext(t, ctx, e, harness, `SELECT COUNT(*) OVER (PARTITION BY 1) FROM litwin`, []sql.Row{
+		{int64(3)},
+		{int64(3)},
+		{int64(3)},
+	}, nil, nil, nil)
+	// No-regression contrasts: both PASS on base (partition columns / ORDER BY
+	// project real values; not regression coverage for the zero-width bug).
+	TestQueryWithContext(t, ctx, e, harness, `SELECT COUNT(*) OVER (PARTITION BY g) FROM litwin ORDER BY g, x`, []sql.Row{
+		{int64(2)},
+		{int64(2)},
+		{int64(1)},
+	}, nil, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT COUNT(*) OVER (ORDER BY x) FROM litwin ORDER BY x`, []sql.Row{
+		{int64(1)},
+		{int64(2)},
+		{int64(3)},
+	}, nil, nil, nil)
 }
 
 func TestWindowRowFrames(t *testing.T, harness Harness) {

--- a/sql/expression/function/aggregation/window_framer.go
+++ b/sql/expression/function/aggregation/window_framer.go
@@ -581,9 +581,14 @@ func nextPeerGroup(ctx *sql.Context, pos, partitionEnd int, orderBy []sql.Expres
 }
 
 // isNewOrderByValue compares the order by columns between two rows, returning true when the last row is null or
-// when the next row's orderBy columns are unique
+// when the next row's orderBy columns are unique.
+// Empty ORDER BY means a single peer group. Zero-width projected rows (len==0) must not be treated as a boundary
+// (see dolthub/dolt#11409): that path used to split RANK()/DENSE_RANK()/PERCENT_RANK() OVER () into 1,2,3 peers.
 func isNewOrderByValue(ctx *sql.Context, orderByExprs []sql.Expression, last sql.Row, row sql.Row) (bool, error) {
-	if len(last) == 0 {
+	if len(orderByExprs) == 0 {
+		return false, nil
+	}
+	if last == nil {
 		return true, nil
 	}
 

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -353,10 +353,16 @@ func partitionsToSortConditions(partitionExprs []sql.Expression) sql.SortConditi
 }
 
 func isNewPartition(ctx *sql.Context, partitionBy []sql.Expression, last sql.Row, row sql.Row) (bool, error) {
-	if len(last) == 0 {
+	// First row of the iterator (last not yet set) always starts a partition.
+	// Sole caller initializePartitions ignores this return when j==0.
+	if last == nil {
 		return true, nil
 	}
 
+	// Empty PARTITION BY means a single partition over the whole result set.
+	// Projection pushdown can produce zero-column rows when only literal/star
+	// window args are projected, so len(row)==0 is not a boundary signal
+	// (see dolthub/dolt#11409).
 	if len(partitionBy) == 0 {
 		return false, nil
 	}

--- a/sql/expression/function/aggregation/window_partition_test.go
+++ b/sql/expression/function/aggregation/window_partition_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
@@ -285,4 +286,42 @@ func TestWindowPartition_SortAndFilterOutput(t *testing.T) {
 			require.ElementsMatch(t, tt.Expected, i.output)
 		})
 	}
+}
+
+func TestIsNewPartitionEmptyPartitionBy(t *testing.T) {
+	db := memory.NewDatabase("test")
+	pro := memory.NewDBProvider(db)
+	ctx := sql.NewContext(context.Background(), sql.WithSession(memory.NewSession(sql.NewBaseSession(), pro)))
+
+	// First row (last == nil) always starts a partition. Sole caller
+	// initializePartitions ignores this return when j==0.
+	emptyRow := sql.Row{}
+	newPart, err := isNewPartition(ctx, nil, nil, emptyRow)
+	require.NoError(t, err)
+	require.True(t, newPart)
+
+	// Non-nil empty last with empty PARTITION BY: stay in one partition even
+	// when projected rows have zero columns (COUNT(*) OVER () after pushdown).
+	newPart, err = isNewPartition(ctx, nil, emptyRow, emptyRow)
+	require.NoError(t, err)
+	require.False(t, newPart)
+
+	// Non-empty PARTITION BY: first row (last == nil) is a new partition.
+	// Empty non-nil last row is not treated as first — compare partition keys.
+	partitionBy := []sql.Expression{expression.NewGetField(0, types.Int64, "g", true)}
+	row1 := sql.Row{int64(1)}
+	row2 := sql.Row{int64(1)}
+	row3 := sql.Row{int64(2)}
+
+	newPart, err = isNewPartition(ctx, partitionBy, nil, row1)
+	require.NoError(t, err)
+	require.True(t, newPart)
+
+	newPart, err = isNewPartition(ctx, partitionBy, row1, row2)
+	require.NoError(t, err)
+	require.False(t, newPart)
+
+	newPart, err = isNewPartition(ctx, partitionBy, row2, row3)
+	require.NoError(t, err)
+	require.True(t, newPart)
 }


### PR DESCRIPTION

Fixes: https://github.com/dolthub/dolt/issues/11409

Credit: reported by Junwen An (@wanteatfruit).

## Summary

Window expressions whose arguments project no table columns can produce zero-width rows after projection pushdown. Two related boundary helpers treated empty row width as a first-row / new-group signal:

1. **`isNewPartition`** — `COUNT(*) OVER ()`, `SUM(1) OVER ()`, `COUNT(0) OVER ()`, and `COUNT(*) OVER (PARTITION BY 1)` returned `1` per row instead of the partition size.
2. **`isNewOrderByValue`** — once partitions stayed merged, empty `ORDER BY` still split every zero-width row into its own peer group, so `RANK()` / `DENSE_RANK()` / `PERCENT_RANK() OVER ()` became `1,2,3` / `0,0.5,1` instead of a single peer (`1,1,1` / `0,0,0`).

Related shapes also affected by the same zero-width path include `ROW_NUMBER() OVER ()` (base returned `1` per row; fixed path is `1,2,3`), `LAG(...) OVER ()`, and the same windows carried through `DISTINCT`, `LIMIT`, `JOIN`, and derived-table wrappers.

Parent commit `9242de20d` (PR #3676, `angela/empty_over`) does **not** cover this bug — empty `OVER ()` framing work is orthogonal to partition/peer-group boundary detection on zero-width projected rows.

## Root cause

Both helpers used `len(last) == 0` as “first / new boundary”:

```go
// isNewPartition (before)
if len(last) == 0 {
    return true, nil
}
if len(partitionBy) == 0 {
    return false, nil
}

// isNewOrderByValue (before)
if len(last) == 0 {
    return true, nil
}
```

After the first assignment of a zero-width row, every subsequent row looked like a new partition or peer group of size 1.

## Fix

1. **`isNewPartition`**: first-row check is `last == nil` (returns true; sole caller ignores the return on `j==0`). Then empty `PARTITION BY` returns false (single partition). Compare partition keys only when both last and partition expressions are present.
2. **`isNewOrderByValue`**: empty `ORDER BY` returns false (single peer group). Then `last == nil` returns true. Never use `len(last)==0` as a peer-group boundary.

This does not change projection pushdown; it only corrects boundary detection.

## Before / after

| Query | Before | After (MySQL/Postgres agree) |
|-------|--------|------------------------------|
| `SELECT COUNT(*) OVER () FROM t` (3 rows) | 1, 1, 1 | 3, 3, 3 |
| `SELECT SUM(1) OVER () FROM t` | 1, 1, 1 | 3, 3, 3 |
| `SELECT COUNT(0) OVER () FROM t` | 1, 1, 1 | 3, 3, 3 |
| `SELECT RANK() OVER () FROM t` | 1, 2, 3 (after partition-only fix) | 1, 1, 1 |
| `SELECT DENSE_RANK() OVER () FROM t` | 1, 2, 3 (after partition-only fix) | 1, 1, 1 |
| `SELECT PERCENT_RANK() OVER () FROM t` | 0, 0.5, 1 (after partition-only fix) | 0, 0, 0 |
| `SELECT COUNT(*) OVER (PARTITION BY 1) FROM t` | 1, 1, 1 | 3, 3, 3 |
| `SELECT x, COUNT(*) OVER () FROM t` | 3, 3, 3 (already ok) | unchanged |
| `SELECT COUNT(*) OVER (PARTITION BY g) FROM t` | 2, 2, 1 (already ok on base) | unchanged (no-regression contrast) |
| `SELECT COUNT(*) OVER (ORDER BY x) FROM t` | 1, 2, 3 (already ok on base) | unchanged (no-regression contrast) |

Note: `PARTITION BY g` projects real partition columns, so base already returned correct group sizes. It is kept only as a no-regression contrast, not as evidence of the zero-width bug.

## Test plan

- Unit: `TestIsNewPartitionEmptyPartitionBy` in `window_partition_test.go`
- Engine litwin cases in `TestWindowFunctions`:
  - Regression: `COUNT(*) OVER ()`, `SUM(1)`, `COUNT(0)`, `RANK()/DENSE_RANK()/PERCENT_RANK() OVER ()`, `COUNT(*) OVER (PARTITION BY 1)`
  - No-regression contrasts: `PARTITION BY g`, `ORDER BY x` (both pass on base)

Local runs (base `9242de20d`, HEAD `05a61c115`):

```
$ go test ./sql/expression/function/aggregation/... -count=1
ok  	github.com/dolthub/go-mysql-server/sql/expression/function/aggregation	0.349s
?   	github.com/dolthub/go-mysql-server/sql/expression/function/aggregation/window	[no test files]

$ go test ./enginetest/ -run TestWindowFunctions -count=1 -v
=== RUN   TestWindowFunctions
--- PASS: TestWindowFunctions (0.01s)
PASS
ok  	github.com/dolthub/go-mysql-server/enginetest	0.565s

$ go test ./enginetest/... ./sql/... -count=1
ok  	github.com/dolthub/go-mysql-server/enginetest	52.101s
ok  	github.com/dolthub/go-mysql-server/enginetest/mysql_harness	0.660s
ok  	github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup	0.276s
ok  	github.com/dolthub/go-mysql-server/sql	2.024s
ok  	github.com/dolthub/go-mysql-server/sql/analyzer	1.022s
ok  	github.com/dolthub/go-mysql-server/sql/expression	0.409s
ok  	github.com/dolthub/go-mysql-server/sql/expression/function	8.516s
ok  	github.com/dolthub/go-mysql-server/sql/expression/function/aggregation	1.392s
# ... remaining sql/* packages ok
```

## Limitations

- Corrects empty-`PARTITION BY` / empty-`ORDER BY` boundary detection on zero-width projected rows.
- Does not change projection pushdown itself (intentional).

## Branch / base

- Branch: `fix/gms-11409-literal-window-partition`
- Base: `9242de20d50989aed3b22239acd34944dff48ce8` (`upstream/main`)
- HEAD: `05a61c115d8a48dc46432f57193a6e7f2af7cbfe`
