### PR TITLE
fix: avoid panic in NTILE with a non-numeric argument (dolt#11467)

### DIFF
--- a/sql/expression/function/aggregation/ntile_nonnumeric_test.go
+++ b/sql/expression/function/aggregation/ntile_nonnumeric_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// TestNTileNonNumericArg is a regression test for a panic where a non-numeric
+// NTILE bucket expression (e.g. NTILE('x')) triggered
+// "interface conversion: interface {} is uint64, not int64" in StartPartition.
+// A non-numeric argument must be reported as an invalid-argument error instead.
+func TestNTileNonNumericArg(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	n := NewNTile(expression.NewLiteral("x", types.Text))
+
+	interval := sql.WindowInterval{Start: 0, End: 2}
+	err := n.StartPartition(ctx, interval, nil)
+	require.Error(t, err)
+	require.True(t, sql.ErrInvalidArgument.Is(err), "want ErrInvalidArgument, got %v", err)
+}

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -1369,7 +1369,7 @@ func (n *NTile) StartPartition(ctx *sql.Context, interval sql.WindowInterval, bu
 	}
 	numBucketsVal, _, err = types.Int64.Convert(ctx, numBucketsVal)
 	if err != nil {
-		numBucketsVal = uint64(0)
+		return sql.ErrInvalidArgument.New("NTILE")
 	}
 	if numBucketsVal == nil {
 		return sql.ErrInvalidArgument.New("NTILE")


### PR DESCRIPTION
## What

Fixes dolthub/dolt#11467.

`NTILE` with a non-numeric bucket argument panics. For example:

```sql
SELECT NTILE('x') OVER (ORDER BY id) AS bucket FROM t;
```

crashes the server with:

```
panic: interface conversion: interface {} is uint64, not int64
    ...aggregation.(*NTile).StartPartition
```

MySQL instead rejects the non-numeric argument with a normal argument/validation error and never starts window execution.

## Cause

`NTile.StartPartition` converts the argument with `types.Int64.Convert`, but on a conversion error it assigned a `uint64` zero and then asserted `int64`:

```go
numBucketsVal, _, err = types.Int64.Convert(ctx, numBucketsVal)
if err != nil {
    numBucketsVal = uint64(0) // wrong type
}
...
if numBucketsVal.(int64) <= 0 { // panics: value is uint64
```

`NTILE('x')` fails the conversion, gets assigned `uint64(0)`, and the following `int64` assertion panics.

## Fix

Return `sql.ErrInvalidArgument` on a conversion failure, consistent with the existing `nil` and non-positive validation branches right below it. A non-numeric `NTILE` argument now surfaces as a normal error instead of crashing.

## Verification (real results, Go)

- New `TestNTileNonNumericArg` calls `StartPartition` with a `'x'` literal and asserts an `ErrInvalidArgument` (no panic).
- **RED/GREEN**: with the old `uint64(0)` assignment the new test panics with exactly `interface conversion: interface {} is uint64, not int64`; with this change it passes.
- Full `./sql/expression/function/aggregation/` test package passes; `gofmt` clean.
