### PR TITLE
Correctly parse and compare JSON docs with numbers that are too large to fit in a float64 without losing precision.

### DIFF
--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -195,6 +195,31 @@ var JsonScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "large integer values keep precision and ordering in document",
+		SetUpScript: []string{
+			// Float between two ints
+			// Int between two floats
+
+			"CREATE TABLE xy (x bigint primary key, y JSON)",
+			`INSERT INTO xy VALUES (0, JSON_ARRAY(9223372036854775807, -9223372036854775807));`,
+			`INSERT INTO xy VALUES (1, CAST(9223372036854775807 AS JSON));`,
+			`INSERT INTO xy VALUES (2, CAST(-9223372036854775807 AS JSON));`,
+			`INSERT INTO xy VALUES (3, JSON_OBJECT("a", 9223372036854775807, "b", -9223372036854775807));`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// According to MySQL JSON type, NUMBER < OBJECT < ARRAY
+				Query: "select x, CAST(y as CHAR) from xy order by y",
+				Expected: []sql.Row{
+					{2, "-9223372036854775807"},
+					{1, "9223372036854775807"},
+					{3, `{"a": 9223372036854775807, "b": -9223372036854775807}`},
+					{0, `[9223372036854775807, -9223372036854775807]`},
+				},
+			},
+		},
+	},
+	{
 		Name: "json_object preserves types",
 		Assertions: []ScriptTestAssertion{
 			{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8727,6 +8727,26 @@ from typestable`,
 		},
 	},
 	{
+		// 9223372036854775808 cannot be represented as a float64
+		Query: "select cast('-9223372036854775806' as json);",
+		Expected: []sql.Row{
+			{types.JSONDocument{int64(-9223372036854775806)}},
+		},
+	},
+	{
+		// 9223372036854775808 cannot be represented as a float64 or an int64
+		Query: "select cast('18446744073709551615' as json);",
+		Expected: []sql.Row{
+			{types.JSONDocument{uint64(18446744073709551615)}},
+		},
+	},
+	{
+		Query: "select cast('1.5' as json);",
+		Expected: []sql.Row{
+			{types.JSONDocument{float64(1.5)}},
+		},
+	},
+	{
 		Query: "select cast(true as json) = true;",
 		Expected: []sql.Row{
 			{true},

--- a/sql/expression/function/json/json_common.go
+++ b/sql/expression/function/json/json_common.go
@@ -16,7 +16,6 @@ package json
 
 import (
 	"context"
-	goJson "encoding/json"
 	"fmt"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -81,7 +80,7 @@ func getJSONDocumentFromRow(ctx *sql.Context, row sql.Row, json sql.Expression) 
 		if err != nil {
 			return nil, err
 		}
-		if err = goJson.Unmarshal(strData.([]byte), &jsonData); err != nil {
+		if err = types.JsonUnmarshal(strData.([]byte), &jsonData); err != nil {
 			return nil, invalidJson(jsType)
 		}
 		return types.JSONDocument{Val: jsonData}, nil

--- a/sql/expression/function/json/json_overlaps.go
+++ b/sql/expression/function/json/json_overlaps.go
@@ -123,9 +123,9 @@ func jsonEquals(left, right interface{}) bool {
 
 func overlaps(left, right interface{}) bool {
 	switch lVal := left.(type) {
-	case nil, bool, string, float64:
+	case nil, bool, string, float64, int64, uint64:
 		switch rVal := right.(type) {
-		case nil, bool, string, float64, map[string]interface{}:
+		case nil, bool, string, float64, int64, uint64, map[string]interface{}:
 			return jsonEquals(left, right)
 		case []interface{}:
 			// scalar must be in array
@@ -137,7 +137,7 @@ func overlaps(left, right interface{}) bool {
 		}
 	case map[string]interface{}:
 		switch rVal := right.(type) {
-		case nil, bool, string, float64:
+		case nil, bool, string, float64, int64, uint64:
 			return overlaps(right, left)
 		case map[string]interface{}:
 			// objects must have at least one key-value pair in common
@@ -159,7 +159,7 @@ func overlaps(left, right interface{}) bool {
 		}
 	case []interface{}:
 		switch rVal := right.(type) {
-		case nil, bool, string, float64:
+		case nil, bool, string, float64, int64, uint64:
 			return overlaps(right, left)
 		case map[string]interface{}:
 			return overlaps(right, left)

--- a/sql/expression/function/json/json_value.go
+++ b/sql/expression/function/json/json_value.go
@@ -15,7 +15,6 @@
 package json
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -180,7 +179,7 @@ func GetJSONFromWrapperOrCoercibleString(ctx *sql.Context, js interface{}, funct
 		if err != nil {
 			return nil, err
 		}
-		if err = json.Unmarshal(strData.([]byte), &jsonData); err != nil {
+		if err = types.JsonUnmarshal(strData.([]byte), &jsonData); err != nil {
 			return nil, err
 		}
 		return jsonData, nil

--- a/sql/types/compare_numbers.go
+++ b/sql/types/compare_numbers.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"cmp"
+	"math"
+)
+
+// compareNumbers is a utility function for comparing numbers of any built-in integer or float type.
+// It avoids any precision loss whenever the inputs can be represented as valid int64, uint64, or float64.
+func compareNumbers(t, u interface{}) int {
+	return newNumber(t).compare(newNumber(u))
+}
+
+// number is an interface that represents any possible built-in number integer or float type, and can be compared
+// to any built-in integer or float type.
+type number interface {
+	compare(other number) int
+}
+
+func newNumber(t interface{}) number {
+	switch v := t.(type) {
+	case uint:
+		return uint64number(v)
+	case uint8:
+		return uint64number(v)
+	case uint16:
+		return uint64number(v)
+	case uint32:
+		return uint64number(v)
+	case uint64:
+		return uint64number(v)
+	case int:
+		return int64number(v)
+	case int8:
+		return int64number(v)
+	case int16:
+		return int64number(v)
+	case int32:
+		return int64number(v)
+	case int64:
+		return int64number(v)
+	case float32:
+		return float64number(v)
+	case float64:
+		return float64number(v)
+	}
+	panic("unreachable")
+}
+
+type int64number int64
+
+func (j int64number) compare(other number) int {
+	switch o := other.(type) {
+	case int64number:
+		return cmp.Compare(j, o)
+	case uint64number:
+		return compareIntToUint(j, o)
+	case float64number:
+		return compareIntToFloat(j, o)
+	}
+	panic("unreachable")
+}
+
+type uint64number uint64
+
+func (j uint64number) compare(other number) int {
+	switch o := other.(type) {
+	case int64number:
+		return compareUintToInt(j, o)
+	case float64number:
+		return compareUintToFloat(j, o)
+	case uint64number:
+		return cmp.Compare(j, o)
+	}
+	panic("unreachable")
+}
+
+type float64number float64
+
+func (j float64number) compare(other number) int {
+	switch o := other.(type) {
+	case int64number:
+		return compareFloatToInt(j, o)
+	case uint64number:
+		return compareFloatToUint(j, o)
+	case float64number:
+		return cmp.Compare(j, o)
+	}
+	panic("unreachable")
+}
+
+// compareIntToFloat compares an int64 to a float64 without unnecessary precision loss.
+func compareIntToFloat(i int64number, f float64number) int {
+	if float64(i) > float64(f) || int64(i) > int64(f) {
+		return 1
+	}
+	if float64(i) < float64(f) || int64(i) < int64(f) {
+		return -1
+	}
+	return 0
+}
+
+func compareFloatToInt(f float64number, i int64number) int {
+	return -compareIntToFloat(i, f)
+}
+
+// compareUintToFloat compares a uint64 to a float64 without unnecessary precision loss.
+func compareUintToFloat(u uint64number, f float64number) int {
+	if f < 0 {
+		return 1
+	}
+	if f > math.MaxUint64 {
+		return -1
+	}
+	if float64(u) > float64(f) || uint64(u) > uint64(f) {
+		return 1
+	}
+	if float64(u) < float64(f) || uint64(u) < uint64(f) {
+		return -1
+	}
+	return 0
+}
+
+func compareFloatToUint(f float64number, u uint64number) int {
+	return -compareUintToFloat(u, f)
+}
+
+func compareIntToUint(i int64number, u uint64number) int {
+	if i < 0 {
+		return -1
+	}
+	if u > math.MaxInt64 {
+		return -1
+	}
+	if int64(i) > int64(u) {
+		return 1
+	}
+	if int64(i) < int64(u) {
+		return -1
+	}
+	return 0
+}
+
+func compareUintToInt(u uint64number, i int64number) int {
+	return -compareIntToUint(i, u)
+}

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -15,9 +15,15 @@
 package types
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"math"
 	"reflect"
+	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/dolthub/vitess/go/sqltypes"
@@ -72,7 +78,7 @@ func convertJSONValue(v interface{}) (interface{}, sql.ConvertInRange, error) {
 	}
 
 	var val interface{}
-	if err := json.Unmarshal(data, &val); err != nil {
+	if err := JsonUnmarshal(data, &val); err != nil {
 		return nil, sql.InRange, sql.ErrInvalidJson.New(err.Error())
 	}
 
@@ -232,8 +238,68 @@ func DeepCopyJson(v interface{}) interface{} {
 
 func MustJSON(s string) JSONDocument {
 	var doc interface{}
-	if err := json.Unmarshal([]byte(s), &doc); err != nil {
+	if err := JsonUnmarshal([]byte(s), &doc); err != nil {
 		panic(err)
 	}
 	return JSONDocument{Val: doc}
+}
+
+// JsonUnmarshal unmarshals JSON data. It picks the best representation
+// for each number to avoid losing precision whenever possible.
+func JsonUnmarshal(data []byte, v *interface{}) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+
+	// Unlike json.Unmarshal, we need to check that the decoder has no more tokens
+	if _, err := dec.Token(); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("invalid JSON")
+		}
+		return err
+	}
+	*v = convertJsonNumbers(*v)
+	return nil
+}
+
+// convertJsonNumbers recursively walks a parsed JSON value and converts json.Number values to
+// int64, uint64, or float64, choosing the most precise representation.
+func convertJsonNumbers(v interface{}) interface{} {
+	switch val := v.(type) {
+	case json.Number:
+		s := val.String()
+		// If the number contains a decimal point or exponent, treat as float
+		f, _ := val.Float64()
+		if strings.ContainsAny(s, ".eE") {
+			return f
+		}
+		// If the number can be represented as a float without losing precision, do so.
+		if math.Abs(f) < (1 << 53) {
+			return f
+		}
+		// Try int64 first
+		if i, err := val.Int64(); err == nil {
+			return i
+		}
+		// Then try uint64
+		if u, err := strconv.ParseUint(s, 10, 64); err == nil {
+			return u
+		}
+		// Otherwise fall back to float
+		return f
+	case map[string]interface{}:
+		for k, inner := range val {
+			val[k] = convertJsonNumbers(inner)
+		}
+		return val
+	case []interface{}:
+		for i, inner := range val {
+			val[i] = convertJsonNumbers(inner)
+		}
+		return val
+	default:
+		return v
+	}
 }

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -253,11 +253,13 @@ func JsonUnmarshal(data []byte, v *interface{}) error {
 		return err
 	}
 
-	// Unlike json.Unmarshal, we need to check that the decoder has no more tokens
-	if _, err := dec.Token(); err != io.EOF {
-		if err == nil {
-			return fmt.Errorf("invalid JSON")
-		}
+	// Unlike json.Unmarshal, we need to check that the decoder has no more tokens to parse.
+	// If the input was valid JSON, then we are at the end of the stream and should receive an io.EOF here.
+	_, err := dec.Token()
+	if err == nil {
+		return fmt.Errorf("invalid JSON")
+	}
+	if err != io.EOF {
 		return err
 	}
 	*v = convertJsonNumbers(*v)

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -180,7 +180,7 @@ func NewLazyJSONDocument(bytes []byte) sql.JSONWrapper {
 		Bytes: bytes,
 		interfaceFunc: sync.OnceValues(func() (interface{}, error) {
 			var val interface{}
-			err := json.Unmarshal(bytes, &val)
+			err := JsonUnmarshal(bytes, &val)
 			if err != nil {
 				return nil, err
 			}
@@ -550,7 +550,7 @@ func ContainsJSON(a, b interface{}) (bool, error) {
 		return containsJSONBool(a, b)
 	case string:
 		return containsJSONString(a, b)
-	case float64:
+	case float64, int64, uint64:
 		return containsJSONNumber(a, b)
 	default:
 		return false, sql.ErrInvalidType.New(a)
@@ -654,15 +654,12 @@ func containsJSONString(a string, b interface{}) (bool, error) {
 	}
 }
 
-func containsJSONNumber(a float64, b interface{}) (bool, error) {
-	switch b := b.(type) {
-	case float64:
-		return a == b, nil
-	case int64:
-		return a == float64(b), nil
-	default:
+func containsJSONNumber(a, b interface{}) (bool, error) {
+	cmp, err := compareJSONNumber(a, b)
+	if err != nil {
 		return false, nil
 	}
+	return cmp == 0, nil
 }
 
 // CompareJSON compares two JSON values. It returns 0 if the values are equal, -1 if a < b, and 1 if a > b.
@@ -752,27 +749,7 @@ func CompareJSON(ctx context.Context, a, b interface{}) (int, error) {
 		return compareJSONObject(ctx, a, b)
 	case string:
 		return compareJSONString(a, b)
-	case int:
-		return compareJSONNumber(float64(a), b)
-	case uint8:
-		return compareJSONNumber(float64(a), b)
-	case uint16:
-		return compareJSONNumber(float64(a), b)
-	case uint32:
-		return compareJSONNumber(float64(a), b)
-	case uint64:
-		return compareJSONNumber(float64(a), b)
-	case int8:
-		return compareJSONNumber(float64(a), b)
-	case int16:
-		return compareJSONNumber(float64(a), b)
-	case int32:
-		return compareJSONNumber(float64(a), b)
-	case int64:
-		return compareJSONNumber(float64(a), b)
-	case float32:
-		return compareJSONNumber(float64(a), b)
-	case float64:
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
 		return compareJSONNumber(a, b)
 	case *apd.Decimal:
 		af, _ := a.Float64()
@@ -916,46 +893,16 @@ func compareJSONString(a string, b interface{}) (int, error) {
 	}
 }
 
-func compareJSONNumber(a float64, b interface{}) (int, error) {
-	switch b := b.(type) {
-	case
-		bool,
-		JsonArray,
-		JsonObject,
-		string:
+func compareJSONNumber(a, b interface{}) (int, error) {
+	switch v := b.(type) {
+	case bool, JsonArray, JsonObject, string:
 		// a is lower precedence
 		return -1, nil
-	case int:
-		return compareJSONNumber(a, float64(b))
-	case uint8:
-		return compareJSONNumber(a, float64(b))
-	case uint16:
-		return compareJSONNumber(a, float64(b))
-	case uint32:
-		return compareJSONNumber(a, float64(b))
-	case uint64:
-		return compareJSONNumber(a, float64(b))
-	case int8:
-		return compareJSONNumber(a, float64(b))
-	case int16:
-		return compareJSONNumber(a, float64(b))
-	case int32:
-		return compareJSONNumber(a, float64(b))
-	case int64:
-		return compareJSONNumber(a, float64(b))
-	case float32:
-		return compareJSONNumber(a, float64(b))
-	case float64:
-		if a > b {
-			return 1, nil
-		}
-		if a < b {
-			return -1, nil
-		}
-		return 0, nil
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return compareNumbers(a, v), nil
 	case *apd.Decimal:
-		bf, _ := b.Float64()
-		return compareJSONNumber(a, bf)
+		f, _ := v.Float64()
+		return compareNumbers(a, f), nil
 	default:
 		// a is higher precedence
 		return 1, nil

--- a/sql/types/jsontests/json_tests.go
+++ b/sql/types/jsontests/json_tests.go
@@ -77,6 +77,7 @@ var JsonCompareTests = []JsonCompareTest{
 	{Left: `0`, Right: `0.0`, Cmp: 0},
 	{Left: `0`, Right: `-1`, Cmp: 1},
 	{Left: `0`, Right: `3.14`, Cmp: -1},
+	{Left: `9223372036854775807`, Right: `9223372036854775808`, Cmp: -1},
 
 	// arrays
 	{Left: `[1,2]`, Right: `[1,2]`, Cmp: 0},


### PR DESCRIPTION
Previously we would parse all numbers in serialized JSON as 64-bit floats, and all comparisons between numbers in JSON would be coerced to 64-bit floats.

This was causing problems for inputs that can't be represented precisely as a float, but can be represented precisely as an int64 or uint64.

This PR enhances the logic for both parsing and comparing JSON documents to correctly handle float64, int64, and uint64 without any loss of precision.