### PR TITLE
fix panic for `GeometryFromWKT` and various GeoSpatial bugs

### DIFF
--- a/enginetest/queries/spatial_queries.go
+++ b/enginetest/queries/spatial_queries.go
@@ -915,6 +915,133 @@ var SpatialScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name:        "ST_GeomFromWKT pure empty types",
+		SetUpScript: []string{},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "select st_isempty(st_geomfromtext('point empty'))",
+				ExpectedErr: sql.ErrInvalidGISData,
+			},
+			{
+				Query:       "select st_isempty(st_geomfromtext('linestring empty'))",
+				ExpectedErr: sql.ErrInvalidGISData,
+			},
+			{
+				Query:       "select st_isempty(st_geomfromtext('polygon empty'))",
+				ExpectedErr: sql.ErrInvalidGISData,
+			},
+			{
+				Query:       "select st_isempty(st_geomfromtext('multipoint empty'))",
+				ExpectedErr: sql.ErrInvalidGISData,
+			},
+			{
+				Query:       "select st_isempty(st_geomfromtext('multilinestring empty'))",
+				ExpectedErr: sql.ErrInvalidGISData,
+			},
+			{
+				Query:       "select st_isempty(st_geomfromtext('multipolygon empty'))",
+				ExpectedErr: sql.ErrInvalidGISData,
+			},
+			{
+				Query:    "select st_isempty(st_geomfromtext('geometrycollection empty'))",
+				Expected: []sql.Row{{true}},
+			},
+		},
+	},
+	{
+		Name:        "ST_GeomFromText and ST_GeomFromWKB axis options",
+		SetUpScript: []string{},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select st_aswkt(st_geomfromtext('point(1 2)', 0, 'axis-order=lat-long'))",
+				Expected: []sql.Row{{"POINT(1 2)"}},
+			},
+			{
+				Query:    "select st_aswkt(st_geomfromtext('point(1 2)', 0, 'axis-order=long-lat'))",
+				Expected: []sql.Row{{"POINT(1 2)"}},
+			},
+			{
+				Query:    "select st_aswkt(st_geomfromtext('point(1 2)', 0, 'axis-order=srid-defined'))",
+				Expected: []sql.Row{{"POINT(1 2)"}},
+			},
+			{
+				Query:          "select st_aswkt(st_geomfromtext('point(1 2)', 0, 'axis-order=blah-blah'))",
+				ExpectedErrStr: "the string 'axis-order=blah-blah' is not a valid key paid for function st_geomfromtext",
+			},
+			{
+				Query:          "select st_aswkt(st_geomfromtext('point(1 2)', 0, 123))",
+				ExpectedErrStr: "the string '123' is not a valid key paid for function st_geomfromtext",
+			},
+
+			{
+				Query:    "select st_aswkt(st_geomfromtext('point(1 2)', 4326))",
+				Expected: []sql.Row{{"POINT(1 2)"}},
+			},
+			{
+				Query:    "select st_aswkt(st_geomfromtext('point(1 2)', 4326, 'axis-order=lat-long'))",
+				Expected: []sql.Row{{"POINT(1 2)"}},
+			},
+			{
+				Query:    "select st_aswkt(st_geomfromtext('point(1 2)', 4326, 'axis-order=long-lat'))",
+				Expected: []sql.Row{{"POINT(2 1)"}},
+			},
+			{
+				Query:    "select st_aswkt(st_geomfromtext('point(1 2)', 4326, 'axis-order=srid-defined'))",
+				Expected: []sql.Row{{"POINT(1 2)"}},
+			},
+			{
+				Query:          "select st_aswkt(st_geomfromtext('point(1 2)', 4326, 'axis-order=blah-blah'))",
+				ExpectedErrStr: "the string 'axis-order=blah-blah' is not a valid key paid for function st_geomfromtext",
+			},
+			{
+				Query:          "select st_aswkt(st_geomfromtext('point(1 2)', 4326, 123))",
+				ExpectedErrStr: "the string '123' is not a valid key paid for function st_geomfromtext",
+			},
+
+			{
+				Query:    "select st_aswkt(st_geomfromwkb(st_aswkb(point(1,2)), 0, 'axis-order=lat-long'))",
+				Expected: []sql.Row{{"POINT(1 2)"}},
+			},
+			{
+				Query:    "select st_aswkt(st_geomfromwkb(st_aswkb(point(1,2)), 0, 'axis-order=long-lat'))",
+				Expected: []sql.Row{{"POINT(1 2)"}},
+			},
+			{
+				Query:    "select st_aswkt(st_geomfromwkb(st_aswkb(point(1,2)), 0, 'axis-order=srid-defined'))",
+				Expected: []sql.Row{{"POINT(1 2)"}},
+			},
+			{
+				Query:          "select st_aswkt(st_geomfromwkb(st_aswkb(point(1,2)), 0, 'axis-order=blah-blah'))",
+				ExpectedErrStr: "the string 'axis-order=blah-blah' is not a valid key paid for function st_geomfromwkb",
+			},
+			{
+				Query:          "select st_aswkt(st_geomfromwkb(st_aswkb(point(1,2)), 0, 123))",
+				ExpectedErrStr: "the string '123' is not a valid key paid for function st_geomfromwkb",
+			},
+
+			{
+				Query:    "select st_aswkt(st_geomfromwkb(st_aswkb(point(1,2)), 4326, 'axis-order=lat-long'))",
+				Expected: []sql.Row{{"POINT(1 2)"}},
+			},
+			{
+				Query:    "select st_aswkt(st_geomfromwkb(st_aswkb(point(1,2)), 4326, 'axis-order=long-lat'))",
+				Expected: []sql.Row{{"POINT(2 1)"}},
+			},
+			{
+				Query:    "select st_aswkt(st_geomfromwkb(st_aswkb(point(1,2)), 4326, 'axis-order=srid-defined'))",
+				Expected: []sql.Row{{"POINT(1 2)"}},
+			},
+			{
+				Query:          "select st_aswkt(st_geomfromwkb(st_aswkb(point(1,2)), 4326, 'axis-order=blah-blah'))",
+				ExpectedErrStr: "the string 'axis-order=blah-blah' is not a valid key paid for function st_geomfromwkb",
+			},
+			{
+				Query:          "select st_aswkt(st_geomfromwkb(st_aswkb(point(1,2)), 4326, 123))",
+				ExpectedErrStr: "the string '123' is not a valid key paid for function st_geomfromwkb",
+			},
+		},
+	},
 }
 
 var SpatialIndexScriptTests = []ScriptTest{

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -641,6 +641,9 @@ var (
 	// ErrInvalidGISData is thrown when a "ST_<spatial_type>FromText" function receives a malformed string
 	ErrInvalidGISData = errors.NewKind("invalid GIS data provided to function %s")
 
+	// ErrInvalidKeyPair is thrown when a function receives an invalid key-pair option
+	ErrInvalidKeyPair = errors.NewKind("the string '%v' is not a valid key paid for function %s")
+
 	// ErrIllegalGISValue is thrown when a spatial type constructor receives a non-geometric when one should be provided
 	ErrIllegalGISValue = errors.NewKind("illegal non geometric '%v' value found during parsing")
 

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -272,6 +272,7 @@ var BuiltIns = []sql.Function{
 	sql.Function1{Name: "st_isempty", Fn: spatial.NewIsEmpty},
 	sql.Function1{Name: "st_issimple", Fn: spatial.NewIsSimple},
 	sql.Function1{Name: "st_latfromgeohash", Fn: spatial.NewLatFromGeoHash},
+	sql.FunctionN{Name: "st_latitude", Fn: spatial.NewLatitude},
 	sql.FunctionN{Name: "st_length", Fn: spatial.NewSTLength},
 	sql.Function1{Name: "st_longfromgeohash", Fn: spatial.NewLongFromGeoHash},
 	sql.FunctionN{Name: "st_longitude", Fn: spatial.NewLongitude},

--- a/sql/expression/function/spatial/wkb.go
+++ b/sql/expression/function/spatial/wkb.go
@@ -150,16 +150,16 @@ func (g *GeomFromWKB) WithChildren(ctx *sql.Context, children ...sql.Expression)
 }
 
 // ParseAxisOrder takes in a key, value string and determines the order of the xy coords
-func ParseAxisOrder(s string) (bool, error) {
+func ParseAxisOrder(s string) (res bool, ok bool) {
 	s = strings.ToLower(s)
 	s = strings.TrimSpace(s)
 	switch s {
 	case "axis-order=long-lat":
-		return true, nil
+		return true, true
 	case "axis-order=lat-long", "axis-order=srid-defined":
-		return false, nil
+		return false, true
 	default:
-		return false, sql.ErrInvalidArgument.New()
+		return false, false
 	}
 }
 
@@ -231,7 +231,7 @@ func EvalGeomFromWKB(ctx *sql.Context, row sql.Row, exprs []sql.Expression, expe
 		return nil, err
 	}
 
-	order := false
+	order := srid == types.GeoSpatialSRID
 	if len(exprs) == 3 {
 		o, err := exprs[2].Eval(ctx, row)
 		if err != nil {
@@ -240,9 +240,20 @@ func EvalGeomFromWKB(ctx *sql.Context, row sql.Row, exprs []sql.Expression, expe
 		if o == nil {
 			return nil, nil
 		}
-		order, err = ParseAxisOrder(o.(string))
-		if err != nil {
-			return nil, sql.ErrInvalidArgument.New()
+		switch str := o.(type) {
+		case string:
+			// this only applies to types.GeoSpatialSRID
+			swap, ok := ParseAxisOrder(str)
+			if !ok {
+				return nil, sql.ErrInvalidKeyPair.New(str, "st_geomfromwkb")
+			}
+			if srid == types.GeoSpatialSRID && swap {
+				order = !order
+			}
+		case nil:
+			return nil, nil
+		default:
+			return nil, sql.ErrInvalidKeyPair.New(o, "st_geomfromwkb")
 		}
 	}
 	if order {

--- a/sql/expression/function/spatial/wkb_test.go
+++ b/sql/expression/function/spatial/wkb_test.go
@@ -349,7 +349,7 @@ func TestGeomFromWKB(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.Point{SRID: types.GeoSpatialSRID, X: 1, Y: 2}, v)
+		require.Equal(types.Point{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, v)
 	})
 
 	t.Run("convert point with invalid srid 1234", func(t *testing.T) {
@@ -375,35 +375,35 @@ func TestGeomFromWKB(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
+		require.Equal(types.Point{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, v)
+	})
+
+	t.Run("convert point with srid 4326 axis lat-long", func(t *testing.T) {
+		require := require.New(t)
+		res, err := hex.DecodeString("0101000000000000000000F03F0000000000000040")
+		require.NoError(err)
+		f, err := NewGeomFromWKB(sql.NewEmptyContext(), expression.NewLiteral(res, types.Blob),
+			expression.NewLiteral(types.GeoSpatialSRID, types.Uint32),
+			expression.NewLiteral("axis-order=lat-long", types.Blob))
+		require.NoError(err)
+
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+		require.Equal(types.Point{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, v)
+	})
+
+	t.Run("convert point with srid 4326 axis long-lat", func(t *testing.T) {
+		require := require.New(t)
+		res, err := hex.DecodeString("0101000000000000000000F03F0000000000000040")
+		require.NoError(err)
+		f, err := NewGeomFromWKB(sql.NewEmptyContext(), expression.NewLiteral(res, types.Blob),
+			expression.NewLiteral(types.GeoSpatialSRID, types.Uint32),
+			expression.NewLiteral("axis-order=long-lat", types.Blob))
+		require.NoError(err)
+
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
 		require.Equal(types.Point{SRID: types.GeoSpatialSRID, X: 1, Y: 2}, v)
-	})
-
-	t.Run("convert point with srid 4326 axis long-lat", func(t *testing.T) {
-		require := require.New(t)
-		res, err := hex.DecodeString("0101000000000000000000F03F0000000000000040")
-		require.NoError(err)
-		f, err := NewGeomFromWKB(sql.NewEmptyContext(), expression.NewLiteral(res, types.Blob),
-			expression.NewLiteral(types.GeoSpatialSRID, types.Uint32),
-			expression.NewLiteral("axis-order=long-lat", types.Blob))
-		require.NoError(err)
-
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
-		require.NoError(err)
-		require.Equal(types.Point{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, v)
-	})
-
-	t.Run("convert point with srid 4326 axis long-lat", func(t *testing.T) {
-		require := require.New(t)
-		res, err := hex.DecodeString("0101000000000000000000F03F0000000000000040")
-		require.NoError(err)
-		f, err := NewGeomFromWKB(sql.NewEmptyContext(), expression.NewLiteral(res, types.Blob),
-			expression.NewLiteral(types.GeoSpatialSRID, types.Uint32),
-			expression.NewLiteral("axis-order=long-lat", types.Blob))
-		require.NoError(err)
-
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
-		require.NoError(err)
-		require.Equal(types.Point{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, v)
 	})
 
 	t.Run("convert linestring with valid srid 3857", func(t *testing.T) {
@@ -429,7 +429,7 @@ func TestGeomFromWKB(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.LineString{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 1, Y: 2}, {SRID: types.GeoSpatialSRID, X: 3, Y: 4}}}, v)
+		require.Equal(types.LineString{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, {SRID: types.GeoSpatialSRID, X: 4, Y: 3}}}, v)
 	})
 
 	t.Run("convert linestring with invalid srid 1234", func(t *testing.T) {
@@ -455,7 +455,7 @@ func TestGeomFromWKB(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.LineString{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, {SRID: types.GeoSpatialSRID, X: 4, Y: 3}}}, v)
+		require.Equal(types.LineString{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 1, Y: 2}, {SRID: types.GeoSpatialSRID, X: 3, Y: 4}}}, v)
 	})
 
 	t.Run("convert polygon with valid srid 4326", func(t *testing.T) {
@@ -468,7 +468,7 @@ func TestGeomFromWKB(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.Polygon{SRID: types.GeoSpatialSRID, Lines: []types.LineString{{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, {SRID: types.GeoSpatialSRID, X: 1, Y: 1}, {SRID: types.GeoSpatialSRID, X: 1, Y: 0}, {SRID: types.GeoSpatialSRID, X: 0, Y: 0}}}}}, v)
+		require.Equal(types.Polygon{SRID: types.GeoSpatialSRID, Lines: []types.LineString{{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, {SRID: types.GeoSpatialSRID, X: 1, Y: 1}, {SRID: types.GeoSpatialSRID, X: 0, Y: 1}, {SRID: types.GeoSpatialSRID, X: 0, Y: 0}}}}}, v)
 	})
 
 	t.Run("convert polygon with valid srid 3857", func(t *testing.T) {
@@ -507,7 +507,7 @@ func TestGeomFromWKB(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.Polygon{SRID: types.GeoSpatialSRID, Lines: []types.LineString{{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, {SRID: types.GeoSpatialSRID, X: 1, Y: 1}, {SRID: types.GeoSpatialSRID, X: 0, Y: 1}, {SRID: types.GeoSpatialSRID, X: 0, Y: 0}}}}}, v)
+		require.Equal(types.Polygon{SRID: types.GeoSpatialSRID, Lines: []types.LineString{{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, {SRID: types.GeoSpatialSRID, X: 1, Y: 1}, {SRID: types.GeoSpatialSRID, X: 1, Y: 0}, {SRID: types.GeoSpatialSRID, X: 0, Y: 0}}}}}, v)
 	})
 
 	t.Run("convert multipoint with valid srid 3857", func(t *testing.T) {
@@ -533,7 +533,7 @@ func TestGeomFromWKB(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.MultiPoint{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 1, Y: 2}, {SRID: types.GeoSpatialSRID, X: 3, Y: 4}}}, v)
+		require.Equal(types.MultiPoint{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, {SRID: types.GeoSpatialSRID, X: 4, Y: 3}}}, v)
 	})
 
 	t.Run("convert multipoint with invalid srid 1234", func(t *testing.T) {
@@ -559,7 +559,7 @@ func TestGeomFromWKB(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.MultiPoint{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, {SRID: types.GeoSpatialSRID, X: 4, Y: 3}}}, v)
+		require.Equal(types.MultiPoint{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 1, Y: 2}, {SRID: types.GeoSpatialSRID, X: 3, Y: 4}}}, v)
 	})
 
 	t.Run("convert null", func(t *testing.T) {

--- a/sql/expression/function/spatial/wkb_test.go
+++ b/sql/expression/function/spatial/wkb_test.go
@@ -594,6 +594,18 @@ func TestGeomFromWKB(t *testing.T) {
 		require.Equal(nil, v)
 	})
 
+	t.Run("convert null axis option", func(t *testing.T) {
+		require := require.New(t)
+		res, err := hex.DecodeString("0101000000000000000000F03F0000000000000040")
+		require.NoError(err)
+		f, err := NewGeomFromWKB(sql.NewEmptyContext(), expression.NewLiteral(res, types.Blob),
+			expression.NewLiteral(0, types.Uint32),
+			expression.NewLiteral(123, types.Int64))
+
+		_, err = f.Eval(sql.NewEmptyContext(), nil)
+		require.Error(err)
+	})
+
 	t.Run("empty args errors", func(t *testing.T) {
 		ctx := sql.NewEmptyContext()
 		require := require.New(t)

--- a/sql/expression/function/spatial/wkt.go
+++ b/sql/expression/function/spatial/wkt.go
@@ -376,6 +376,10 @@ func WKTToLine(s string, srid uint32, order bool) (types.LineString, error) {
 
 // WKTToPoly Expects a string like "(1 2, 3 4), (5 6, 7 8), ..."
 func WKTToPoly(s string, srid uint32, order bool) (types.Polygon, error) {
+	if len(s) == 0 {
+		return types.Polygon{}, sql.ErrInvalidGISData.New()
+	}
+
 	var lines []types.LineString
 	for {
 		// Get first linestring
@@ -467,6 +471,10 @@ func WKTToMPoint(s string, srid uint32, order bool) (types.MultiPoint, error) {
 
 // WKTToMLine Expects a string like "(1 2, 3 4), (5 6, 7 8), ..."
 func WKTToMLine(s string, srid uint32, order bool) (types.MultiLineString, error) {
+	if len(s) == 0 {
+		return types.MultiLineString{}, sql.ErrInvalidGISData.New()
+	}
+
 	var lines []types.LineString
 	for {
 		// Get first linestring
@@ -506,6 +514,9 @@ func WKTToMLine(s string, srid uint32, order bool) (types.MultiLineString, error
 
 // WKTToMPoly Expects a string like "((1 2, 3 4), (5 6, 7 8), ...), ..."
 func WKTToMPoly(s string, srid uint32, order bool) (types.MultiPolygon, error) {
+	if len(s) == 0 {
+		return types.MultiPolygon{}, sql.ErrInvalidGISData.New()
+	}
 	var polys []types.Polygon
 	for {
 		// Get first polygon
@@ -625,6 +636,8 @@ func WKTToGeom(ctx *sql.Context, row sql.Row, exprs []sql.Expression, expectedGe
 	if expectedGeomType != "" && geomType != expectedGeomType {
 		return nil, sql.ErrInvalidGISData.New()
 	}
+
+	// only GEOMETRYCOLLECTION is allowed to be empty
 
 	srid := uint32(0)
 	if len(exprs) >= 2 {

--- a/sql/expression/function/spatial/wkt.go
+++ b/sql/expression/function/spatial/wkt.go
@@ -664,12 +664,20 @@ func WKTToGeom(ctx *sql.Context, row sql.Row, exprs []sql.Expression, expectedGe
 		if err != nil {
 			return nil, err
 		}
-		if o == nil {
+		switch str := o.(type) {
+		case string:
+			// this only applies to types.GeoSpatialSRID
+			swap, ok := ParseAxisOrder(str)
+			if !ok {
+				return nil, sql.ErrInvalidKeyPair.New(str, "st_geomfromtext")
+			}
+			if srid == types.GeoSpatialSRID && swap {
+				order = !order
+			}
+		case nil:
 			return nil, nil
-		}
-		order, err = ParseAxisOrder(o.(string))
-		if err != nil {
-			return nil, err
+		default:
+			return nil, sql.ErrInvalidKeyPair.New(o, "st_geomfromtext")
 		}
 	}
 

--- a/sql/expression/function/spatial/wkt_test.go
+++ b/sql/expression/function/spatial/wkt_test.go
@@ -315,6 +315,17 @@ func TestGeomFromText(t *testing.T) {
 		require.Equal(nil, v)
 	})
 
+	t.Run("invalid axis option type returns error", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewGeomFromText(sql.NewEmptyContext(), expression.NewLiteral("POINT(1 2)", types.Blob),
+			expression.NewLiteral(types.GeoSpatialSRID, types.Uint32),
+			expression.NewLiteral(123, types.Int64))
+		require.NoError(err)
+
+		_, err = f.Eval(sql.NewEmptyContext(), nil)
+		require.Error(err)
+	})
+
 	t.Run("create polygon with non linear ring", func(t *testing.T) {
 		require := require.New(t)
 		f, err := NewGeomFromText(sql.NewEmptyContext(), expression.NewLiteral("polygon((1 2, 3 4))", types.Blob))

--- a/sql/expression/function/spatial/wkt_test.go
+++ b/sql/expression/function/spatial/wkt_test.go
@@ -630,4 +630,48 @@ func TestGeomFromText(t *testing.T) {
 		_, ok := typ.(types.GeometryType)
 		require.True(ok)
 	})
+
+	// MySQL only supports "GEOMETRYCOLLECTION EMPTY", and errors for all other pure empty Geomtry forms
+	t.Run("create pure empty geometries", func(t *testing.T) {
+		require := require.New(t)
+		var ctx = sql.NewEmptyContext()
+		var f sql.Expression
+		var err error
+		f, err = NewGeomFromText(ctx, expression.NewLiteral("POINT EMPTY", types.Blob))
+		require.NoError(err)
+		_, err = f.Eval(ctx, nil)
+		require.Error(err)
+
+		f, err = NewGeomFromText(ctx, expression.NewLiteral("LINESTRING EMPTY", types.Blob))
+		require.NoError(err)
+		_, err = f.Eval(ctx, nil)
+		require.Error(err)
+
+		f, err = NewGeomFromText(ctx, expression.NewLiteral("POLYGON EMPTY", types.Blob))
+		require.NoError(err)
+		_, err = f.Eval(ctx, nil)
+		require.Error(err)
+
+		f, err = NewGeomFromText(ctx, expression.NewLiteral("MULTIPOINT EMPTY", types.Blob))
+		require.NoError(err)
+		_, err = f.Eval(ctx, nil)
+		require.Error(err)
+
+		f, err = NewGeomFromText(ctx, expression.NewLiteral("MULTILINESTRING EMPTY", types.Blob))
+		require.NoError(err)
+		_, err = f.Eval(ctx, nil)
+		require.Error(err)
+
+		f, err = NewGeomFromText(ctx, expression.NewLiteral("MULTIPOLYGON EMPTY", types.Blob))
+		require.NoError(err)
+		_, err = f.Eval(ctx, nil)
+		require.Error(err)
+
+		var v any
+		f, err = NewGeomFromText(ctx, expression.NewLiteral("GEOMETRYCOLLECTION EMPTY", types.Blob))
+		require.NoError(err)
+		v, err = f.Eval(ctx, nil)
+		require.NoError(err)
+		require.Equal(types.GeomColl{Geoms: []types.GeometryValue{}}, v)
+	})
 }

--- a/sql/expression/function/spatial/wkt_test.go
+++ b/sql/expression/function/spatial/wkt_test.go
@@ -385,7 +385,7 @@ func TestGeomFromText(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.Point{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, v)
+		require.Equal(types.Point{SRID: types.GeoSpatialSRID, X: 1, Y: 2}, v)
 	})
 
 	t.Run("create valid linestring with valid srid", func(t *testing.T) {
@@ -418,7 +418,7 @@ func TestGeomFromText(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.LineString{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, {SRID: types.GeoSpatialSRID, X: 4, Y: 3}}}, v)
+		require.Equal(types.LineString{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 1, Y: 2}, {SRID: types.GeoSpatialSRID, X: 3, Y: 4}}}, v)
 	})
 
 	t.Run("create valid polygon with valid srid", func(t *testing.T) {
@@ -451,7 +451,7 @@ func TestGeomFromText(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.Polygon{SRID: types.GeoSpatialSRID, Lines: []types.LineString{{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, {SRID: types.GeoSpatialSRID, X: 1, Y: 0}, {SRID: types.GeoSpatialSRID, X: 0, Y: 1}, {SRID: types.GeoSpatialSRID, X: 0, Y: 0}}}}}, v)
+		require.Equal(types.Polygon{SRID: types.GeoSpatialSRID, Lines: []types.LineString{{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, {SRID: types.GeoSpatialSRID, X: 0, Y: 1}, {SRID: types.GeoSpatialSRID, X: 1, Y: 0}, {SRID: types.GeoSpatialSRID, X: 0, Y: 0}}}}}, v)
 	})
 
 	t.Run("create valid multipoint with valid srid", func(t *testing.T) {
@@ -484,7 +484,7 @@ func TestGeomFromText(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.MultiPoint{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 2, Y: 1}, {SRID: types.GeoSpatialSRID, X: 4, Y: 3}}}, v)
+		require.Equal(types.MultiPoint{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 1, Y: 2}, {SRID: types.GeoSpatialSRID, X: 3, Y: 4}}}, v)
 	})
 
 	t.Run("create valid multilinestring with valid srid", func(t *testing.T) {
@@ -517,7 +517,7 @@ func TestGeomFromText(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		require.Equal(types.MultiLineString{SRID: types.GeoSpatialSRID, Lines: []types.LineString{{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, {SRID: types.GeoSpatialSRID, X: 1, Y: 0}, {SRID: types.GeoSpatialSRID, X: 0, Y: 1}, {SRID: types.GeoSpatialSRID, X: 0, Y: 0}}}}}, v)
+		require.Equal(types.MultiLineString{SRID: types.GeoSpatialSRID, Lines: []types.LineString{{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, {SRID: types.GeoSpatialSRID, X: 0, Y: 1}, {SRID: types.GeoSpatialSRID, X: 1, Y: 0}, {SRID: types.GeoSpatialSRID, X: 0, Y: 0}}}}}, v)
 	})
 
 	t.Run("create valid multipolygon with valid srid", func(t *testing.T) {
@@ -554,9 +554,9 @@ func TestGeomFromText(t *testing.T) {
 
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
-		line1 := types.LineString{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, {SRID: types.GeoSpatialSRID, X: 2, Y: 1}, {SRID: types.GeoSpatialSRID, X: 4, Y: 3}, {SRID: types.GeoSpatialSRID, X: 0, Y: 0}}}
+		line1 := types.LineString{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, {SRID: types.GeoSpatialSRID, X: 1, Y: 2}, {SRID: types.GeoSpatialSRID, X: 3, Y: 4}, {SRID: types.GeoSpatialSRID, X: 0, Y: 0}}}
 		poly1 := types.Polygon{SRID: types.GeoSpatialSRID, Lines: []types.LineString{line1}}
-		line2 := types.LineString{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 1, Y: 1}, {SRID: types.GeoSpatialSRID, X: 3, Y: 2}, {SRID: types.GeoSpatialSRID, X: 5, Y: 4}, {SRID: types.GeoSpatialSRID, X: 1, Y: 1}}}
+		line2 := types.LineString{SRID: types.GeoSpatialSRID, Points: []types.Point{{SRID: types.GeoSpatialSRID, X: 1, Y: 1}, {SRID: types.GeoSpatialSRID, X: 2, Y: 3}, {SRID: types.GeoSpatialSRID, X: 4, Y: 5}, {SRID: types.GeoSpatialSRID, X: 1, Y: 1}}}
 		poly2 := types.Polygon{SRID: types.GeoSpatialSRID, Lines: []types.LineString{line2}}
 		require.Equal(types.MultiPolygon{SRID: types.GeoSpatialSRID, Polygons: []types.Polygon{poly1, poly2}}, v)
 	})

