### PR TITLE
SOUNDEX: keep a non-ASCII initial letter as written

### DIFF
--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -2798,4 +2798,14 @@ var FunctionQueryTests = []QueryTest{
 		Query:    `SELECT SOUNDEX('hello')`,
 		Expected: []sql.Row{{"H400"}},
 	},
+	{
+		// MySQL's my_uni_isalpha counts every code point at or above U+00C0 as a letter,
+		// including U+00D7 MULTIPLICATION SIGN. Used to be skipped as leading garbage.
+		Query:    `SELECT SOUNDEX('×')`,
+		Expected: []sql.Row{{"×000"}},
+	},
+	{
+		Query:    `SELECT SOUNDEX('©x')`,
+		Expected: []sql.Row{{"X000"}},
+	},
 }

--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -2769,4 +2769,33 @@ var FunctionQueryTests = []QueryTest{
 		Query:    "select extract(hour from true)",
 		Expected: []sql.Row{{0}},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/11546 -- SOUNDEX keeps the first letter
+		// verbatim, and MySQL only uppercases it if it is ASCII. Used to return 'É000'.
+		Query:    `SELECT SOUNDEX('é')`,
+		Expected: []sql.Row{{"é000"}},
+	},
+	{
+		// The exact reproduction from dolthub/dolt#11546.
+		Query:    `SELECT FIRST_VALUE(SOUNDEX('é')) OVER () AS actual FROM (SELECT 1 AS z) q`,
+		Expected: []sql.Row{{"é000"}},
+	},
+	{
+		Query:    `SELECT SOUNDEX('émile')`,
+		Expected: []sql.Row{{"é540"}},
+	},
+	{
+		Query:    `SELECT SOUNDEX('Émile')`,
+		Expected: []sql.Row{{"É540"}},
+	},
+	{
+		// U+017F LATIN SMALL LETTER LONG S. Go's case folding turns it into 'S', which
+		// changed both the emitted letter and its soundex code.
+		Query:    `SELECT SOUNDEX('ſ')`,
+		Expected: []sql.Row{{"ſ000"}},
+	},
+	{
+		Query:    `SELECT SOUNDEX('hello')`,
+		Expected: []sql.Row{{"H400"}},
+	},
 }

--- a/sql/expression/function/soundex.go
+++ b/sql/expression/function/soundex.go
@@ -74,7 +74,8 @@ func (s *Soundex) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	var b strings.Builder
 	var last rune
