### PR TITLE
Fix panic for `LIKE` expression with empty `ESCAPE` character

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -4994,6 +4994,78 @@ SELECT * FROM cte WHERE  d = 2;`,
 		},
 	},
 	{
+		Query: `select 'test1' like 'test_';`,
+		Expected: []sql.Row{
+			{true},
+		},
+	},
+	{
+		Query: `select 'test1' like 'test_' escape '\\';`,
+		Expected: []sql.Row{
+			{true},
+		},
+	},
+	{
+		Query: `select 'test1' like 'test_' escape '';`,
+		Expected: []sql.Row{
+			{true},
+		},
+	},
+	{
+		Query: `select 'test1' like 'test\0_' escape '';`,
+		Expected: []sql.Row{
+			{false},
+		},
+	},
+	{
+		Query: `select 'test_' like 'test_';`,
+		Expected: []sql.Row{
+			{true},
+		},
+	},
+	{
+		Query: `select 'test_' like 'test_' escape '\\';`,
+		Expected: []sql.Row{
+			{true},
+		},
+	},
+	{
+		Query: `select 'test_' like 'test_' escape '';`,
+		Expected: []sql.Row{
+			{true},
+		},
+	},
+	{
+		Query: `select 'test_' like 'test\0_' escape '';`,
+		Expected: []sql.Row{
+			{true},
+		},
+	},
+	{
+		Query: `select 'test\0_' like 'test\0_' escape '';`,
+		Expected: []sql.Row{
+			{false},
+		},
+	},
+	{
+		Query: `select 'test\\_' like 'test\\_';`,
+		Expected: []sql.Row{
+			{false},
+		},
+	},
+	{
+		Query: `select 'test\\_' like 'test\\_' escape '\\';`,
+		Expected: []sql.Row{
+			{false},
+		},
+	},
+	{
+		Query: `select 'test\\_' like 'test\\_' escape '';`,
+		Expected: []sql.Row{
+			{true},
+		},
+	},
+	{
 		Query: `SELECT * FROM foo.othertable`,
 		Expected: []sql.Row{
 			{"a", int32(4)},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -14763,7 +14763,8 @@ select * from t1 except (
 		},
 	},
 	{
-		Name: "LIKE expression with ESCAPE clause",
+		Name:    "LIKE expression with ESCAPE clause",
+		Dialect: "mysql",
 		SetUpScript: []string{
 			"CREATE TABLE t(value VARCHAR(1), pattern VARCHAR(1));",
 			"INSERT INTO t VALUES ('a', 'a');",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -14762,6 +14762,21 @@ select * from t1 except (
 			},
 		},
 	},
+	{
+		Name: "LIKE expression with ESCAPE clause",
+		SetUpScript: []string{
+			"CREATE TABLE t(value VARCHAR(1), pattern VARCHAR(1));",
+			"INSERT INTO t VALUES ('a', 'a');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT FIRST_VALUE(value LIKE pattern ESCAPE '') OVER () AS actual FROM t;",
+				Expected: []sql.Row{
+					{true},
+				},
+			},
+		},
+	},
 }
 
 var BrokenScriptTests = []ScriptTest{

--- a/sql/expression/like.go
+++ b/sql/expression/like.go
@@ -150,39 +150,46 @@ func (l *Like) evalRight(ctx *sql.Context, row sql.Row) (right *string, escape r
 	if err != nil {
 		return nil, 0, err
 	}
-	if _, ok := rightVal.(string); !ok {
+	var rightStr string
+	var ok bool
+	if rightStr, ok = rightVal.(string); !ok {
 		// Use type-aware conversion for enum types
-		rightStr, _, err := types.ConvertToCollatedString(ctx, rightVal, l.Right().Type(ctx))
+		rightStr, _, err = types.ConvertToCollatedString(ctx, rightVal, l.Right().Type(ctx))
 		if err != nil {
 			return nil, 0, err
 		}
-		rightVal = rightStr
 	}
+	right = &rightStr
 
-	var escapeVal interface{}
+	escape = '\\'
 	if l.Escape != nil {
+		var escapeVal any
 		escapeVal, err = l.Escape.Eval(ctx, row)
 		if err != nil {
 			return nil, 0, err
 		}
-		if escapeVal == nil {
-			escapeVal = `\`
-		}
-		if _, ok := escapeVal.(string); !ok {
-			escapeVal, _, err = types.LongText.Convert(ctx, escapeVal)
-			if err != nil {
-				return nil, 0, err
+		if escapeVal != nil {
+			var escapeStr string
+			if escapeStr, ok = escapeVal.(string); !ok {
+				escapeVal, _, err = types.LongText.Convert(ctx, escapeVal)
+				if err != nil {
+					return nil, 0, err
+				}
+				escapeStr = escapeVal.(string)
+			}
+			switch utf8.RuneCountInString(escapeStr) {
+			case 0:
+				// an empty string escape character means escape the NUL character (\0)
+				escape = 0
+			case 1:
+				escape = []rune(escapeStr)[0]
+			default:
+				return nil, 0, sql.ErrInvalidArgument.New("ESCAPE")
 			}
 		}
-		if utf8.RuneCountInString(escapeVal.(string)) > 1 {
-			return nil, 0, sql.ErrInvalidArgument.New("ESCAPE")
-		}
-	} else {
-		escapeVal = `\`
 	}
 
-	rightStr := rightVal.(string)
-	return &rightStr, []rune(escapeVal.(string))[0], nil
+	return right, escape, nil
 }
 
 func (l *Like) String() string {

--- a/sql/expression/like_test.go
+++ b/sql/expression/like_test.go
@@ -78,13 +78,14 @@ func TestCustomPatternToRegex(t *testing.T) {
 
 func TestLike(t *testing.T) {
 	testCases := []struct {
-		pattern, value, escape string
-		ok                     bool
-		collation              sql.CollationID
+		pattern, value string
+		escape         any
+		ok             bool
+		collation      sql.CollationID
 	}{
 		{"a__", "abc", "", true, sql.Collation_Default},
 		{"a__", "abcd", "", false, sql.Collation_Default},
-		{"a%b", "acb", "", true, sql.Collation_Default},
+		{"ab\\_", "ab_", "", false, sql.Collation_Default},
 		{"a%b", "acdkeflskjfdklb", "", true, sql.Collation_Default},
 		{"a%b", "ab", "", true, sql.Collation_Default},
 		{"a%b", "a", "", false, sql.Collation_Default},
@@ -96,10 +97,10 @@ func TestLike(t *testing.T) {
 		{"a_%_b%_%c", "AaAbBcCbCc", "", true, sql.Collation_utf8mb4_0900_ai_ci},
 		{"a_%_b%_%c", "AbbbbC", "", true, sql.Collation_utf8mb4_0900_ai_ci},
 		{"a_%_n%_%z", "aBcDeFgHiJkLmNoPqRsTuVwXyZ", "", true, sql.Collation_utf8mb4_0900_ai_ci},
-		{`a\%b`, "acb", "", false, sql.Collation_Default},
-		{`a\%b`, "a%b", "", true, sql.Collation_Default},
-		{`a\%b`, "A%B", "", false, sql.Collation_Default},
-		{`a\%b`, "A%B", "", true, sql.Collation_utf8mb4_0900_ai_ci},
+		{`a\%b`, "acb", nil, false, sql.Collation_Default},
+		{`a\%b`, "a%b", nil, true, sql.Collation_Default},
+		{`a\%b`, "A%B", nil, false, sql.Collation_Default},
+		{`a\%b`, "A%B", nil, true, sql.Collation_utf8mb4_0900_ai_ci},
 		{"a$%b", "acb", "$", false, sql.Collation_Default},
 		{"a$%b", "a%b", "$", true, sql.Collation_Default},
 		{"a$%b", "A%B", "$", false, sql.Collation_Default},
@@ -125,8 +126,8 @@ func TestLike(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(fmt.Sprintf("%q LIKE %q", tt.value, tt.pattern), func(t *testing.T) {
 			var escape sql.Expression
-			if tt.escape != "" {
-				escape = NewLiteral(tt.escape, types.LongText)
+			if tt.escape != nil {
+				escape = NewLiteral(tt.escape.(string), types.LongText)
 			}
 			f := NewLike(
 				NewGetField(0, types.CreateText(tt.collation), "", false),


### PR DESCRIPTION
Despite what MySQL documentation says, empty `ESCAPE` character actually escapes the `NUL` character (`\0`).

fixes: https://github.com/dolthub/dolt/issues/11518