### PR TITLE
SECURITY: Document security stance on panics generated by GMS.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,9 +9,25 @@ versions will also be created. If you need ongoing security support for an
 older version of go-mysql-server, please [contact
 DoltHub](https://www.dolthub.com/contact), the company behind this project.
 
+## Scope
+
+This code is not fully robust against generating `panic`s in its handling of
+untrusted input like SQL queries. Code calling into this project should always
+`recover()` if it needs to avoid crashing in certain error cases. Note that
+`recover()` only works in the goroutine where the `panic` occurs, so this is
+only sufficient for panics which unwind back into your calling code.
+
+For the time being, these panics are treated as bugs, not security issues.
+Please report them in GitHub Issues and we will be happy to address them.
+
+A `panic` which a caller cannot `recover()` from is still a security issue. In
+particular, a `panic` that reaches the top of a goroutine which this project
+owns or spawned will crash the process regardless of what the caller does.
+Please report those to the address below instead.
+
 ## Reporting a Vulnerability
 
-Any security issues with go-mysql-server can be reported to [security@dolthub.com](security@dolthub.com).
+Any security issues with go-mysql-server can be reported to [security@dolthub.com](mailto:security@dolthub.com).
 
 Reports will be responded to within one business day. The majority of
 our team operates on Pacific Time and on a US holiday schedule.

--- a/errguard/errguard.go
+++ b/errguard/errguard.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -34,4 +35,17 @@ func Go(g *errgroup.Group, fn func() error) {
 		}()
 		return fn()
 	})
+}
+
+// RecoverAndLog recovers a panic in the calling goroutine and logs it with a
+// stack trace. |what| describes the work the goroutine was doing and is
+// included in the log message. Defer it as the first statement of the top-level
+// function of a goroutine this project spawns; callers of this project cannot
+// recover a panic that unwinds out of one of our goroutines, so we do it for
+// them. The goroutine's work is abandoned either way, so call sites should
+// document any functionality lost when their goroutine dies.
+func RecoverAndLog(what string) {
+	if r := recover(); r != nil {
+		logrus.Errorf("panic recovered in %s: %v\n%s", what, r, debug.Stack())
+	}
 }

--- a/errguard/errguard_test.go
+++ b/errguard/errguard_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errguard_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/go-mysql-server/errguard"
+)
+
+func TestGo(t *testing.T) {
+	t.Run("returns the function's error", func(t *testing.T) {
+		expected := errors.New("an error")
+		eg := new(errgroup.Group)
+		errguard.Go(eg, func() error { return expected })
+		assert.ErrorIs(t, eg.Wait(), expected)
+	})
+
+	t.Run("converts a panic into an error", func(t *testing.T) {
+		eg := new(errgroup.Group)
+		errguard.Go(eg, func() error { panic("boom") })
+		err := eg.Wait()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "panic recovered: boom")
+	})
+}
+
+func TestRecoverAndLog(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer errguard.RecoverAndLog("test goroutine")
+		panic("boom")
+	}()
+	<-done
+}

--- a/eventscheduler/event_scheduler.go
+++ b/eventscheduler/event_scheduler.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/dolthub/go-mysql-server/errguard"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
 	"github.com/dolthub/go-mysql-server/sql/mysql_db"
@@ -240,7 +241,12 @@ func (es *EventScheduler) loadEventsAndStartEventExecutor(ctx *sql.Context, a *a
 	es.executor.loadAllEvents(ctx)
 	bgCtx, cancel := context.WithCancel(context.Background())
 	es.cancel = cancel
-	es.wg.Go(func() { es.executor.start(bgCtx) })
+	// A recovered panic here leaves the scheduler's status as ON, but no further
+	// events execute until it is turned off and back on again.
+	es.wg.Go(func() {
+		defer errguard.RecoverAndLog("event scheduler executor")
+		es.executor.start(bgCtx)
+	})
 	return nil
 }
 

--- a/server/connwatch.go
+++ b/server/connwatch.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/dolthub/vitess/go/mysql"
 	"github.com/sirupsen/logrus"
+
+	"github.com/dolthub/go-mysql-server/errguard"
 )
 
 const (
@@ -222,8 +224,11 @@ func (w *connWatcher) wake() {
 
 // run is the sweeper loop. It ticks (one reused timer for the whole process)
 // only while there is pending work, and parks on wakeCh with no timer otherwise.
+// A recovered panic stops the loop for the life of the process, after which
+// queries no longer get the client-went-away cancellation it provides.
 func (w *connWatcher) run() {
 	defer close(w.doneCh)
+	defer errguard.RecoverAndLog("connection watcher sweeper")
 	timer := time.NewTimer(w.tick)
 	if !timer.Stop() {
 		<-timer.C

--- a/server/handler.go
+++ b/server/handler.go
@@ -1099,6 +1099,7 @@ func getThreadsConnected() uint64 {
 // value of Max_used_connections.
 func updateMaxUsedConnectionsStatusVariable() {
 	go func() {
+		defer errguard.RecoverAndLog("Max_used_connections status variable update")
 		maxUsedConnections := getMaxUsedConnections()
 		threadsConnected := getThreadsConnected()
 		if threadsConnected > maxUsedConnections {

--- a/sql/background_threads.go
+++ b/sql/background_threads.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 	"sync"
+
+	"github.com/dolthub/go-mysql-server/errguard"
 )
 
 var ErrCannotAddToClosedBackgroundThreads = errors.New("cannot add to a close background threads instance")
@@ -64,6 +66,7 @@ func (bt *BackgroundThreads) Add(name string, f func(ctx context.Context)) error
 	bt.nameToCancel[name] = threadCancel
 	bt.nameToCtx[name] = threadCtx
 	bt.wg.Go(func() {
+		defer errguard.RecoverAndLog("background thread " + name)
 		f(threadCtx)
 	})
 	return nil

--- a/sql/background_threads_test.go
+++ b/sql/background_threads_test.go
@@ -98,4 +98,20 @@ func TestBackgroundThreads(t *testing.T) {
 		sort.Ints(b)
 		assert.Equal(t, []int{}, b)
 	})
+
+	t.Run("panic in a thread does not crash the process", func(t *testing.T) {
+		bThreads = sql.NewBackgroundThreads()
+		defer bThreads.Shutdown()
+
+		ran := make(chan struct{})
+		err = bThreads.Add("panics", func(ctx context.Context) {
+			close(ran)
+			panic("this panic must not be fatal")
+		})
+		assert.NoError(t, err)
+		<-ran
+
+		err = bThreads.Shutdown()
+		assert.NoError(t, err)
+	})
 }

--- a/sql/index_registry.go
+++ b/sql/index_registry.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/dolthub/go-mysql-server/errguard"
 	"github.com/dolthub/go-mysql-server/internal/similartext"
 )
 
@@ -526,6 +527,7 @@ func (r *IndexRegistry) AddIndex(
 	var _created = make(chan struct{})
 	var _ready = make(chan struct{})
 	go func() {
+		defer errguard.RecoverAndLog("index registry AddIndex")
 		<-_created
 		r.mut.Lock()
 		defer r.mut.Unlock()
@@ -600,6 +602,7 @@ func (r *IndexRegistry) DeleteIndex(db, id string, force bool) (<-chan struct{},
 	r.rcmut.Unlock()
 
 	go func() {
+		defer errguard.RecoverAndLog("index registry DeleteIndex")
 		<-onReadyToDelete
 		r.mut.Lock()
 		defer r.mut.Unlock()


### PR DESCRIPTION
Add some defensive recover() calls at places where GMS itself spawns goroutines.