-	for _, c := range strings.ToUpper(v.(string)) {
+	for _, c := range v.(string) {
+		c = soundexToUpper(c)
 		if last == 0 && !unicode.IsLetter(c) {
 			continue
 		}
@@ -97,6 +98,20 @@ func (s *Soundex) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		b.WriteRune('0')
 	}
 	return b.String(), nil
+}
+
+// soundexToUpper mirrors MySQL's soundex_toupper (sql/item_strfunc.cc), which uppercases
+// ASCII 'a'-'z' and nothing else. The first letter of the input is emitted verbatim after
+// this conversion, so using unicode-wide case folding here changes the returned string:
+// SOUNDEX('é') gave 'É000' where MySQL gives 'é000' (dolthub/dolt#11546). It also matters
+// for the codes, because Go's case folding maps some non-ASCII letters onto ASCII ones --
+// U+017F LATIN SMALL LETTER LONG S becomes 'S' and would then be coded '2' rather than the
+// '0' MySQL assigns to anything outside A-Z.
+func soundexToUpper(c rune) rune {
+	if c >= 'a' && c <= 'z' {
+		return c - 'a' + 'A'
+	}
+	return c
 }
 
 func (s *Soundex) code(c rune) rune {

--- a/sql/expression/function/soundex.go
+++ b/sql/expression/function/soundex.go
@@ -17,7 +17,6 @@ package function
 import (
 	"fmt"
 	"strings"
-	"unicode"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -76,7 +75,7 @@ func (s *Soundex) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	var last rune
 	for _, c := range v.(string) {
 		c = soundexToUpper(c)
-		if last == 0 && !unicode.IsLetter(c) {
+		if last == 0 && !soundexIsAlpha(c) {
 			continue
 		}
 		code := s.code(c)
@@ -112,6 +111,16 @@ func soundexToUpper(c rune) rune {
 		return c - 'a' + 'A'
 	}
 	return c
+}
+
+// soundexIsAlpha mirrors MySQL's my_uni_isalpha (sql/item_strfunc.cc), which decides what
+// SOUNDEX treats as a letter. It is deliberately coarser than unicode.IsLetter: MySQL
+// counts every code point at or above U+00C0 as a letter, on the reasoning quoted in its
+// own source that "characters between 'z' and U+00C0 are controls and punctuations".
+// U+00D7 MULTIPLICATION SIGN and U+00F7 DIVISION SIGN sit above that line, so MySQL keeps
+// them as the leading letter where unicode.IsLetter skipped them as garbage.
+func soundexIsAlpha(c rune) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c >= 0xC0
 }
 
 func (s *Soundex) code(c rune) rune {

--- a/sql/expression/function/soundex_test.go
+++ b/sql/expression/function/soundex_test.go
@@ -65,3 +65,52 @@ func TestSoundex(t *testing.T) {
 		req.Equal(tt.rowType, f.Type(ctx))
 	}
 }
+
+// TestSoundexNonASCIIInitial covers dolthub/dolt#11546. MySQL uppercases SOUNDEX input
+// with soundex_toupper() (sql/item_strfunc.cc), which is deliberately ASCII-only:
+//
+//	static int soundex_toupper(int ch) {
+//	  return (ch >= 'a' && ch <= 'z') ? ch - 'a' + 'A' : ch;
+//	}
+//
+// The failing cases here used to run through strings.ToUpper, which case-folds the whole
+// Unicode range, so the retained first character came back uppercased -- or, for U+017F
+// and U+0131, silently rewritten into an ASCII letter -- where MySQL returns it verbatim.
+func TestSoundexNonASCIIInitial(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected interface{}
+	}{
+		// The exact case reported in dolthub/dolt#11546.
+		{"lowercase accented initial is preserved", "é", "é000"},
+		{"uppercase accented initial is unchanged", "É", "É000"},
+		{"accented initial with ASCII tail", "émile", "é540"},
+		{"uppercase accented initial with ASCII tail", "Émile", "É540"},
+		{"tilde n", "ñu", "ñ000"},
+		{"leading garbage is still skipped", "-é", "é000"},
+		{"repeated accented letter still collapses", "éé", "é000"},
+		// unicode.ToUpper maps U+017F LATIN SMALL LETTER LONG S to 'S' and U+0131 LATIN
+		// SMALL LETTER DOTLESS I to 'I'. Both changed the emitted initial, and U+017F also
+		// changed its own soundex code from '0' (not a letter A-Z) to '2' (as 'S').
+		{"long s stays long s", "ſ", "ſ000"},
+		{"dotless i stays dotless i", "ı", "ı000"},
+		// Guards. A non-ASCII letter that is not the first letter contributes only its
+		// code, so it never reached the emitted-verbatim path and does not move here.
+		{"non-initial accented letter", "Ré", "R000"},
+		{"caseless script initial", "日本語", "日000"},
+		{"ASCII is unaffected", "hello", "H400"},
+		// U+00DF has no simple uppercase mapping in Go's tables, so strings.ToUpper leaves
+		// it alone and it already matched MySQL. Pinned so a future change to the folding
+		// rule cannot break it quietly.
+		{"sharp s is not case-folded", "ß", "ß000"},
+	}
+
+	ctx := sql.NewEmptyContext()
+	for _, tt := range testCases {
+		f := NewSoundex(ctx, expression.NewGetField(0, types.LongText, "", true))
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, eval(t, f, sql.NewRow(tt.input)))
+		})
+	}
+}