--- a/sql/expression/function/spatial/x_y_latitude_longitude.go
+++ b/sql/expression/function/spatial/x_y_latitude_longitude.go
@@ -105,6 +105,10 @@ func (s *STX) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	// If just one argument, return X
 	if len(s.ChildExpressions) == 1 {
+		// Backwards for types.GeoSpatialSRID
+		if _p.SRID == types.GeoSpatialSRID {
+			return _p.Y, nil
+		}
 		return _p.X, nil
 	}
 
@@ -125,8 +129,21 @@ func (s *STX) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 
+	// Backwards for types.GeoSpatialSRID
+	if _p.SRID == types.GeoSpatialSRID {
+		return types.Point{
+			SRID: _p.SRID,
+			X:    _p.X,
+			Y:    _x.(float64),
+		}, nil
+	}
+
 	// Create point with new X and old Y
-	return types.Point{SRID: _p.SRID, X: _x.(float64), Y: _p.Y}, nil
+	return types.Point{
+		SRID: _p.SRID,
+		X:    _x.(float64),
+		Y:    _p.Y,
+	}, nil
 }
 
 // STY is a function that returns the y value from a given point.
@@ -207,6 +224,10 @@ func (s *STY) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	// If just one argument, return Y
 	if len(s.ChildExpressions) == 1 {
+		// Backwards for types.GeoSpatialSRID
+		if _p.SRID == types.GeoSpatialSRID {
+			return _p.X, nil
+		}
 		return _p.Y, nil
 	}
 
