### PR TITLE
Allow `NULL` and other numerical swap flags for `BIN_TO_UUID`

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3248,6 +3248,15 @@ CREATE TABLE tab3 (
 				Expected: []sql.Row{{"6ccd780c-baba-1026-9564-5b8c656024db"}},
 			},
 			{
+				// https://github.com/dolthub/dolt/issues/11457
+				Query:    `SELECT BIN_TO_UUID(UUID_TO_BIN(@uuid), null)`,
+				Expected: []sql.Row{{"6ccd780c-baba-1026-9564-5b8c656024db"}},
+			},
+			{
+				Query:    `SELECT BIN_TO_UUID(UUID_TO_BIN(@uuid), 3000)`,
+				Expected: []sql.Row{{"6ccd780c-baba-1026-9564-5b8c656024db"}},
+			},
+			{
 				Query:    `SELECT UUID_TO_BIN(NULL)`,
 				Expected: []sql.Row{{nil}},
 			},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3254,7 +3254,11 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:    `SELECT BIN_TO_UUID(UUID_TO_BIN(@uuid), 3000)`,
-				Expected: []sql.Row{{"6ccd780c-baba-1026-9564-5b8c656024db"}},
+				Expected: []sql.Row{{"baba1026-780c-6ccd-9564-5b8c656024db"}},
+			},
+			{
+				Query:    `SELECT BIN_TO_UUID(UUID_TO_BIN(@uuid), -10)`,
+				Expected: []sql.Row{{"baba1026-780c-6ccd-9564-5b8c656024db"}},
 			},
 			{
 				Query:    `SELECT UUID_TO_BIN(NULL)`,

--- a/sql/expression/function/uuid.go
+++ b/sql/expression/function/uuid.go
@@ -486,10 +486,10 @@ func (bu BinToUUID) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 
-	// If the swap flag is 0 we can return uuid's string format as is.
-	if sf.(int8) == 0 {
+	// If the swap flag is null or 0, we can return uuid's string format as is.
+	if sf == nil || sf.(int8) == 0 {
 		return parsed.String(), nil
-	} else if sf.(int8) == 1 {
+	} else {
 		encoding := unswapUUIDBytes(parsed)
 		parsed, err = uuid.FromBytes(encoding)
 
@@ -498,8 +498,6 @@ func (bu BinToUUID) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		}
 
 		return parsed.String(), nil
-	} else {
-		return nil, fmt.Errorf("UUID_TO_BIN received invalid swap flag")
 	}
 }
 

--- a/sql/expression/function/uuid_test.go
+++ b/sql/expression/function/uuid_test.go
@@ -174,6 +174,8 @@ func TestBinToUUID(t *testing.T) {
 	}{
 		{"valid uuid; swap=0", types.MustCreateBinary(query.Type_VARBINARY, int64(16)), []byte("lxºº & d[e`$Û"), true, types.Int8, int8(0), "6c78c2ba-c2ba-2026-2064-5b656024c39b"},
 		{"valid uuid; swap=1", types.MustCreateBinary(query.Type_VARBINARY, int64(16)), []byte("&ººlÍxd[e`$Û"), true, types.Int8, int8(1), "ba6cc38d-bac2-26c2-7864-5b656024c39b"},
+		{"valid uuid; swap=1000", types.MustCreateBinary(query.Type_VARBINARY, int64(16)), []byte("&ººlÍxd[e`$Û"), true, types.Int64, 1000, "ba6cc38d-bac2-26c2-7864-5b656024c39b"},
+		{"valid uuid; swap=null", types.MustCreateBinary(query.Type_VARBINARY, int64(16)), []byte("lxºº & d[e`$Û"), true, types.Null, nil, "6c78c2ba-c2ba-2026-2064-5b656024c39b"},
 		{"valid uuid; no swap", types.MustCreateBinary(query.Type_VARBINARY, int64(16)), []byte("lxºº & d[e`$Û"), false, nil, nil, "6c78c2ba-c2ba-2026-2064-5b656024c39b"},
 		{"null input", types.Null, nil, false, nil, nil, nil},
 	}
@@ -208,7 +210,6 @@ func TestBinToUUIDFailing(t *testing.T) {
 		swapType  sql.Type
 		swapValue interface{}
 	}{
-		{"bad swap value", types.MustCreateBinary(query.Type_VARBINARY, int64(16)), "helo", types.Int8, int8(2)},
 		{"bad binary value", types.MustCreateBinary(query.Type_VARBINARY, int64(16)), "sdasdsad", types.Int8, int8(0)},
 		{"bad input value", types.Int8, int8(0), types.Int8, int8(0)},
 	}


### PR DESCRIPTION
Fixes dolthub/dolt#11457