--- a/sql/expression/function/soundex_test.go
+++ b/sql/expression/function/soundex_test.go
@@ -114,3 +114,45 @@ func TestSoundexNonASCIIInitial(t *testing.T) {
 		})
 	}
 }
+
+// TestSoundexAlphaClassification covers MySQL's my_uni_isalpha (sql/item_strfunc.cc),
+// which decides what counts as a letter for SOUNDEX:
+//
+//	static bool my_uni_isalpha(int wc) {
+//	  /*
+//	    Return true for all Basic Latin letters: a..z A..Z.
+//	    Return true for all Unicode characters with code higher than U+00C0:
+//	    - characters between 'z' and U+00C0 are controls and punctuations.
+//	    - "U+00C0 LATIN CAPITAL LETTER A WITH GRAVE" is the first letter after 'z'.
+//	  */
+//	  return (wc >= 'a' && wc <= 'z') || (wc >= 'A' && wc <= 'Z') || (wc >= 0xC0);
+//	}
+//
+// That is coarser than unicode.IsLetter. Everything at or above U+00C0 is a letter as far
+// as SOUNDEX is concerned, including U+00D7 MULTIPLICATION SIGN and U+00F7 DIVISION SIGN,
+// which unicode.IsLetter rejects -- so they used to be skipped as leading garbage.
+func TestSoundexAlphaClassification(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected interface{}
+	}{
+		{"multiplication sign is a letter above U+00C0", "×", "×000"},
+		{"division sign is a letter above U+00C0", "÷", "÷000"},
+		{"symbol above U+00C0 takes the initial slot", "×y", "×000"},
+		// Guards: below U+00C0 the two rules agree, so nothing here moves.
+		{"ASCII punctuation is still garbage", "-", "0000"},
+		{"ASCII digit is still garbage", "1", "0000"},
+		{"empty is still empty", "", "0000"},
+		{"copyright sign is below U+00C0", "©x", "X000"},
+		{"latin letters are unaffected", "Wilcox", "W420"},
+	}
+
+	ctx := sql.NewEmptyContext()
+	for _, tt := range testCases {
+		f := NewSoundex(ctx, expression.NewGetField(0, types.LongText, "", true))
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, eval(t, f, sql.NewRow(tt.input)))
+		})
+	}
+}


### PR DESCRIPTION
`Soundex.Eval` iterates the input as `strings.ToUpper(v.(string))`. SOUNDEX keeps the **first letter verbatim**, so uppercasing the whole Unicode range changes the returned string: `SOUNDEX('é')` came back `É000` where MySQL returns `é000`.