@@ -227,8 +248,21 @@ func (s *STY) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 
+	// Backwards for types.GeoSpatialSRID
+	if _p.SRID == types.GeoSpatialSRID {
+		return types.Point{
+			SRID: _p.SRID,
+			X:    _y.(float64),
+			Y:    _p.Y,
+		}, nil
+	}
+
 	// Create point with old X and new Ys
-	return types.Point{SRID: _p.SRID, X: _p.X, Y: _y.(float64)}, nil
+	return types.Point{
+		SRID: _p.SRID,
+		X:    _p.X,
+		Y:    _y.(float64),
+	}, nil
 }
 
 // Longitude is a function that returns the x value from a given point.
@@ -357,7 +391,7 @@ var _ sql.FunctionExpression = (*Latitude)(nil)
 var _ sql.CollationCoercible = (*Latitude)(nil)
 
 // NewLatitude creates a new ST_LATITUDE expression.
-func NewLatitude(args ...sql.Expression) (sql.Expression, error) {
+func NewLatitude(ctx *sql.Context, args ...sql.Expression) (sql.Expression, error) {
 	if len(args) != 1 && len(args) != 2 {
 		return nil, sql.ErrInvalidArgumentNumber.New("ST_LATITUDE", "1 or 2", len(args))
 	}
@@ -398,7 +432,7 @@ func (l *Latitude) String() string {
 
 // WithChildren implements the Expression interface.
 func (l *Latitude) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
-	return NewLatitude(children...)
+	return NewLatitude(ctx, children...)
 }
 
 // Eval implements the sql.Expression interface.

--- a/sql/expression/function/spatial/x_y_latitude_longitude_test.go
+++ b/sql/expression/function/spatial/x_y_latitude_longitude_test.go
@@ -28,72 +28,93 @@ func TestSTX(t *testing.T) {
 	ctx := sql.NewEmptyContext()
 	t.Run("select int x value", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTX(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 1, Y: 2}, types.PointType{}))
+		f, err := NewSTX(ctx, expression.NewLiteral(types.Point{X: 1, Y: 2}, types.PointType{}))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(1.0, v)
 	})
 
