### PR TITLE
Fix LOAD_FILE panic on non-string argument (dolt#11564)

### DIFF
--- a/sql/expression/function/load_file.go
+++ b/sql/expression/function/load_file.go
@@ -113,15 +113,27 @@ func (l *LoadFile) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 // getFile returns the file handler for the passed in filename. The file must be in the secure_file_priv
 // directory.
 func (l *LoadFile) getFile(ctx *sql.Context, row sql.Row, secureFileDir string) (*os.File, error) {
-	fileName, err := l.fileName.Eval(ctx, row)
+	fileNameVal, err := l.fileName.Eval(ctx, row)
 	if err != nil {
 		return nil, err
 	}
+	if fileNameVal == nil {
+		return nil, nil
+	}
+
+	// The filename argument may be any type (e.g. LOAD_FILE(1)); MySQL coerces it
+	// to a string before resolving the path. Convert here so a non-string value
+	// does not trigger a type-assertion panic.
+	fileNameVal, _, err = types.LongText.Convert(ctx, fileNameVal)
+	if err != nil {
+		return nil, err
+	}
+	fileName := fileNameVal.(string)
 
 	// If the secure_file_priv directory is not set, just read the file from whatever directory it is in
 	// Otherwise determine whether the file is in the secure_file_priv directory.
 	if secureFileDir == "" {
-		return os.Open(fileName.(string))
+		return os.Open(fileName)
 	}
 
 	// Open the two directories (secure_file_priv and the file dir) and validate they are the same.
@@ -135,7 +147,7 @@ func (l *LoadFile) getFile(ctx *sql.Context, row sql.Row, secureFileDir string) 
 		return nil, err
 	}
 
-	ffDir, err := os.Open(filepath.Dir(fileName.(string)))
+	ffDir, err := os.Open(filepath.Dir(fileName))
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +162,7 @@ func (l *LoadFile) getFile(ctx *sql.Context, row sql.Row, secureFileDir string) 
 		return nil, nil
 	}
 
-	return os.Open(fileName.(string))
+	return os.Open(fileName)
 }
 
 // isFileTooBig return the current file size and whether or not it is larger than max_allowed_packet.

--- a/sql/expression/function/load_file_test.go
+++ b/sql/expression/function/load_file_test.go
@@ -69,6 +69,18 @@ func TestLoadFileBadDir(t *testing.T) {
 	assert.Equal(t, nil, res)
 }
 
+func TestLoadFileNumericArg(t *testing.T) {
+	// LOAD_FILE with a non-string (numeric) argument must not panic. MySQL
+	// coerces the argument to a string filename, does not find such a file,
+	// and returns SQL NULL. See dolthub/dolt#11564.
+	fileName := expression.NewLiteral(int8(1), types.Int8)
+	fn := NewLoadFile(sql.NewEmptyContext(), fileName)
+
+	res, err := fn.Eval(sql.NewEmptyContext(), sql.Row{})
+	assert.NoError(t, err)
+	assert.Equal(t, nil, res)
+}
+
 type loadFileTestCase struct {
 	name     string
 	fileData []byte


### PR DESCRIPTION
## What

Fixes the panic reported in dolthub/dolt#11564.

```sql
SELECT FIRST_VALUE(LOAD_FILE(1)) OVER () AS actual FROM (SELECT 1 AS z) q;
```

crashes Dolt with:

```
panic: interface conversion: interface {} is int8, not string
```

MySQL instead coerces the numeric argument to a string filename, fails to find
that file, and returns SQL `NULL`.

## Fix

`LoadFile.getFile` evaluated the filename expression and type-asserted the result
directly to `string` (`fileName.(string)`), so any non-string argument
(`LOAD_FILE(1)`, `LOAD_FILE(1.5)`, etc.) panicked. The evaluated value is now
converted with `types.LongText.Convert` before being used as a path, matching how
other string functions in this package (`conv`, `concat_ws`, `find_in_set`,
`insert`, …) coerce their arguments. A `nil` argument now returns `NULL` as well.

## Tests

Added `TestLoadFileNumericArg`, which passes an `int8(1)` literal and asserts the
call returns `NULL` with no error (and no panic).

## Validation (real results on this checkout)

Toolchain: Go 1.26.2. Regex-dependent code was built with the repo's own
`gms_pure_go` tag (`CGO_ENABLED=0`) because ICU dev headers aren't available in my
environment.

RED→GREEN, genuinely reproduced:

- Before the fix, `go test -tags gms_pure_go -run TestLoadFileNumericArg ./sql/expression/function/`
  panics with the exact reported error at `load_file.go:124`.
- After the fix:

```
$ go test -tags gms_pure_go -v -run 'TestLoadFile' ./sql/expression/function/
--- PASS: TestLoadFileNoSecurePriv
--- PASS: TestLoadFileBadDir
--- PASS: TestLoadFileNumericArg
--- PASS: TestLoadFile
ok  github.com/dolthub/go-mysql-server/sql/expression/function
```

`gofmt -l` reports no changes for the two touched files, and `go vet` shows no new
warnings from this diff.

Note: running the full `./sql/expression/function/` suite under `gms_pure_go` shows
one unrelated pre-existing failure, `TestRegexpReplaceWithFlags/all_flags` (a
CRLF-flag difference in the pure-Go regex fallback). I confirmed it fails
identically on a clean checkout with my change stashed, so it is outside this diff.

First-time contributor here — happy to adjust the approach or test style.
