### PR TITLE
fix panic in TRIM functions

### DIFF
--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -1201,6 +1201,31 @@ var FunctionQueryTests = []QueryTest{
 		Query:    `SELECT TRIM(LEADING 1 FROM 11111112)`,
 		Expected: []sql.Row{{"2"}},
 	},
+	// TODO: TimeSpan type currently always has precision 6
+	{
+		Query:    `SELECT TRIM(TIME('12:34:56.123456'))`,
+		Expected: []sql.Row{{"12:34:56.123456"}},
+	},
+	{
+		Query:    `SELECT LTRIM(TIME('12:34:56.123456'))`,
+		Expected: []sql.Row{{"12:34:56.123456"}},
+	},
+	{
+		Query:    `SELECT RTRIM(TIME('12:34:56.123456'))`,
+		Expected: []sql.Row{{"12:34:56.123456"}},
+	},
+	{
+		Query:    `SELECT TRIM(LEADING '12:34:56.' FROM TIME('12:34:56.123456'))`,
+		Expected: []sql.Row{{"123456"}},
+	},
+	{
+		Query:    `SELECT TRIM(TRAILING '.123456' FROM TIME('12:34:56.123456'))`,
+		Expected: []sql.Row{{"12:34:56"}},
+	},
+	{
+		Query:    `SELECT TRIM('0' FROM TIME('00:12:34.123'))`,
+		Expected: []sql.Row{{":12:34.123"}},
+	},
 
 	// SUBSTRING_INDEX Function Tests
 	{

--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -1201,30 +1201,41 @@ var FunctionQueryTests = []QueryTest{
 		Query:    `SELECT TRIM(LEADING 1 FROM 11111112)`,
 		Expected: []sql.Row{{"2"}},
 	},
-	// TODO: TimeSpan type currently always has precision 6
 	{
-		Query:    `SELECT TRIM(TIME('12:34:56.123456'))`,
-		Expected: []sql.Row{{"12:34:56.123456"}},
+		// TODO: TimeSpan type currently always has precision 6, but it has precision 0 on ServerEngine
+		SkipServerEngine: true,
+		Query:            `SELECT TRIM(TIME('12:34:56.123456'))`,
+		Expected:         []sql.Row{{"12:34:56.123456"}},
 	},
 	{
-		Query:    `SELECT LTRIM(TIME('12:34:56.123456'))`,
-		Expected: []sql.Row{{"12:34:56.123456"}},
+		// TODO: TimeSpan type currently always has precision 6, but it has precision 0 on ServerEngine
+		SkipServerEngine: true,
+		Query:            `SELECT LTRIM(TIME('12:34:56.123456'))`,
+		Expected:         []sql.Row{{"12:34:56.123456"}},
 	},
 	{
-		Query:    `SELECT RTRIM(TIME('12:34:56.123456'))`,
-		Expected: []sql.Row{{"12:34:56.123456"}},
+		// TODO: TimeSpan type currently always has precision 6, but it has precision 0 on ServerEngine
+		SkipServerEngine: true,
+		Query:            `SELECT RTRIM(TIME('12:34:56.123456'))`,
+		Expected:         []sql.Row{{"12:34:56.123456"}},
 	},
 	{
-		Query:    `SELECT TRIM(LEADING '12:34:56.' FROM TIME('12:34:56.123456'))`,
-		Expected: []sql.Row{{"123456"}},
+		// TODO: TimeSpan type currently always has precision 6, but it has precision 0 on ServerEngine
+		SkipServerEngine: true,
+		Query:            `SELECT TRIM(LEADING '12:34:56.' FROM TIME('12:34:56.123456'))`,
+		Expected:         []sql.Row{{"123456"}},
 	},
 	{
-		Query:    `SELECT TRIM(TRAILING '.123456' FROM TIME('12:34:56.123456'))`,
-		Expected: []sql.Row{{"12:34:56"}},
+		// TODO: TimeSpan type currently always has precision 6, but it has precision 0 on ServerEngine
+		SkipServerEngine: true,
+		Query:            `SELECT TRIM(TRAILING '.123456' FROM TIME('12:34:56.123456'))`,
+		Expected:         []sql.Row{{"12:34:56"}},
 	},
 	{
-		Query:    `SELECT TRIM('0' FROM TIME('00:12:34.123'))`,
-		Expected: []sql.Row{{":12:34.123"}},
+		// TODO: TimeSpan type currently always has precision 6, but it has precision 0 on ServerEngine
+		SkipServerEngine: true,
+		Query:            `SELECT TRIM('0' FROM TIME('00:12:34.123'))`,
+		Expected:         []sql.Row{{":12:34.123"}},
 	},
 
 	// SUBSTRING_INDEX Function Tests

--- a/sql/expression/function/trim_ltrim_rtrim.go
+++ b/sql/expression/function/trim_ltrim_rtrim.go
@@ -36,7 +36,11 @@ var _ sql.FunctionExpression = (*Trim)(nil)
 var _ sql.CollationCoercible = (*Trim)(nil)
 
 func NewTrim(str sql.Expression, pat sql.Expression, dir string) sql.Expression {
-	return &Trim{str, pat, dir}
+	return &Trim{
+		str: str,
+		pat: pat,
+		dir: dir,
+	}
 }
 
 // FunctionName implements sql.FunctionExpression
@@ -69,7 +73,7 @@ func (t *Trim) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	// Convert pat into string and unwrap automatically
 	pat, _, err = types.LongText.Convert(ctx, pat)
 	if err != nil {
-		return nil, sql.ErrInvalidType.New(reflect.TypeOf(pat).String())
+		return nil, err
 	}
 
 	// Handle Dolt's TextStorage wrapper that doesn't convert to plain string
@@ -92,7 +96,7 @@ func (t *Trim) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	// Convert str to text type and unwrap automatically
 	str, _, err = types.LongText.Convert(ctx, str)
 	if err != nil {
-		return nil, sql.ErrInvalidType.New(reflect.TypeOf(str).String())
+		return nil, err
 	}
 
 	// Handle Dolt's TextStorage wrapper that doesn't convert to plain string
@@ -128,11 +132,11 @@ func (t *Trim) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 }
 
 // IsNullable implements the Expression interface.