-	t.Run("select float x value", func(t *testing.T) {
+	t.Run("select int x value srid 4326", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTX(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 123.456, Y: 78.9}, types.PointType{}))
+		f, err := NewSTX(ctx, expression.NewLiteral(types.Point{SRID: types.GeoSpatialSRID, X: 1, Y: 2}, types.PointType{}))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
+		require.NoError(err)
+		require.Equal(2.0, v)
+	})
+
+	t.Run("select float x value", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewSTX(ctx, expression.NewLiteral(types.Point{X: 123.456, Y: 78.9}, types.PointType{}))
+		require.NoError(err)
+
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(123.456, v)
 	})
 
 	t.Run("replace x value", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTX(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
+		f, err := NewSTX(ctx, expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(123.456, types.Float64))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{X: 123.456, Y: 0}, v)
 	})
 
+	t.Run("replace x value srid 4326", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewSTX(ctx, expression.NewLiteral(types.Point{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, types.PointType{}),
+			expression.NewLiteral(123.456, types.Float64))
+		require.NoError(err)
+
+		v, err := f.Eval(ctx, nil)
+		require.NoError(err)
+		require.Equal(types.Point{SRID: types.GeoSpatialSRID, X: 0, Y: 123.456}, v)
+	})
+
 	t.Run("replace x value with valid string", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTX(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
+		f, err := NewSTX(ctx, expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral("-123.456", types.Blob))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{X: -123.456, Y: 0}, v)
 	})
 
 	t.Run("replace x value with negative float", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTX(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
+		f, err := NewSTX(ctx, expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral("-123.456", types.Blob))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{X: -123.456, Y: 0}, v)
 	})
 
 	t.Run("non-point provided", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTX(sql.NewEmptyContext(), expression.NewLiteral("notapoint", types.Blob))
+		f, err := NewSTX(ctx, expression.NewLiteral("notapoint", types.Blob))
 		require.NoError(err)
 
-		_, err = f.Eval(sql.NewEmptyContext(), nil)
+		_, err = f.Eval(ctx, nil)
 		require.Error(err)
 	})
 
 	t.Run("check return type with one argument", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTX(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 1, Y: 2}, types.PointType{}))
