### PR TITLE
fix: avoid panic in LOAD_FILE with a non-string argument (dolt#11564)

### DIFF
--- a/sql/expression/function/load_file.go
+++ b/sql/expression/function/load_file.go
@@ -113,15 +113,31 @@ func (l *LoadFile) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 // getFile returns the file handler for the passed in filename. The file must be in the secure_file_priv
 // directory.
 func (l *LoadFile) getFile(ctx *sql.Context, row sql.Row, secureFileDir string) (*os.File, error) {
-	fileName, err := l.fileName.Eval(ctx, row)
+	fileNameVal, err := l.fileName.Eval(ctx, row)
 	if err != nil {
 		return nil, err
 	}
 
+	// LOAD_FILE(NULL) yields NULL.
+	if fileNameVal == nil {
+		return nil, nil
+	}
+
+	// The filename argument need not already be a string (e.g. LOAD_FILE(1));
+	// coerce it the way MySQL does instead of asserting, which would panic.
+	fileNameConv, _, err := types.LongText.Convert(ctx, fileNameVal)
+	if err != nil {
+		return nil, err
+	}
+	if fileNameConv == nil {
+		return nil, nil
+	}
+	fileName := fileNameConv.(string)
+
 	// If the secure_file_priv directory is not set, just read the file from whatever directory it is in
 	// Otherwise determine whether the file is in the secure_file_priv directory.
 	if secureFileDir == "" {
-		return os.Open(fileName.(string))
+		return os.Open(fileName)
 	}
 
 	// Open the two directories (secure_file_priv and the file dir) and validate they are the same.
@@ -135,7 +151,7 @@ func (l *LoadFile) getFile(ctx *sql.Context, row sql.Row, secureFileDir string) 
 		return nil, err
 	}
 
-	ffDir, err := os.Open(filepath.Dir(fileName.(string)))
+	ffDir, err := os.Open(filepath.Dir(fileName))
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +166,7 @@ func (l *LoadFile) getFile(ctx *sql.Context, row sql.Row, secureFileDir string) 
 		return nil, nil
 	}
 
-	return os.Open(fileName.(string))
+	return os.Open(fileName)
 }
 
 // isFileTooBig return the current file size and whether or not it is larger than max_allowed_packet.

--- a/sql/expression/function/load_file_nonstring_test.go
+++ b/sql/expression/function/load_file_nonstring_test.go
@@ -1,0 +1,36 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// TestLoadFileNonStringArg is a regression test for a panic where a non-string
+// argument to LOAD_FILE (e.g. LOAD_FILE(1)) triggered
+// "interface conversion: interface {} is int8, not string".
+// MySQL coerces the argument to a string and returns NULL when no such file
+// exists, so the function must not panic.
+func TestLoadFileNonStringArg(t *testing.T) {
+	// Make sure secure_file_priv does not point at a real directory from a
+	// previous test, so getFile takes the plain os.Open path.
+	vars := map[string]interface{}{"secure_file_priv": ""}
+	require.NoError(t, sql.SystemVariables.AssignValues(vars))
+
+	// Integer argument: coerced to the filename "1", which does not exist.
+	fn := NewLoadFile(sql.NewEmptyContext(), expression.NewLiteral(int8(1), types.Int8))
+	res, err := fn.Eval(sql.NewEmptyContext(), sql.Row{})
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+
+	// NULL argument yields NULL.
+	fnNull := NewLoadFile(sql.NewEmptyContext(), expression.NewLiteral(nil, types.Null))
+	resNull, err := fnNull.Eval(sql.NewEmptyContext(), sql.Row{})
+	assert.NoError(t, err)
+	assert.Nil(t, resNull)
+}


### PR DESCRIPTION
## What

Fixes dolthub/dolt#11564.

`LOAD_FILE` with a non-string argument panics. For example:

```sql
SELECT FIRST_VALUE(LOAD_FILE(1)) OVER () AS actual FROM (SELECT 1 AS z) q;
```

crashes the server with:

```
panic: interface conversion: interface {} is int8, not string
```

MySQL instead coerces the argument to a string (so `LOAD_FILE(1)` looks for a file named `1`) and returns `NULL` when no such file exists.

## Cause

`getFile` evaluated the filename expression and asserted the result was a string directly:

```go
fileName, err := l.fileName.Eval(ctx, row)
...
return os.Open(fileName.(string))
```

Any argument that does not already evaluate to `string` (an integer literal here, but also `NULL`) hits the unchecked assertion and panics.

## Fix

Coerce the evaluated argument with `types.LongText.Convert` (the same way other functions normalise string inputs) instead of asserting, and return `NULL` for a `NULL` argument. `LOAD_FILE(1)` now looks for a file named `1` and returns `NULL` when it is absent, matching MySQL.

## Verification (real results, Go)

- New `TestLoadFileNonStringArg` covers `LOAD_FILE(1)` (integer) and `LOAD_FILE(NULL)`; both return `NULL` with no error.
- **RED/GREEN**: with the old `fileName.(string)` assertion the new test panics with exactly `interface conversion: interface {} is int8, not string`; with this change it passes.
- Existing `TestLoadFile*` tests still pass; `gofmt` clean.

(The unrelated `TestRegexpReplaceWithFlags/all_flags` failure reproduces on a clean `main` under the `gms_pure_go` build tag and is not affected by this change.)
