### PR TITLE
Support PostgreSQL scalar function aliases in FROM

### DIFF
--- a/sql/overrides.go
+++ b/sql/overrides.go
@@ -56,6 +56,10 @@ type BuilderOverrides struct {
 	// expression will be used in place of the `GetField` expression used for columns. The input `fields` contains the
 	// `GetField` expressions for all of the table's columns. For standard MySQL compatibility, this should be nil.
 	ParseTableAsColumn func(ctx *Context, tableName string, fields []Expression, tblSch []*Column) (Expression, error)
+	// ScalarFunctionAliasAsColumn enables PostgreSQL-compatible aliasing for regular scalar functions used in FROM.
+	// When enabled, an alias without an explicit column list names both the relation and its single output column.
+	// Leave this false for standard MySQL compatibility.
+	ScalarFunctionAliasAsColumn bool
 	// Represents the parser to use. If this is nil, then the MySQL parser will be used.
 	Parser Parser
 }

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -541,6 +541,18 @@ func (b *Builder) buildTableFunc(inScope *scope, t *ast.TableFuncExpr) (outScope
 			b.handleErr(sql.ErrUnsupportedSyntax.New(ast.String(t)))
 		}
 		newAlias = tableAlias.WithColumnNames(renameCols)
+	} else if !t.Alias.IsEmpty() && b.overrides.ScalarFunctionAliasAsColumn {
+		// PostgreSQL uses a table alias as the column name as well when a scalar
+		// function appears in FROM without an explicit column alias list. Keep
+		// native table functions unchanged: their aliases name the relation only,
+		// especially when they return a record with named output columns.
+		if _, ok := newInstance.(*dtablefunctions.TableFunctionWrapper); ok {
+			tableAlias, ok := newAlias.(*plan.TableAlias)
+			if !ok {
+				b.handleErr(sql.ErrUnsupportedSyntax.New(ast.String(t)))
+			}
+			newAlias = tableAlias.WithColumnNames([]string{name})
+		}
 	}
 
 	tabId := outScope.addTable(name)

--- a/sql/planbuilder/from_test.go
+++ b/sql/planbuilder/from_test.go
@@ -18,9 +18,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"

--- a/sql/planbuilder/from_test.go
+++ b/sql/planbuilder/from_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planbuilder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ast "github.com/dolthub/vitess/go/vt/sqlparser"
+
+	"github.com/dolthub/go-mysql-server/memory"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression/function"
+)
+
+func TestScalarFunctionTableAliasColumnName(t *testing.T) {
+	db := memory.NewDatabase("mydb")
+	ctx := sql.NewContext(context.Background(), sql.WithSession(memory.NewSession(sql.NewBaseSession(), memory.NewDBProvider(db))))
+	ctx.SetCurrentDatabase("mydb")
+
+	tests := []struct {
+		name             string
+		postgresAliasing bool
+		expectedColumn   string
+	}{
+		{name: "PostgreSQL compatibility", postgresAliasing: true, expectedColumn: "k"},
+		{name: "MySQL compatibility", postgresAliasing: false, expectedColumn: "abs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cat := tableFunctionTestCatalog{
+				MapCatalog: sql.MapCatalog{
+					Databases: map[string]sql.Database{"mydb": db},
+					Funcs:     function.NewRegistry(),
+				},
+				overrides: sql.EngineOverrides{Builder: sql.BuilderOverrides{ScalarFunctionAliasAsColumn: tt.postgresAliasing}},
+			}
+			b := New(ctx, cat, nil)
+			outScope := b.buildTableFunc(b.newScope(), tableFuncExpr("abs", "k", ast.NewIntVal([]byte("1"))))
+
+			require.Equal(t, "k", outScope.node.(sql.Nameable).Name())
+			require.Equal(t, tt.expectedColumn, outScope.node.Schema(ctx)[0].Name)
+		})
+	}
+}
+
+func TestNativeTableFunctionAliasPreservesColumnName(t *testing.T) {
+	db := memory.NewDatabase("mydb")
+	ctx := sql.NewContext(context.Background(), sql.WithSession(memory.NewSession(sql.NewBaseSession(), memory.NewDBProvider(db))))
+	ctx.SetCurrentDatabase("mydb")
+	cat := tableFunctionTestCatalog{
+		MapCatalog: sql.MapCatalog{
+			Databases: map[string]sql.Database{"mydb": db},
+			Funcs:     function.NewRegistry(),
+		},
+		tableFunctions: map[string]sql.TableFunction{"table_func": memory.TableFunc{}},
+		overrides:      sql.EngineOverrides{Builder: sql.BuilderOverrides{ScalarFunctionAliasAsColumn: true}},
+	}
+	b := New(ctx, cat, nil)
+	outScope := b.buildTableFunc(b.newScope(), tableFuncExpr(
+		"table_func", "k", ast.NewStrVal([]byte("named_column")), ast.NewIntVal([]byte("1"))))
+
+	require.Equal(t, "k", outScope.node.(sql.Nameable).Name())
+	require.Equal(t, "named_column", outScope.node.Schema(ctx)[0].Name)
+}
+
+func tableFuncExpr(name, alias string, exprs ...ast.Expr) *ast.TableFuncExpr {
+	aliasedExprs := make(ast.SelectExprs, len(exprs))
+	for i, expr := range exprs {
+		aliasedExprs[i] = &ast.AliasedExpr{Expr: expr}
+	}
+	return &ast.TableFuncExpr{Name: name, Alias: ast.NewTableIdent(alias), Exprs: aliasedExprs}
+}
+
+type tableFunctionTestCatalog struct {
+	sql.MapCatalog
+	tableFunctions map[string]sql.TableFunction
+	overrides      sql.EngineOverrides
+}
+
+func (c tableFunctionTestCatalog) TableFunction(_ *sql.Context, name string) (sql.TableFunction, bool) {
+	f, ok := c.tableFunctions[name]
+	return f, ok
+}
+
+func (c tableFunctionTestCatalog) Overrides() sql.EngineOverrides {
+	return c.overrides
+}


### PR DESCRIPTION
Add an opt-in plan-builder override for PostgreSQL scalar-function alias semantics in `FROM` clauses. The default remains disabled so MySQL-compatible callers retain existing behavior.

Native table functions continue to preserve their named output columns. Added planbuilder coverage for PostgreSQL mode, default MySQL mode, and native table functions.

Verified with `go test ./sql/planbuilder -count=1`.