### PR TITLE
Fix functional index display in `SHOW INDEX` and `information_schema.statistics` 

### DIFF
--- a/enginetest/queries/indexed_expressions_queries.go
+++ b/enginetest/queries/indexed_expressions_queries.go
@@ -1659,7 +1659,7 @@ var IndexedExpressionsScriptTests = []ScriptTest{
 		Name: "multiple expressions: SHOW INDEX reports all key parts in the correct order",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk INT PRIMARY KEY, c1 INT, c2 INT, c3 INT);",
-			"CREATE INDEX idx1 ON test ((c1 * 10), c2, (c3 * 10));",
+			"CREATE INDEX idx1 ON test ((COALESCE(c1, 0)), c2, (COALESCE(c3, 0)));",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -1673,18 +1673,18 @@ var IndexedExpressionsScriptTests = []ScriptTest{
 			{
 				Query: "SELECT Seq_in_index, Column_name, Expression FROM information_schema.statistics WHERE table_name = 'test' AND index_name = 'idx1' ORDER BY Seq_in_index;",
 				Expected: []sql.Row{
-					{1, nil, "((c1 * 10))"},
+					{1, nil, "(coalesce(c1,0))"},
 					{2, "c2", nil},
-					{3, nil, "((c3 * 10))"},
+					{3, nil, "(coalesce(c3,0))"},
 				},
 			},
 			{
 				Query: "SHOW INDEX FROM test;",
 				Expected: []sql.Row{
 					{"test", 0, "PRIMARY", 1, "pk", nil, int64(0), nil, nil, "", "BTREE", "", "", "YES", nil},
-					{"test", 1, "idx1", 1, nil, nil, int64(0), nil, nil, "YES", "BTREE", "", "", "YES", "((c1 * 10))"},
+					{"test", 1, "idx1", 1, nil, nil, int64(0), nil, nil, "", "BTREE", "", "", "YES", "(coalesce(c1,0))"},
 					{"test", 1, "idx1", 2, "c2", nil, int64(0), nil, nil, "YES", "BTREE", "", "", "YES", nil},
-					{"test", 1, "idx1", 3, nil, nil, int64(0), nil, nil, "YES", "BTREE", "", "", "YES", "((c3 * 10))"},
+					{"test", 1, "idx1", 3, nil, nil, int64(0), nil, nil, "", "BTREE", "", "", "YES", "(coalesce(c3,0))"},
 				},
 			},
 		},

--- a/enginetest/queries/indexed_expressions_queries.go
+++ b/enginetest/queries/indexed_expressions_queries.go
@@ -1665,10 +1665,53 @@ var IndexedExpressionsScriptTests = []ScriptTest{
 			{
 				Query: "SELECT Seq_in_index, Column_name FROM information_schema.statistics WHERE table_name = 'test' AND index_name = 'idx1' ORDER BY Seq_in_index;",
 				Expected: []sql.Row{
-					{1, "!hidden!idx1!0!0"},
+					{1, nil},
 					{2, "c2"},
-					{3, "!hidden!idx1!2!0"},
+					{3, nil},
 				},
+			},
+			{
+				Query: "SELECT Seq_in_index, Column_name, Expression FROM information_schema.statistics WHERE table_name = 'test' AND index_name = 'idx1' ORDER BY Seq_in_index;",
+				Expected: []sql.Row{
+					{1, nil, "((c1 * 10))"},
+					{2, "c2", nil},
+					{3, nil, "((c3 * 10))"},
+				},
+			},
+			{
+				Query: "SHOW INDEX FROM test;",
+				Expected: []sql.Row{
+					{"test", 0, "PRIMARY", 1, "pk", nil, int64(0), nil, nil, "", "BTREE", "", "", "YES", nil},
+					{"test", 1, "idx1", 1, nil, nil, int64(0), nil, nil, "YES", "BTREE", "", "", "YES", "((c1 * 10))"},
+					{"test", 1, "idx1", 2, "c2", nil, int64(0), nil, nil, "YES", "BTREE", "", "", "YES", nil},
+					{"test", 1, "idx1", 3, nil, nil, int64(0), nil, nil, "YES", "BTREE", "", "", "YES", "((c3 * 10))"},
+				},
+			},
+		},
+	},
+	{
+		Name: "functional index NULL field reflects the expression's actual nullability, not just the underlying column",
+		SetUpScript: []string{
+			"CREATE TABLE test (pk INT PRIMARY KEY, a VARCHAR(10) NOT NULL, b VARCHAR(10));",
+			"CREATE UNIQUE INDEX idx_not_null ON test ((COALESCE(b, a)));",
+			"CREATE UNIQUE INDEX idx_nullable ON test ((COALESCE(b, b)));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT Column_name, Expression LIKE '%coalesce(b,a)%', Nullable FROM information_schema.statistics WHERE table_name = 'test' AND index_name = 'idx_not_null';",
+				Expected: []sql.Row{
+					{nil, true, ""},
+				},
+			},
+			{
+				Query: "SELECT Column_name, Expression LIKE '%coalesce(b,b)%', Nullable FROM information_schema.statistics WHERE table_name = 'test' AND index_name = 'idx_nullable';",
+				Expected: []sql.Row{
+					{nil, true, "YES"},
+				},
+			},
+			{
+				Query:    "INSERT INTO test VALUES (1, 'x', NULL);",
+				Expected: []sql.Row{{gmstypes.NewOkResult(1)}},
 			},
 		},
 	},