+		f, err := NewSTX(ctx, expression.NewLiteral(types.Point{X: 1, Y: 2}, types.PointType{}))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 
 		typ := f.Type(ctx)
@@ -103,11 +124,11 @@ func TestSTX(t *testing.T) {
 
 	t.Run("check return type with two arguments", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTX(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
+		f, err := NewSTX(ctx, expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(123.456, types.Float64))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 
 		typ := f.Type(ctx)
@@ -120,72 +141,93 @@ func TestSTY(t *testing.T) {
 	ctx := sql.NewEmptyContext()
 	t.Run("select int y value", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTY(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 1, Y: 2}, types.PointType{}))
+		f, err := NewSTY(ctx, expression.NewLiteral(types.Point{X: 1, Y: 2}, types.PointType{}))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(2.0, v)
 	})
 
-	t.Run("select float y value", func(t *testing.T) {
+	t.Run("select int y value srid 4326", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTY(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 123.456, Y: 78.9}, types.PointType{}))
+		f, err := NewSTY(ctx, expression.NewLiteral(types.Point{SRID: types.GeoSpatialSRID, X: 1, Y: 2}, types.PointType{}))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
+		require.NoError(err)
+		require.Equal(1.0, v)
+	})
+
+	t.Run("select float y value", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewSTY(ctx, expression.NewLiteral(types.Point{X: 123.456, Y: 78.9}, types.PointType{}))
+		require.NoError(err)
+
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(78.9, v)
 	})
 
 	t.Run("replace y value", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTY(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
+		f, err := NewSTY(ctx, expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(123.456, types.Float64))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{X: 0, Y: 123.456}, v)
 	})
 