MySQL uppercases with `soundex_toupper` ([`sql/item_strfunc.cc`](https://github.com/mysql/mysql-server/blob/8.0/sql/item_strfunc.cc)), which is deliberately ASCII-only:

```c
static int soundex_toupper(int ch) {
  return (ch >= 'a' && ch <= 'z') ? ch - 'a' + 'A' : ch;
}
```

This does the same. Fixes dolthub/dolt#11546.

### Two things the ASCII-only rule fixes beyond the reported symptom

Go's case folding maps some non-ASCII letters **onto ASCII letters**, which changed their soundex code as well as the emitted character:

| input | before | after / MySQL | why |
|---|---|---|---|
| `ſ` U+017F LONG S | `S000` | `ſ000` | `unicode.ToUpper` gives `'S'`, then coded `2`; MySQL leaves it outside `A-Z` and codes it `0` |
| `ı` U+0131 DOTLESS I | `I000` | `ı000` | `unicode.ToUpper` gives `'I'` |

`ß` U+00DF has no simple uppercase mapping in Go's tables, so it already matched; there is a test pinning that so a future change to the folding rule cannot break it quietly.

### Second commit is separable

`bd0e4e6` replaces `unicode.IsLetter` with MySQL's `my_uni_isalpha` from the same file:

```c
static bool my_uni_isalpha(int wc) {
  /*
    Return true for all Basic Latin letters: a..z A..Z.
    Return true for all Unicode characters with code higher than U+00C0:
    - characters between 'z' and U+00C0 are controls and punctuations.
    - "U+00C0 LATIN CAPITAL LETTER A WITH GRAVE" is the first letter after 'z'.
  */
  return (wc >= 'a' && wc <= 'z') || (wc >= 'A' && wc <= 'Z') || (wc >= 0xC0);
}
```

That is coarser than `unicode.IsLetter`, and the visible difference is U+00D7 MULTIPLICATION SIGN and U+00F7 DIVISION SIGN: MySQL keeps them as the leading letter, this skipped them as garbage. `SELECT SOUNDEX('×y')` returned `Y000` and now returns `×000`. **It is a separate commit on purpose — say the word and I will drop it and leave the PR at the reported bug.**

### Deliberately not changed

`SOUNDEX('')` and `SOUNDEX('-')` return `0000` here; MySQL's `make_empty_result()` returns the empty string. That is a different defect with existing expectations behind it (`text empty`, `text ignored character`) and no issue asking for it, so it is left alone.

## Verification — executed on this branch, both directions

**Unit, before the patch:** 10 of the 21 new subtests fail against unpatched `main`, including the issue's exact input reproducing as `É000`. All 19 pre-existing `TestSoundex` cases pass before and after.

```
--- FAIL: TestSoundexNonASCIIInitial/lowercase_accented_initial_is_preserved
        expected: "é000"   actual: "É000"      <- dolthub/dolt#11546
--- FAIL: TestSoundexNonASCIIInitial/accented_initial_with_ASCII_tail
--- FAIL: TestSoundexNonASCIIInitial/tilde_n
--- FAIL: TestSoundexNonASCIIInitial/leading_garbage_is_still_skipped
--- FAIL: TestSoundexNonASCIIInitial/repeated_accented_letter_still_collapses
--- FAIL: TestSoundexNonASCIIInitial/long_s_stays_long_s
--- FAIL: TestSoundexNonASCIIInitial/dotless_i_stays_dotless_i
--- FAIL: TestSoundexAlphaClassification/multiplication_sign_is_a_letter_above_U+00C0
--- FAIL: TestSoundexAlphaClassification/division_sign_is_a_letter_above_U+00C0
--- FAIL: TestSoundexAlphaClassification/symbol_above_U+00C0_takes_the_initial_slot
```

**Unit, after:** `go test -tags gms_pure_go ./sql/expression/function/ -run TestSoundex -v` — 40 subtests, all pass.

**Enginetest:** 8 new `FunctionQueryTests`, run plain and prepared — 16 executions, all pass. They include the issue's exact reproduction:

```
--- PASS: TestQueries/SELECT_FIRST_VALUE(SOUNDEX('é'))_OVER_()_AS_actual_FROM_(SELECT_1_AS_z)_q
--- PASS: TestQueriesPrepared/function_query_prepared_tests/SELECT_FIRST_VALUE(SOUNDEX('é'))_OVER_()_...
```

`TestScripts/String_functions_with_TextStorage_(comprehensive_test)` also passes, including its existing `SELECT SOUNDEX(content)` assertion, so the `TextStorage` unwrap path is unaffected.

**Regression:** `go test -tags gms_pure_go ./sql/expression/...` run with and without the patch and the failure lists diffed — **identical**, only the elapsed-time line differs. The four `TestRegexpReplaceWithFlags/*multiline*` failures are pre-existing and belong to the pure-Go regex backend, not to this change.

Built and tested with `-tags gms_pure_go` (no C toolchain on this machine). No MySQL server was available to re-run the comparison live; the expected values above come from the issue's own reported MySQL 8.0.43 output and from the MySQL source linked above.

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*