--- a/sql/expression/function/coalesce.go
+++ b/sql/expression/function/coalesce.go
@@ -140,14 +140,16 @@ func (c *Coalesce) CollationCoercibility(ctx *sql.Context) (collation sql.Collat
 }
 
 // IsNullable implements the sql.Expression interface.
-// Returns true if all arguments are nil
-// or of the first non-nil argument is nullable, otherwise false.
+// COALESCE only evaluates to NULL when every argument evaluates to NULL, so it is nullable
+// only if all of its arguments are nullable.
 func (c *Coalesce) IsNullable(ctx *sql.Context) bool {
 	for _, arg := range c.args {
 		if arg == nil {
 			continue
 		}
-		return arg.IsNullable(ctx)
+		if !arg.IsNullable(ctx) {
+			return false
+		}
 	}
 	return true
 }

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -1545,7 +1545,14 @@ func statisticsRowIter(ctx *Context, c Catalog) (RowIter, error) {
 								nullable = ""
 							}
 
-							// TODO: we currently don't support expression index such as ((i * 20))
+							var colNameVal, expression interface{}
+							if col.HiddenSystem && col.Generated != nil {
+								colNameVal = nil
+								expression = plan.GetGeneratedColumnExpressionString(col)
+							} else {
+								colNameVal = colName
+								expression = nil
+							}
 
 							rows = append(rows, Row{
 								db.CatalogName, // table_catalog
@@ -1555,7 +1562,7 @@ func statisticsRowIter(ctx *Context, c Catalog) (RowIter, error) {
 								db.SchemaName,  // index_schema
 								indexName,      // index_name
 								seqInIndex,     // seq_in_index	NOT NULL
-								colName,        // column_name
+								colNameVal,     // column_name
 								collation,      // collation
 								cardinality,    // cardinality
 								subPart,        // sub_part
@@ -1565,7 +1572,7 @@ func statisticsRowIter(ctx *Context, c Catalog) (RowIter, error) {
 								comment,        // comment		NOT NULL
 								indexComment,   // index_comment	NOT NULL
 								isVisible,      // is_visible		NOT NULL
-								nil,            // expression
+								expression,     // expression
 							})
 						}
 					}

--- a/sql/plan/showcolumns.go
+++ b/sql/plan/showcolumns.go
@@ -171,3 +171,12 @@ func GetColumnFromIndexExpr(ctx *sql.Context, expr string, table sql.Table) *sql
 
 	return nil
 }