-func (t Trim) IsNullable(ctx *sql.Context) bool {
+func (t *Trim) IsNullable(ctx *sql.Context) bool {
 	return t.str.IsNullable(ctx) || t.pat.IsNullable(ctx)
 }
 
-func (t Trim) String() string {
+func (t *Trim) String() string {
 	if t.dir == sqlparser.Leading {
 		return fmt.Sprintf("trim(leading %v from %v)", t.pat, t.str)
 	} else if t.dir == sqlparser.Trailing {
@@ -145,20 +149,20 @@ func (t Trim) String() string {
 	}
 }
 
-func (t Trim) Resolved() bool {
+func (t *Trim) Resolved() bool {
 	return t.str.Resolved() && t.pat.Resolved() && t.pat.Resolved()
 }
 
-func (t Trim) Type(ctx *sql.Context) sql.Type { return t.str.Type(ctx) }
+func (t *Trim) Type(ctx *sql.Context) sql.Type { return t.str.Type(ctx) }
 
 // CollationCoercibility implements the interface sql.CollationCoercible.
-func (t Trim) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+func (t *Trim) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
 	leftCollation, leftCoercibility := sql.GetCoercibility(ctx, t.str)
 	rightCollation, rightCoercibility := sql.GetCoercibility(ctx, t.pat)
 	return sql.ResolveCoercibility(leftCollation, leftCoercibility, rightCollation, rightCoercibility)
 }
 
-func (t Trim) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
+func (t *Trim) WithChildren(x *sql.Context, children ...sql.Expression) (sql.Expression, error) {
 	if len(children) != 2 {
 		return nil, sql.ErrInvalidChildrenNumber.New(t, len(children), 2)
 	}
@@ -289,7 +293,7 @@ func (t *RightTrim) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	str, _, err = types.LongText.Convert(ctx, str)
 	if err != nil {
-		return nil, sql.ErrInvalidType.New(reflect.TypeOf(str))
+		return nil, err
 	}
 
 	// Handle Dolt's TextStorage wrapper that doesn't convert to plain string

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -452,6 +452,8 @@ func ConvertToBytes(ctx context.Context, v interface{}, t sql.StringType, dest [
 		start = 0
 	case GeometryValue:
 		return s.Serialize(), nil
+	case Timespan:
+		val = s.AppendBytes(dest)
 	default:
 		return nil, sql.ErrConvertToSQL.New(s, t)
 	}


### PR DESCRIPTION
Added a conversion for `TimeSpan` type to `LongText` and updated errors to not panic.

fixes: https://github.com/dolthub/dolt/issues/11455