+	t.Run("replace y value srid 4326", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewSTY(ctx, expression.NewLiteral(types.Point{SRID: types.GeoSpatialSRID, X: 0, Y: 0}, types.PointType{}),
+			expression.NewLiteral(123.456, types.Float64))
+		require.NoError(err)
+
+		v, err := f.Eval(ctx, nil)
+		require.NoError(err)
+		require.Equal(types.Point{SRID: types.GeoSpatialSRID, X: 123.456, Y: 0}, v)
+	})
+
 	t.Run("replace y value with valid string", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTY(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
+		f, err := NewSTY(ctx, expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral("-123.456", types.Blob))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{X: 0, Y: -123.456}, v)
 	})
 
 	t.Run("replace y value with negative float", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTY(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
+		f, err := NewSTY(ctx, expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral("-123.456", types.Blob))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{X: 0, Y: -123.456}, v)
 	})
 
 	t.Run("non-point provided", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTY(sql.NewEmptyContext(), expression.NewLiteral("notapoint", types.Blob))
+		f, err := NewSTY(ctx, expression.NewLiteral("notapoint", types.Blob))
 		require.NoError(err)
 
-		_, err = f.Eval(sql.NewEmptyContext(), nil)
+		_, err = f.Eval(ctx, nil)
 		require.Error(err)
 	})
 
 	t.Run("check return type with one argument", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTY(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 1, Y: 2}, types.PointType{}))
