### PR TITLE
bug fix: outer scope visibility in multiple levels of nested derived tables

### DIFF
--- a/enginetest/queries/derived_table_outer_scope_visibility_queries.go
+++ b/enginetest/queries/derived_table_outer_scope_visibility_queries.go
@@ -156,4 +156,23 @@ WHERE dcim_rackgroup.id IN ('rackgroup1', 'rackgroup2')`,
 			},
 		},
 	},
+	{
+		Name: "outer scope visibility propagates through multiple levels of derived table nesting",
+		SetUpScript: []string{
+			"create table outer_t (a int primary key);",
+			"create table inner_t (v int primary key);",
+			"insert into outer_t values (1), (2);",
+			"insert into inner_t values (10);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT a, (SELECT colid FROM (SELECT x AS colid FROM (SELECT outer_t.a AS x FROM inner_t) inner1) outer1) FROM outer_t ORDER BY a;",
+				Expected: []sql.Row{{1, 1}, {2, 2}},
+			},
+			{
+				Query:    "SELECT a, (SELECT colid FROM (SELECT y AS colid FROM (SELECT x AS y FROM (SELECT outer_t.a AS x FROM inner_t) inner2) inner1) outer1) FROM outer_t ORDER BY a;",
+				Expected: []sql.Row{{1, 1}, {2, 2}},
+			},
+		},
+	},
 }

--- a/sql/plan/scope.go
+++ b/sql/plan/scope.go
@@ -147,6 +147,9 @@ func (s *Scope) NewScopeFromSubqueryAlias(sqa *SubqueryAlias) *Scope {
 			if s.CurrentNodeIsFromSubqueryExpression { // TODO: probably copy this for lateral
 				sqa.OuterScopeVisibility = true
 				subScope.nodes = append(subScope.nodes, s.InnerToOuter()...)
+				// Propagate this flag so that derived tables nested inside |sqa| (i.e. a derived
+				// table within a derived table) also receive outer scope visibility.
+				subScope.CurrentNodeIsFromSubqueryExpression = true
 			}
 		}
 		if len(s.joinSiblings) > 0 {


### PR DESCRIPTION
Fixes a bug where a derived table nested inside another derived table (both within a correlated subquery expression) failed to inherit outer-scope visibility past the first nesting level, causing correlated references two-plus levels deep to resolve to the wrong field index or silently return wrong results. OuterScopeVisibility now propagates transitively through nested derived tables instead of only being granted to the outermost one.  