### PR TITLE
cap initial heapsize

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -14707,6 +14707,47 @@ select * from t1 except (
 			},
 		},
 	},
+	{
+		Name: "TopN with huge limit",
+		SetUpScript: []string{
+			"create table t (i int);",
+			"insert into t values (1), (2), (3)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select * from t order by i limit 18446744073709551615",
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query: "select * from t order by i limit 9223372036854775807",
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query: "select * from t order by i limit 4294967295",
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query: "select * from t order by i limit 2147483647",
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+		},
+	},
 }
 
 var BrokenScriptTests = []ScriptTest{

--- a/sql/sorters/rows_heap.go
+++ b/sql/sorters/rows_heap.go
@@ -16,8 +16,9 @@ package sorters
 
 import (
 	"container/heap"
-	"github.com/dolthub/go-mysql-server/sql"
 	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
 )
 
 const initHeapSize = 1024

--- a/sql/sorters/rows_heap.go
+++ b/sql/sorters/rows_heap.go
@@ -16,18 +16,21 @@ package sorters
 
 import (
 	"container/heap"
-	"io"
-
 	"github.com/dolthub/go-mysql-server/sql"
+	"io"
 )
+
+const initHeapSize = 1024
 
 // GetTopNRows uses a Top-N Heap Sort to find the top (min) N rows in a RowIter. It inserts each row of the iter into
 // the max-heap, popping the max row if the size of the heap exceeds N such that the heap only contains the N min rows.
 // At the end, it pops the contents of the heap and returns them in min-first order.
 func GetTopNRows(ctx *sql.Context, iter sql.RowIter, sortConditions sql.SortConditions, n int64) ([]sql.Row, int64, error) {
+	// Limit heapSize
+	heapSize := min(initHeapSize, n)
 	rowsHeap := &maxRowsHeap{
-		RowSorter: NewRowSorterWithRows(ctx, sortConditions, make([]sql.Row, 0, n+1)),
-		order:     make([]int64, 0, n+1),
+		RowSorter: NewRowSorterWithRows(ctx, sortConditions, make([]sql.Row, 0, heapSize+1)),
+		order:     make([]int64, 0, heapSize+1),
 	}
 
 	var rowCount int64


### PR DESCRIPTION
This PR adds a cap to the initial heap size of the `maxRowHeap` within `TopNRowsIter`, to prevent overflows.
Additionally, unnecessarily large `order by ... limit x` clauses would result wasted time allocating space.
`heap.Push` appends to the internal slice, so we'll rely on golang to manage the memory.

fixes: https://github.com/dolthub/dolt/issues/11503