### PR TITLE
Return decimal type for greatest and least with decimal arguments

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -14580,10 +14580,9 @@ select * from t1 except (
 		Assertions: []ScriptTestAssertion{
 			{
 				// https://github.com/dolthub/dolt/issues/10562
-				Query: "select greatest(a, b, c), least(a, b, c) from t;",
-				// TODO: greatest and least currently return a float64 for decimals. MySQL returns a decimal with the
-				//  highest precision https://github.com/dolthub/dolt/issues/10567
-				Expected: []sql.Row{{8.8, 2.75}},
+				// https://github.com/dolthub/dolt/issues/10567
+				Query:    "select greatest(a, b, c), least(a, b, c) from t;",
+				Expected: []sql.Row{{"8.80000", "2.75000"}},
 			},
 		},
 	},

--- a/sql/expression/function/greatest_least.go
+++ b/sql/expression/function/greatest_least.go
@@ -43,6 +43,42 @@ func compEval(
 		return nil, nil
 	}
 
+	if dt, ok := returnType.(sql.DecimalType); ok {
+		// exact values compared exactly: going through floats here would
+		// corrupt digits a decimal can hold but a float cannot
+		greatest := cmp(float64(1), float64(0))
+		var selected *apd.Decimal
+		for i, arg := range args {
+			val, err := arg.Eval(ctx, row)
+			if err != nil {
+				return nil, err
+			}
+			if val == nil {
+				return nil, nil
+			}
+			conv, _, err := types.InternalDecimalType.Convert(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			d := conv.(*apd.Decimal)
+			if i == 0 || (greatest && d.Cmp(selected) > 0) || (!greatest && d.Cmp(selected) < 0) {
+				selected = d
+			}
+		}
+		// MySQL presents the picked value at the unified scale
+		digits := selected.NumDigits() + int64(dt.Scale())
+		if digits < 1 {
+			digits = 1
+		}
+		quantized := new(apd.Decimal)
+		qCtx := sql.DecimalCtx.WithPrecision(uint32(digits))
+		if _, err := qCtx.Quantize(quantized, selected, -int32(dt.Scale())); err != nil {
+			return nil, err
+		}
+		ret, _, err := dt.Convert(ctx, quantized)
+		return ret, err
+	}
+
 	var selectedNum float64
 	var selectedString string
 	var selectedTime time.Time
@@ -158,6 +194,9 @@ func compRetType(ctx *sql.Context, args ...sql.Expression) (sql.Type, error) {
 	allString := true
 	allInt := true
 	allDatetime := true
+	anyDecimal := false
+	anyFloat := false
+	var argTypes []sql.Type
 
 	for _, arg := range args {
 		if !arg.Resolved() {
@@ -177,6 +216,13 @@ func compRetType(ctx *sql.Context, args ...sql.Expression) (sql.Type, error) {
 			if !types.IsInteger(argType) {
 				allInt = false
 			}
+			if types.IsDecimal(argType) {
+				anyDecimal = true
+			}
+			if types.IsFloat(argType) {
+				anyFloat = true
+			}
+			argTypes = append(argTypes, argType)
 		} else if types.IsText(argType) {
 			allInt = false
 			allDatetime = false
@@ -193,13 +239,19 @@ func compRetType(ctx *sql.Context, args ...sql.Expression) (sql.Type, error) {
 		}
 	}
 
-	// TODO: return Decimal type if all Decimals. Account for Decimals of different scales and precisions
 	if allString {
 		return types.LongText, nil
 	} else if allInt {
 		return types.Int64, nil
 	} else if allDatetime {
 		return types.DatetimeMaxPrecision, nil
+	} else if anyDecimal && !anyFloat && len(argTypes) == len(args) {
+		// only numeric arguments, at least one an exact decimal: the result
+		// keeps the widest integer part and the widest scale among them
+		if unified, ok := types.UnifiedDecimalType(argTypes...); ok {
+			return unified, nil
+		}
+		return types.Float64, nil
 	} else {
 		return types.Float64, nil
 	}

--- a/sql/types/decimal.go
+++ b/sql/types/decimal.go
@@ -645,3 +645,70 @@ func DecimalTruncate(val *apd.Decimal, scale int32) *apd.Decimal {
 	}
 	return val
 }
+
+// DecimalDigitsForType returns the precision and scale MySQL gives a numeric
+// type when it takes part in an operation that produces a DECIMAL result.
+// Integer types contribute as many digits as their widest value, unsigned
+// BIGINT contributing one more than signed. The boolean result is false for
+// non-numeric and floating-point types, which never convert to DECIMAL this
+// way.
+func DecimalDigitsForType(t sql.Type) (uint8, uint8, bool) {
+	if dt, ok := t.(sql.DecimalType); ok {
+		return dt.Precision(), dt.Scale(), true
+	}
+	switch t {
+	case Int8, Uint8, Boolean:
+		return 3, 0, true
+	case Int16, Uint16:
+		return 5, 0, true
+	case Int24, Uint24:
+		return 8, 0, true
+	case Int32, Uint32:
+		return 10, 0, true
+	case Int64:
+		return 19, 0, true
+	case Uint64:
+		return 20, 0, true
+	}
+	return 0, 0, false
+}
+
+// boundDecimalType builds a DECIMAL type with the given count of integer
+// digits and fractional digits, reducing both to the type system's limits
+// while keeping as many integer digits as possible, the way MySQL bounds
+// derived result types.
+func boundDecimalType(intDigits, scale uint16) sql.DecimalType {
+	if scale > DecimalTypeMaxScale {
+		scale = DecimalTypeMaxScale
+	}
+	prec := intDigits + scale
+	if prec > DecimalTypeMaxPrecision {
+		prec = DecimalTypeMaxPrecision
+	}
+	if prec < scale {
+		prec = scale
+	}
+	return MustCreateDecimalType(uint8(prec), uint8(scale))
+}
+
+// UnifiedDecimalType returns the DECIMAL type able to hold every one of the
+// given numeric types: it keeps the largest count of integer digits and the
+// largest scale found among them. This is how MySQL types an expression that
+// picks one of several possible values, and how it unifies result columns of
+// set operations.
+func UnifiedDecimalType(typs ...sql.Type) (sql.DecimalType, bool) {
+	var intDigits, scale uint16
+	for _, t := range typs {
+		p, s, ok := DecimalDigitsForType(t)
+		if !ok {
+			return nil, false
+		}
+		if id := uint16(p - s); id > intDigits {
+			intDigits = id
+		}
+		if uint16(s) > scale {
+			scale = uint16(s)
+		}
+	}
+	return boundDecimalType(intDigits, scale), true
+}


### PR DESCRIPTION
`GREATEST` and `LEAST` currently convert every argument through `float64` before comparing. For decimal arguments this both mis-reports the result type and can lose precision.

**Wrong result type:**
```sql
CREATE TABLE t (a decimal(6,2), b decimal(8,5), c decimal(5,1));
CREATE TABLE r AS SELECT GREATEST(a,b,c) FROM t;
-- current: column `r` is double, value 8.8
-- MySQL:   column `r` is decimal(9,5), value 8.80000
```

**Precision corruption:**
```sql
CREATE TABLE f (a decimal(31,30), b decimal(31,30));
INSERT INTO f VALUES ('1.000000000000000000000000000002',
                      '1.000000000000000000000000000001');
SELECT GREATEST(a,b) FROM f;
-- current: 1        (both values collapse to ~1.0 as float64; 30 digits lost)
-- MySQL:   1.000000000000000000000000000002
```

## Change

When every argument is an exact numeric (no `float`/`double`), `greatest`/`least` now take a decimal path:

- **Type:** the unified decimal across the arguments — widest integer part and widest scale (`decimal(6,2)`, `decimal(8,5)`, `decimal(5,1)` → `decimal(9,5)`), matching MySQL.
- **Comparison:** done on the `*apd.Decimal` values directly, so arguments differing only past float precision still order correctly.
- **Value:** presented at the unified scale.
- **Unchanged:** a `NULL` argument still yields `NULL`; if any argument is `float`/`double`, the existing approximate behavior is kept.

The type derivation uses three small helpers added to `sql/types/decimal.go` (`DecimalDigitsForType`, `boundDecimalType`, `UnifiedDecimalType`).

The existing `Greatest and least with decimal arguments` script test is updated from the float expectation to the exact decimal result, and its `// TODO ... return a float64` note (which pointed here) is removed.

Fixes dolthub/dolt#10567