+
+// GetGeneratedColumnExpressionString returns the SQL text of the expression used to generate the hidden,
+// system column |col|, which must have been created to back a functional index key part.
+func GetGeneratedColumnExpressionString(col *sql.Column) string {
+	if _, ok := col.Generated.Expr.(*sql.UnresolvedColumnDefault); ok {
+		return col.Generated.Expr.String()
+	}
+	return col.Generated.String()
+}

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -2532,7 +2532,7 @@ func (b *BaseBuilder) createHiddenSystemColumn(ctx *sql.Context, n *plan.AlterIn
 		Source:         n.Table.Name(),
 		DatabaseSource: n.Table.Database().Name(),
 		PrimaryKey:     false,
-		Nullable:       true,
+		Nullable:       expr.IsNullable(ctx),
 		Virtual:        true,
 		AutoIncrement:  false,
 		// Marking this as a hidden system column means it can't be referenced

--- a/sql/rowexec/show_iters.go
+++ b/sql/rowexec/show_iters.go
@@ -243,7 +243,12 @@ func (i *showIndexesIter) Next(ctx *sql.Context) (sql.Row, error) {
 
 	nullable := ""
 	if col := plan.GetColumnFromIndexExpr(ctx, show.expression, tbl); col != nil {
-		columnName, expression = col.Name, nil
+		if col.HiddenSystem && col.Generated != nil {
+			// For a functional index key part, don't expose the internal hidden virtual column's name
+			columnName, expression = nil, plan.GetGeneratedColumnExpressionString(col)
+		} else {
+			columnName, expression = col.Name, nil
+		}
 		if col.Nullable {
 			nullable = "YES"
 		}
@@ -485,24 +490,20 @@ func (i *showCreateTablesIter) produceCreateTableStatement(ctx *sql.Context, tab
 				continue
 			}
 			if col.HiddenSystem && col.Generated != nil {
-				// TODO: This type-check is a workaround for an inconsistency in how Dolt stores
-				// generated expressions. Dolt's ToDoltCol() serializes via col.Generated.String()
-				// (i.e. ColumnDefaultValue.String()), which wraps the inner expression in parens:
-				// e.g. Arithmetic.String()="(c1*10)" → stored as "((c1*10))". On read, that string
-				// becomes UnresolvedColumnDefault.ExprString, so calling ColumnDefaultValue.String()
-				// again would triple-wrap it. Two cleaner fixes exist:
+				// TODO: The paren-doubling workaround inside GetGeneratedColumnExpressionString is due to
+				// an inconsistency in how Dolt stores generated expressions. Dolt's ToDoltCol() serializes
+				// via col.Generated.String() (i.e. ColumnDefaultValue.String()), which wraps the inner
+				// expression in parens: e.g. Arithmetic.String()="(c1*10)" → stored as "((c1*10))". On
+				// read, that string becomes UnresolvedColumnDefault.ExprString, so calling
+				// ColumnDefaultValue.String() again would triple-wrap it. Two cleaner fixes exist:
 				//   A) Change ColumnDefaultValue.String() to return Expr.String() directly when Expr
 				//      is *UnresolvedColumnDefault (making it idempotent for the stored form). No
 				//      migration needed, but affects every call site that mixes resolved/unresolved.
 				//   B) Change Dolt's ToDoltCol() to store col.Generated.Expr.String() instead of
 				//      col.Generated.String(), removing the extra paren at the source. Requires
 				//      migration for any existing databases with functional indexes.
-				// Either fix would let this site use col.Generated.String() unconditionally.
-				if _, ok := col.Generated.Expr.(*sql.UnresolvedColumnDefault); ok {
-					indexCols = append(indexCols, col.Generated.Expr.String())
-				} else {
-					indexCols = append(indexCols, col.Generated.String())
-				}
+				// Either fix would let GetGeneratedColumnExpressionString use col.Generated.String() unconditionally.
+				indexCols = append(indexCols, plan.GetGeneratedColumnExpressionString(col))
 			} else {
 				indexDef := i.formatter.QuoteIdentifier(col.Name)
 				if len(prefixLengths) > idx && prefixLengths[idx] != 0 {


### PR DESCRIPTION
`SHOW INDEX` and `information_schema.statistics` were exposing the internal !hidden!... system-column name in `Column_name` and leaving `Expression` `NULL` for functional index key parts, instead of matching MySQL's Column_name=NULL / Expression=<SQL text> convention. Chasing this down also surfaced a bug in `Coalesce.IsNullable()` that only checked its first argument, causing wrong `NULL` reporting for expressions like `COALESCE(b, a)` where a is `NOT NULL`. 