+		f, err := NewSTY(ctx, expression.NewLiteral(types.Point{X: 1, Y: 2}, types.PointType{}))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 
 		typ := f.Type(ctx)
@@ -195,7 +237,7 @@ func TestSTY(t *testing.T) {
 
 	t.Run("check return type with two arguments", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewSTY(sql.NewEmptyContext(), expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
+		f, err := NewSTY(ctx, expression.NewLiteral(types.Point{X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(123.456, types.Float64))
 		require.NoError(err)
 
@@ -209,93 +251,93 @@ func TestLongitude(t *testing.T) {
 	ctx := sql.NewEmptyContext()
 	t.Run("select longitude value", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLongitude(sql.NewEmptyContext(), expression.NewLiteral(types.Point{SRID: 4326, X: 1, Y: 2}, types.PointType{}))
+		f, err := NewLongitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 1, Y: 2}, types.PointType{}))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(1.0, v)
 	})
 
 	t.Run("replace longitude value", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLongitude(sql.NewEmptyContext(), expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLongitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(123.456, types.Float64))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{SRID: 4326, X: 123.456, Y: 0}, v)
 	})
 
 	t.Run("replace x value with valid string", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLongitude(sql.NewEmptyContext(), expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLongitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral("-123.456", types.Blob))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{SRID: 4326, X: -123.456, Y: 0}, v)
 	})
 
 	t.Run("replace x value with negative float", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLongitude(sql.NewEmptyContext(), expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLongitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral("-123.456", types.Blob))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{SRID: 4326, X: -123.456, Y: 0}, v)
 	})
 
 	t.Run("null point", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLongitude(sql.NewEmptyContext(), expression.NewLiteral(nil, types.Null))
+		f, err := NewLongitude(ctx, expression.NewLiteral(nil, types.Null))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(nil, v)
 	})
 
 	t.Run("replace with null value", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLongitude(sql.NewEmptyContext(), expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLongitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(nil, types.Null))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(nil, v)
 	})
 
 	t.Run("replace x value with out of range coordinate", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLongitude(sql.NewEmptyContext(), expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLongitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(999, types.Blob))
 		require.NoError(err)
 
-		_, err = f.Eval(sql.NewEmptyContext(), nil)
+		_, err = f.Eval(ctx, nil)
 		require.Error(err)
 	})
 
 	t.Run("non-point provided", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLongitude(sql.NewEmptyContext(), expression.NewLiteral("notapoint", types.Blob))
+		f, err := NewLongitude(ctx, expression.NewLiteral("notapoint", types.Blob))
 		require.NoError(err)
 
-		_, err = f.Eval(sql.NewEmptyContext(), nil)
+		_, err = f.Eval(ctx, nil)
 		require.Error(err)
 	})
 
 	t.Run("check return type with one argument", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLongitude(sql.NewEmptyContext(), expression.NewLiteral(types.Point{SRID: 4326, X: 1, Y: 2}, types.PointType{}))
+		f, err := NewLongitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 1, Y: 2}, types.PointType{}))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 
 		typ := f.Type(ctx)
