### PR TITLE
fix panic for `UNION`, `INTERSECT` and `EXCEPT` with unequal schema lengths

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -56,7 +56,6 @@ func TestQueries(t *testing.T, harness Harness) {
 	harness.Setup(setup.SimpleSetup...)
 	e := mustNewEngine(t, harness)
 	defer e.Close()
-	ctx := NewContext(harness)
 	for _, tt := range queries.QueryTests {
 		t.Run(tt.Query, func(t *testing.T) {
 			if sh, ok := harness.(SkippingHarness); tt.Skip || (ok && sh.SkipQueryTest(tt.Query)) {
@@ -65,7 +64,7 @@ func TestQueries(t *testing.T, harness Harness) {
 			if IsServerEngine(e) && tt.SkipServerEngine {
 				t.Skip("skipping for server engine")
 			}
-			TestQueryWithContext(t, ctx, e, harness, tt.Query, tt.Expected, tt.ExpectedColumns, nil, nil)
+			TestQueryWithEngine(t, harness, e, tt)
 		})
 	}
 

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -4926,6 +4926,18 @@ SELECT * FROM cte WHERE  d = 2;`,
 		Expected: []sql.Row{},
 	},
 	{
+		Query:       "select 1, 2, 3 union select 4, 5;",
+		ExpectedErr: planbuilder.ErrSelectsDifferentLength,
+	},
+	{
+		Query:       "select 1, 2, 3 intersect select 4, 5;",
+		ExpectedErr: planbuilder.ErrSelectsDifferentLength,
+	},
+	{
+		Query:       "select 1, 2, 3 except select 4, 5;",
+		ExpectedErr: planbuilder.ErrSelectsDifferentLength,
+	},
+	{
 		SkipPrepared: true,
 		Query:        "",
 		Expected:     []sql.Row{},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2768,6 +2768,10 @@ CREATE TABLE tab3 (
 				},
 			},
 			{
+				Query:       "with recursive cte (x,y) as (select 1, 2, 3 union select x, y from cte where x < 5) select * from cte;",
+				ExpectedErr: planbuilder.ErrSelectsDifferentLength,
+			},
+			{
 				Query: "with recursive cte (x,y) as (select 1, 1 intersect select 1, 1 union select x + 1, y + 2 from cte where x < 5) select * from cte;",
 				Expected: []sql.Row{
 					{1, 1},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2445,7 +2445,11 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:       "select i, k from `left` union select i, j, k from `right`",
-				ExpectedErr: planbuilder.ErrUnionSchemasDifferentLength,
+				ExpectedErr: planbuilder.ErrSelectsDifferentLength,
+			},
+			{
+				Query:       "select i, j, k from `left` union select i, j from `right`",
+				ExpectedErr: planbuilder.ErrSelectsDifferentLength,
 			},
 			{
 				Query: "table t1 union table t2 order by i;",

--- a/sql/planbuilder/cte.go
+++ b/sql/planbuilder/cte.go
@@ -131,8 +131,13 @@ func (b *Builder) buildRecursiveCte(inScope *scope, union *ast.SetOp, name strin
 	var cols sql.ColSet
 	{
 		rInit = leftScope.node
-		recSch = make(sql.Schema, len(rInit.Schema(b.ctx)))
-		for i, c := range rInit.Schema(b.ctx) {
+		rInitSch := rInit.Schema(b.ctx)
+		// recursive CTEs may leave columns empty
+		if len(columns) != 0 && len(columns) != len(rInitSch) {
+			b.handleErr(ErrSelectsDifferentLength.New(len(columns), len(rInitSch)))
+		}
+		recSch = make(sql.Schema, len(rInitSch))
+		for i, c := range rInitSch {
 			newC := c.Copy()
 			if len(columns) > 0 {
 				newC.Name = columns[i]

--- a/sql/planbuilder/errors.go
+++ b/sql/planbuilder/errors.go
@@ -25,10 +25,10 @@ var (
 
 	ErrPrimaryKeyOnNullField = errors.NewKind("All parts of PRIMARY KEY must be NOT NULL")
 
-	// ErrUnionSchemasDifferentLength is returned when the two sides of a
+	// ErrSelectsDifferentLength is returned when the two sides of a
 	// UNION do not have the same number of columns in their schemas.
-	ErrUnionSchemasDifferentLength = errors.NewKind(
-		"cannot union two queries whose schemas are different lengths; left has %d column(s) right has %d column(s).",
+	ErrSelectsDifferentLength = errors.NewKind(
+		"the used SELECT statements have a different number of columns; left has %d column(s) right has %d column(s).",
 	)
 
 	ErrQualifiedOrderBy = errors.NewKind("Table '%s' from one of the SELECTs cannot be used in global ORDER clause")

--- a/sql/planbuilder/set_op.go
+++ b/sql/planbuilder/set_op.go
@@ -117,11 +117,13 @@ func (b *Builder) buildSetOp(inScope *scope, u *ast.SetOp) (outScope *scope) {
 	tabId := b.tabId
 	ret := plan.NewSetOp(setOpType, leftScope.node, rightScope.node, distinct, limit, offset, sortConditions).WithId(tabId).WithColumns(cols)
 	outScope = leftScope
-	outScope.cols = b.mergeSetOpScopeColumns(leftScope.cols, rightScope.cols, tabId)
 	outScope.node = b.mergeSetOpSchemas(ret.(*plan.SetOp))
+	outScope.cols = b.mergeSetOpScopeColumns(leftScope.cols, rightScope.cols, tabId)
 	return
 }
 
+// mergeSetOpScopeColumns assumes that left and right are the same length.
+// This is condition is checked by mergeSetOpSchemas
 func (b *Builder) mergeSetOpScopeColumns(left, right []scopeColumn, tabId sql.TableId) []scopeColumn {
 	merged := make([]scopeColumn, len(left))
 	for i := range left {

--- a/sql/planbuilder/set_op.go
+++ b/sql/planbuilder/set_op.go
@@ -122,9 +122,13 @@ func (b *Builder) buildSetOp(inScope *scope, u *ast.SetOp) (outScope *scope) {
 	return
 }
 
-// mergeSetOpScopeColumns assumes that left and right are the same length.
-// This is condition is checked by mergeSetOpSchemas
 func (b *Builder) mergeSetOpScopeColumns(left, right []scopeColumn, tabId sql.TableId) []scopeColumn {
+	lLen, rLen := len(left), len(right)
+	if lLen != rLen {
+		err := ErrSelectsDifferentLength.New(lLen, rLen)
+		b.handleErr(err)
+	}
+
 	merged := make([]scopeColumn, len(left))
 	for i := range left {
 		merged[i] = scopeColumn{
@@ -144,7 +148,7 @@ func (b *Builder) mergeSetOpScopeColumns(left, right []scopeColumn, tabId sql.Ta
 func (b *Builder) mergeSetOpSchemas(u *plan.SetOp) sql.Node {
 	ls, rs := u.Left().Schema(b.ctx), u.Right().Schema(b.ctx)
 	if len(ls) != len(rs) {
-		err := ErrUnionSchemasDifferentLength.New(len(ls), len(rs))
+		err := ErrSelectsDifferentLength.New(len(ls), len(rs))
 		b.handleErr(err)
 	}
 


### PR DESCRIPTION
fixes: https://github.com/dolthub/dolt/issues/11491