### PR TITLE
When serializing bytes for a MySQL client, correctly handle wrapped values, such as adaptive encoded columns

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -2431,6 +2431,28 @@ WHERE
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/11350
+		name: "left outer join with duplicate join keys and non-merge filter",
+		setup: [][]string{
+			{
+				"create table b2 (cat varchar(50) not null, code varchar(16) not null, lang varchar(20) not null, primary key(cat, code, lang), key(code))",
+				"create table t2 (id varchar(36) primary key, code varchar(16), lang varchar(16), key(code, lang))",
+				"insert into b2 values ('cat0','P1','de:app'),('cat1','P1','fr:app'),('cat2','P1','nl:app')",
+				"insert into t2 values ('t1','P1','de'),('t2','P1','es'),('t3','P1','fr')",
+			},
+		},
+		tests: []JoinOpTests{
+			{
+				Query: "select p.lang, w.lang from b2 p left join t2 w on w.code = p.code and w.lang = substring_index(p.lang, ':', 1) order by 1, 2",
+				Expected: []sql.Row{
+					{"de:app", "de"},
+					{"fr:app", "fr"},
+					{"nl:app", nil},
+				},
+			},
+		},
+	},
 }
 
 var rangeJoinOpTests = []JoinOpTests{

--- a/enginetest/queries/type_wire_queries.go
+++ b/enginetest/queries/type_wire_queries.go
@@ -15,7 +15,9 @@
 package queries
 
 import (
+	"fmt"
 	"github.com/dolthub/go-mysql-server/sql"
+	"strings"
 )
 
 // TypeWireTest is used to ensure that types are properly represented over the wire (vs being directly returned from the
@@ -846,7 +848,7 @@ var TypeWireTests = []TypeWireTest{
 		Name: "JSON",
 		SetUpScript: []string{
 			`CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 JSON);`,
-			`INSERT INTO test VALUES (1, '{"key1": {"key": "value"}}'), (2, '{"key1": "value1", "key2": "value2"}'), (3, '{"key1": {"key": [2,3]}}');`,
+			`INSERT INTO test VALUES (1, '{"key1": {"key": "value"}}'), (2, '{"key1": "value1", "key2": "value2"}'), (3, '{"key1": {"key": [2,3]}}'), (4, CONCAT('{"key": "', REPEAT('X', 5000), '"}'));`,
 			`UPDATE test SET v1 = '["a", 1]' WHERE pk = 1;`,
 			`DELETE FROM test WHERE pk = 3;`,
 		},
@@ -856,9 +858,9 @@ var TypeWireTests = []TypeWireTest{
 			`SELECT pk, JSON_ARRAYAGG(v1) FROM (SELECT * FROM test ORDER BY pk) as sub GROUP BY pk, v1 ORDER BY pk;`,
 		},
 		Results: [][]sql.Row{
-			{{"1", "[\"a\",1]"}, {"2", "{\"key1\":\"value1\",\"key2\":\"value2\"}"}},
-			{{"[\"a\",1]", "1"}, {"{\"key1\":\"value1\",\"key2\":\"value2\"}", "2"}},
-			{{"1", "[[\"a\",1]]"}, {"2", "[{\"key1\":\"value1\",\"key2\":\"value2\"}]"}},
+			{{"1", "[\"a\",1]"}, {"2", "{\"key1\":\"value1\",\"key2\":\"value2\"}"}, {"4", fmt.Sprintf("{\"key\":\"%s\"}", strings.Repeat("X", 5000))}},
+			{{"[\"a\",1]", "1"}, {"{\"key1\":\"value1\",\"key2\":\"value2\"}", "2"}, {fmt.Sprintf("{\"key\":\"%s\"}", strings.Repeat("X", 5000)), "4"}},
+			{{"1", "[[\"a\",1]]"}, {"2", "[{\"key1\":\"value1\",\"key2\":\"value2\"}]"}, {"4", fmt.Sprintf("[{\"key\":\"%s\"}]", strings.Repeat("X", 5000))}},
 		},
 	},
 	{

--- a/enginetest/queries/type_wire_queries.go
+++ b/enginetest/queries/type_wire_queries.go
@@ -16,8 +16,9 @@ package queries
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql"
 	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // TypeWireTest is used to ensure that types are properly represented over the wire (vs being directly returned from the

--- a/server/handler.go
+++ b/server/handler.go
@@ -1172,7 +1172,11 @@ func RowValueToSQLValues(ctx *sql.Context, sch sql.Schema, row sql.ValueRow, buf
 				outVals[i] = sqltypes.NULL
 				continue
 			}
-			outVals[i] = sqltypes.MakeTrusted(row[i].Typ, row[i].Val)
+			unwrappedVal, err := row[i].Unwrap(ctx)
+			if err != nil {
+				return nil, err
+			}
+			outVals[i] = sqltypes.MakeTrusted(row[i].Typ, unwrappedVal)
 			continue
 		}
 		if buf == nil {

--- a/sql/value_row.go
+++ b/sql/value_row.go
@@ -52,6 +52,14 @@ func (v Value) IsNull() bool {
 	return (v.Val == nil && v.WrappedVal == nil) || v.Typ == query.Type_NULL_TYPE
 }
 
+// Unwrap returns the underlying bytes for the value, unwrapping it if the value is wrapped by the BytesWrapper interface.
+func (v Value) Unwrap(ctx *Context) ([]byte, error) {
+	if v.Val != nil {
+		return v.Val, nil
+	}
+	return v.WrappedVal.Unwrap(ctx)
+}
+
 type RowFrame struct {
 	Types []query.Type
 


### PR DESCRIPTION
Currently, when a `sql.Value` contains a wrapped value, but the value's type doesn't implement `sql.ValueType`, we fail to properly serialize it when sending the bytes to the MySQL client.