### PR TITLE
block certain statements from `PREPARE`

### DIFF
--- a/enginetest/queries/prepared_statement_queries.go
+++ b/enginetest/queries/prepared_statement_queries.go
@@ -414,7 +414,68 @@ var PreparedScriptTests = []ScriptTest{
 			},
 		},
 	},
-	// TODO: prepare delete
+	{
+		Name: "prepare delete",
+		SetUpScript: []string{
+			"set @a = 1;",
+			"create table t (i int, j varchar(100));",
+			"insert into t values (1, 'abc'), (2, 'def'), (3, 'ghi');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "prepare s from 'delete from t where i = ?'",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute s using @a",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1}},
+				},
+			},
+			{
+				Query: "select * from t order by i",
+				Expected: []sql.Row{
+					{2, "def"},
+					{3, "ghi"},
+				},
+			},
+			{
+				Query: "deallocate prepare s",
+				Expected: []sql.Row{
+					{types.OkResult{}},
+				},
+			},
+			{
+				Query: "prepare s from 'delete from t where i = 2'",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				// execute depends on prepare stmt for whether to use 'query' or 'exec' from go sql driver.
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute s;",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1}},
+				},
+			},
+			{
+				Query: "select * from t order by i",
+				Expected: []sql.Row{
+					{3, "ghi"},
+				},
+			},
+			{
+				Query: "deallocate prepare s",
+				Expected: []sql.Row{
+					{types.OkResult{}},
+				},
+			},
+		},
+	},
 	{
 		Name:        "prepare create table",
 		SetUpScript: []string{},
@@ -440,6 +501,50 @@ var PreparedScriptTests = []ScriptTest{
 				Expected: []sql.Row{
 					{"t", "CREATE TABLE `t` (\n" +
 						"  `i` int\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
+	{
+		Name: "prepare create index",
+		SetUpScript: []string{
+			"create table t (i int);",
+			"insert into t values (0), (1), (2);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "show create table t;",
+				Expected: []sql.Row{
+					{"t", "CREATE TABLE `t` (\n" +
+						"  `i` int\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "prepare stmt from 'create index idx on t (i)';",
+				Expected: []sql.Row{
+					{types.OkResult{
+						Info: plan.PrepareInfo{},
+					}},
+				},
+			},
+			{
+				Query: "execute stmt",
+				Expected: []sql.Row{
+					{types.OkResult{}},
+				},
+			},
+			{
+				Query:       "execute stmt",
+				ExpectedErr: sql.ErrDuplicateKey,
+			},
+			{
+				Query: "show create table t;",
+				Expected: []sql.Row{
+					{"t", "CREATE TABLE `t` (\n" +
+						"  `i` int,\n" +
+						"  KEY `idx` (`i`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
 			},

--- a/enginetest/queries/prepared_statement_queries.go
+++ b/enginetest/queries/prepared_statement_queries.go
@@ -414,6 +414,57 @@ var PreparedScriptTests = []ScriptTest{
 			},
 		},
 	},
+	// TODO: prepare delete
+	{
+		Name:        "prepare create table",
+		SetUpScript: []string{},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "prepare stmt from 'create table t (i int);' ",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				Query: "execute stmt",
+				Expected: []sql.Row{
+					{types.OkResult{}},
+				},
+			},
+			{
+				Query:       "execute stmt",
+				ExpectedErr: sql.ErrTableAlreadyExists,
+			},
+			{
+				Query: "show create table t",
+				Expected: []sql.Row{
+					{"t", "CREATE TABLE `t` (\n" +
+						"  `i` int\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
+	{
+		Name:        "prepare create event",
+		SetUpScript: []string{},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "prepare bad from 'create event e on schedule at current_timestamp do select 1';",
+				ExpectedErr: sql.ErrUnsupportedPreparedStatement,
+			},
+		},
+	},
+	{
+		Name:        "prepare create procedure",
+		SetUpScript: []string{},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "prepare bad from 'create procedure p(i int) select 1';",
+				ExpectedErr: sql.ErrUnsupportedPreparedStatement,
+			},
+		},
+	},
 	{
 		Name: "prepare using user vars",
 		SetUpScript: []string{

--- a/enginetest/queries/prepared_statement_queries.go
+++ b/enginetest/queries/prepared_statement_queries.go
@@ -792,6 +792,67 @@ var PreparedScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "prepare alter table foreign key constraint",
+		SetUpScript: []string{
+			"create table parent (i int primary key);",
+			"create table child (x int primary key);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "prepare stmt from 'alter table child add constraint fk foreign key (x) references parent(i)';",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				Query: "execute stmt;",
+				Expected: []sql.Row{
+					{types.OkResult{}},
+				},
+			},
+			{
+				Query:       "execute stmt;",
+				ExpectedErr: sql.ErrForeignKeyDuplicateName,
+			},
+			{
+				Query: "show create table child;",
+				Expected: []sql.Row{
+					{"child", "CREATE TABLE `child` (\n" +
+						"  `x` int NOT NULL,\n" +
+						"  PRIMARY KEY (`x`),\n" +
+						"  CONSTRAINT `fk` FOREIGN KEY (`x`) REFERENCES `parent` (`i`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Query: "prepare stmt from 'alter table child drop constraint fk';",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				Query: "execute stmt;",
+				Expected: []sql.Row{
+					{types.OkResult{}},
+				},
+			},
+			{
+				Query:       "execute stmt;",
+				ExpectedErr: sql.ErrUnknownConstraint,
+			},
+			{
+				Query: "show create table child;",
+				Expected: []sql.Row{
+					{"child", "CREATE TABLE `child` (\n" +
+						"  `x` int NOT NULL,\n" +
+						"  PRIMARY KEY (`x`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
+	{
 		Name: "prepare using user vars",
 		SetUpScript: []string{
 			"create table t (i int primary key);",

--- a/enginetest/queries/prepared_statement_queries.go
+++ b/enginetest/queries/prepared_statement_queries.go
@@ -718,7 +718,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query: "execute stmt;",
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt;",
 				Expected: []sql.Row{
 					{types.OkResult{}},
 				},
@@ -744,7 +745,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query: "execute stmt;",
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt;",
 				Expected: []sql.Row{
 					{types.OkResult{}},
 				},
@@ -770,7 +772,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query: "execute stmt;",
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt;",
 				Expected: []sql.Row{
 					{types.OkResult{}},
 				},
@@ -805,7 +808,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query: "execute stmt;",
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt;",
 				Expected: []sql.Row{
 					{types.OkResult{}},
 				},
@@ -832,7 +836,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query: "execute stmt;",
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt;",
 				Expected: []sql.Row{
 					{types.OkResult{}},
 				},
@@ -865,7 +870,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query: "execute stmt;",
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt;",
 				Expected: []sql.Row{
 					{types.OkResult{}},
 				},

--- a/enginetest/queries/prepared_statement_queries.go
+++ b/enginetest/queries/prepared_statement_queries.go
@@ -853,6 +853,63 @@ var PreparedScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "prepare alter table check constraint",
+		SetUpScript: []string{
+			"create table t (i int);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "prepare stmt from 'alter table t add constraint chk check (i > 0)';",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				Query: "execute stmt;",
+				Expected: []sql.Row{
+					{types.OkResult{}},
+				},
+			},
+			{
+				Query:       "execute stmt;",
+				ExpectedErr: sql.ErrDuplicateCheckName,
+			},
+			{
+				Query: "show create table t;",
+				Expected: []sql.Row{
+					{"t", "CREATE TABLE `t` (\n" +
+						"  `i` int,\n" +
+						"  CONSTRAINT `chk` CHECK ((`i` > 0))\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Query: "prepare stmt from 'alter table t drop check chk';",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				// TODO: should return OkResult
+				Query:    "execute stmt;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:       "execute stmt;",
+				ExpectedErr: sql.ErrUnknownConstraint,
+			},
+			{
+				Query: "show create table t;",
+				Expected: []sql.Row{
+					{"t", "CREATE TABLE `t` (\n" +
+						"  `i` int\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
+	{
 		Name: "prepare using user vars",
 		SetUpScript: []string{
 			"create table t (i int primary key);",

--- a/enginetest/queries/prepared_statement_queries.go
+++ b/enginetest/queries/prepared_statement_queries.go
@@ -487,7 +487,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query: "execute stmt",
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt",
 				Expected: []sql.Row{
 					{types.OkResult{}},
 				},
@@ -530,7 +531,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query: "execute stmt",
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt",
 				Expected: []sql.Row{
 					{types.OkResult{}},
 				},
@@ -546,6 +548,37 @@ var PreparedScriptTests = []ScriptTest{
 						"  `i` int,\n" +
 						"  KEY `idx` (`i`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
+	{
+		Name:        "prepare create database",
+		SetUpScript: []string{},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "prepare stmt from 'create database prepdb;' ",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt",
+				Expected: []sql.Row{
+					{types.OkResult{
+						RowsAffected: 1,
+					}},
+				},
+			},
+			{
+				Query:       "execute stmt",
+				ExpectedErr: sql.ErrDatabaseExists,
+			},
+			{
+				Query: "show create database prepdb",
+				Expected: []sql.Row{
+					{"prepdb", "CREATE DATABASE `prepdb` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_bin */"},
 				},
 			},
 		},
@@ -567,6 +600,194 @@ var PreparedScriptTests = []ScriptTest{
 			{
 				Query:       "prepare bad from 'create procedure p(i int) select 1';",
 				ExpectedErr: sql.ErrUnsupportedPreparedStatement,
+			},
+		},
+	},
+	{
+		Name: "prepare alter table column",
+		SetUpScript: []string{
+			"create table t (i int);",
+			"insert into t values (0), (1), (2);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "prepare stmt from 'alter table t add column j int';",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt;",
+				Expected: []sql.Row{
+					{types.OkResult{}},
+				},
+			},
+			{
+				Query:       "execute stmt;",
+				ExpectedErr: sql.ErrColumnExists,
+			},
+			{
+				Query: "show columns from t",
+				Expected: []sql.Row{
+					{"i", "int", "YES", "", nil, ""},
+					{"j", "int", "YES", "", nil, ""},
+				},
+			},
+			{
+				Query: "select * from t order by i",
+				Expected: []sql.Row{
+					{0, nil},
+					{1, nil},
+					{2, nil},
+				},
+			},
+
+			{
+				Query: "prepare stmt from 'alter table t change column j k int';",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt;",
+				Expected:                      []sql.Row{{types.OkResult{}}},
+			},
+			{
+				Query:       "execute stmt;",
+				ExpectedErr: sql.ErrTableColumnNotFound,
+			},
+			{
+				Query: "show columns from t",
+				Expected: []sql.Row{
+					{"i", "int", "YES", "", nil, ""},
+					{"k", "int", "YES", "", nil, ""},
+				},
+			},
+			{
+				Query: "select * from t order by i",
+				Expected: []sql.Row{
+					{0, nil},
+					{1, nil},
+					{2, nil},
+				},
+			},
+
+			{
+				Query: "prepare stmt from 'alter table t drop column k';",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				SkipResultCheckOnServerEngine: true,
+				Query:                         "execute stmt;",
+				Expected:                      []sql.Row{{types.OkResult{}}},
+			},
+			{
+				Query:       "execute stmt;",
+				ExpectedErr: sql.ErrTableColumnNotFound,
+			},
+			{
+				Query: "show columns from t",
+				Expected: []sql.Row{
+					{"i", "int", "YES", "", nil, ""},
+				},
+			},
+			{
+				Query: "select * from t order by i",
+				Expected: []sql.Row{
+					{0},
+					{1},
+					{2},
+				},
+			},
+		},
+	},
+	{
+		Name: "prepare alter table index",
+		SetUpScript: []string{
+			"create table t (i int, j int);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "prepare stmt from 'alter table t add primary key (i)';",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				Query: "execute stmt;",
+				Expected: []sql.Row{
+					{types.OkResult{}},
+				},
+			},
+			{
+				Query:       "execute stmt;",
+				ExpectedErr: sql.ErrMultiplePrimaryKeysDefined,
+			},
+			{
+				Query: "show create table t;",
+				Expected: []sql.Row{
+					{"t", "CREATE TABLE `t` (\n" +
+						"  `i` int NOT NULL,\n" +
+						"  `j` int,\n" +
+						"  PRIMARY KEY (`i`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "prepare stmt from 'alter table t drop primary key';",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				Query: "execute stmt;",
+				Expected: []sql.Row{
+					{types.OkResult{}},
+				},
+			},
+			{
+				Query:       "execute stmt;",
+				ExpectedErr: sql.ErrCantDropFieldOrKey,
+			},
+			{
+				Query: "show create table t;",
+				Expected: []sql.Row{
+					{"t", "CREATE TABLE `t` (\n" +
+						"  `i` int NOT NULL,\n" +
+						"  `j` int\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Query: "prepare stmt from 'alter table t add unique index idx (j)';",
+				Expected: []sql.Row{
+					{types.OkResult{Info: plan.PrepareInfo{}}},
+				},
+			},
+			{
+				Query: "execute stmt;",
+				Expected: []sql.Row{
+					{types.OkResult{}},
+				},
+			},
+			{
+				Query:       "execute stmt;",
+				ExpectedErr: sql.ErrDuplicateKey,
+			},
+			{
+				Query: "show create table t;",
+				Expected: []sql.Row{
+					{"t", "CREATE TABLE `t` (\n" +
+						"  `i` int NOT NULL,\n" +
+						"  `j` int,\n" +
+						"  UNIQUE KEY `idx` (`j`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
 			},
 		},
 	},

--- a/memory/table.go
+++ b/memory/table.go
@@ -1982,7 +1982,7 @@ func (t *Table) CreateCheck(ctx *sql.Context, check *sql.CheckDefinition) error 
 
 	for _, key := range data.checks {
 		if key.Name == toInsert.Name {
-			return sql.ErrForeignKeyDuplicateName.New(toInsert.Name)
+			return sql.ErrDuplicateCheckName.New(toInsert.Name)
 		}
 	}
 

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -702,6 +702,9 @@ var (
 	// ErrInvalidCheckConstraint is returned when a check constraint is defined incorrectly
 	ErrInvalidCheckConstraint = errors.NewKind("invalid constraint definition: %s")
 
+	// ErrDuplicateCheckName is returned when a check constraint is defined incorrectly
+	ErrDuplicateCheckName = errors.NewKind("duplicate check constraint name: %s")
+
 	// ErrUserCreationFailure is returned when attempting to create a user and it fails for any reason.
 	ErrUserCreationFailure = errors.NewKind("Operation CREATE USER failed for %s")
 

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -297,6 +297,9 @@ var (
 	// ErrUnknownPreparedStatement is returned when an unknown query is executed.
 	ErrUnknownPreparedStatement = errors.NewKind(`Unknown prepared statement handler (%s) given to EXECUTE`)
 
+	// ErrUnsupportedPreparedStatement is returned when an unsupported query is prepared.
+	ErrUnsupportedPreparedStatement = errors.NewKind("This command is not supported in the prepared statement protocol yet")
+
 	// ErrTruncateReferencedFromForeignKey is returned when a table is referenced in a foreign key and TRUNCATE is called on it.
 	ErrTruncateReferencedFromForeignKey = errors.NewKind("cannot truncate table %s as it is referenced in foreign key %s on table %s")
 

--- a/sql/planbuilder/transactions.go
+++ b/sql/planbuilder/transactions.go
@@ -64,7 +64,8 @@ func (b *Builder) buildPrepare(inScope *scope, n *ast.Prepare) (outScope *scope)
 	}
 
 	// Prevent certain statements from getting prepared
-	// TODO: by either saving the original query or avoid reparsing, we can make these statements work
+	// TODO: MySQL doesn't currently support these, but by either saving the original query or avoiding reparsing,
+	//  we can make these statements work
 	switch stmt := childStmt.(type) {
 	case *ast.DDL:
 		if stmt.EventSpec != nil {

--- a/sql/planbuilder/transactions.go
+++ b/sql/planbuilder/transactions.go
@@ -63,6 +63,18 @@ func (b *Builder) buildPrepare(inScope *scope, n *ast.Prepare) (outScope *scope)
 		b.handleErr(err)
 	}
 
+	// Prevent certain statements from getting prepared
+	// TODO: by either saving the original query or avoid reparsing, we can make these statements work
+	switch stmt := childStmt.(type) {
+	case *ast.DDL:
+		if stmt.EventSpec != nil {
+			b.handleErr(sql.ErrUnsupportedPreparedStatement.New())
+		}
+		if stmt.ProcedureSpec != nil {
+			b.handleErr(sql.ErrUnsupportedPreparedStatement.New())
+		}
+	}
+
 	oldCtx := b.BindCtx()
 	defer func() {
 		b.bindCtx = oldCtx


### PR DESCRIPTION
This PR blocks `CREATE EVENT` and `CREATE PROCEDURE` from getting created.
Additionally, adds tests for a variety of DDL statements like `DELETE`, `CREATE`, and `ALTER`.

Fixes:
https://github.com/dolthub/dolt/issues/11417
https://github.com/dolthub/dolt/issues/11451