@@ -305,11 +347,11 @@ func TestLongitude(t *testing.T) {
 
 	t.Run("check return type with two arguments", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLongitude(sql.NewEmptyContext(), expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLongitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(123.456, types.Float64))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 
 		typ := f.Type(ctx)
@@ -322,93 +364,93 @@ func TestLatitude(t *testing.T) {
 	ctx := sql.NewEmptyContext()
 	t.Run("select latitude value", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLatitude(expression.NewLiteral(types.Point{SRID: 4326, X: 1, Y: 2}, types.PointType{}))
+		f, err := NewLatitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 1, Y: 2}, types.PointType{}))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(2.0, v)
 	})
 
 	t.Run("replace latitude value", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLatitude(expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLatitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(12.3456, types.Float64))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{SRID: 4326, X: 0, Y: 12.3456}, v)
 	})
 
 	t.Run("replace y value with valid string", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLatitude(expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLatitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral("-12.3456", types.Blob))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{SRID: 4326, X: 0, Y: -12.3456}, v)
 	})
 
 	t.Run("replace y value with negative float", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLatitude(expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLatitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral("-12.3456", types.Blob))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(types.Point{SRID: 4326, X: 0, Y: -12.3456}, v)
 	})
 
 	t.Run("null point", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLatitude(expression.NewLiteral(nil, types.Null))
+		f, err := NewLatitude(ctx, expression.NewLiteral(nil, types.Null))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(nil, v)
 	})
 
 	t.Run("replace with null value", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLatitude(expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLatitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(nil, types.Null))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 		require.Equal(nil, v)
 	})
 
 	t.Run("replace y value with out of range coordinate", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLatitude(expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLatitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(999, types.Blob))
 		require.NoError(err)
 
-		_, err = f.Eval(sql.NewEmptyContext(), nil)
+		_, err = f.Eval(ctx, nil)
 		require.Error(err)
 	})
 
 	t.Run("non-point provided", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLatitude(expression.NewLiteral("notapoint", types.Blob))
+		f, err := NewLatitude(ctx, expression.NewLiteral("notapoint", types.Blob))
 		require.NoError(err)
 
-		_, err = f.Eval(sql.NewEmptyContext(), nil)
+		_, err = f.Eval(ctx, nil)
 		require.Error(err)
 	})
 
 	t.Run("check return type with one argument", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLatitude(expression.NewLiteral(types.Point{SRID: 4326, X: 1, Y: 2}, types.PointType{}))
+		f, err := NewLatitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 1, Y: 2}, types.PointType{}))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 
 		typ := f.Type(ctx)
@@ -418,11 +460,11 @@ func TestLatitude(t *testing.T) {
 
 	t.Run("check return type with two arguments", func(t *testing.T) {
 		require := require.New(t)
-		f, err := NewLatitude(expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
+		f, err := NewLatitude(ctx, expression.NewLiteral(types.Point{SRID: 4326, X: 0, Y: 0}, types.PointType{}),
 			expression.NewLiteral(12.3456, types.Float64))
 		require.NoError(err)
 
-		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		v, err := f.Eval(ctx, nil)
 		require.NoError(err)
 
 		typ := f.Type(ctx)


### PR DESCRIPTION
We added support for "pure empty geometry forms", which MySQL doesn't support, except for "GEOMETRYCOLLECTION EMPTY".
Changes:
 - fix panics for pure empty geometry forms
 - fix panics for invalid axis-order options
 - fix ordering for axis-order options
 - expose st_latitude function
 - fix geospatial srid for `st_x()` and `st_y()` functions

Fixes: https://github.com/dolthub/dolt/issues/11492