### PR TITLE
Handle empty set results in table function wrappers

### DIFF
--- a/sql/expression/tablefunction/table_function.go
+++ b/sql/expression/tablefunction/table_function.go
@@ -84,6 +84,16 @@ func (t *TableFunctionWrapper) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter
 	if err != nil {
 		return nil, err
 	}
+	// RowIterExpression implementations may represent an empty set as nil. Preserve
+	// that distinction from an ordinary scalar NULL, which produces one NULL row.
+	// Keep using Eval instead of EvalRowIter because the latter collapses multi-column
+	// SRFs into a single record for SELECT-list semantics, while FROM requires separate
+	// columns.
+	if v == nil {
+		if rowIterExpr, ok := t.funcExpr.(sql.RowIterExpression); ok && rowIterExpr.ReturnsRowIter() {
+			return sql.RowsToRowIter(), nil
+		}
+	}
 	if ri, ok := v.(sql.RowIter); ok {
 		return ri, nil
 	}

--- a/sql/expression/tablefunction/table_function_test.go
+++ b/sql/expression/tablefunction/table_function_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dtablefunctions
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+func TestTableFunctionWrapperEmptySet(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	fn := sql.Function1{
+		Name: "empty_set",
+		Fn: func(_ *sql.Context, _ sql.Expression) sql.Expression {
+			return &emptySetExpression{Literal: expression.NewLiteral(nil, types.Int64)}
+		},
+	}
+	wrapper := NewTableFunctionWrapper(fn)
+	instance, err := wrapper.NewInstance(ctx, nil, []sql.Expression{expression.NewLiteral(nil, types.Int64)})
+	require.NoError(t, err)
+	tableFunc := instance.(*TableFunctionWrapper)
+
+	iter, err := tableFunc.RowIter(ctx, nil)
+	require.NoError(t, err)
+	_, err = iter.Next(ctx)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestTableFunctionWrapperScalarNull(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	fn := sql.Function1{
+		Name: "scalar_null",
+		Fn: func(_ *sql.Context, _ sql.Expression) sql.Expression {
+			return expression.NewLiteral(nil, types.Int64)
+		},
+	}
+	wrapper := NewTableFunctionWrapper(fn)
+	instance, err := wrapper.NewInstance(ctx, nil, []sql.Expression{expression.NewLiteral(nil, types.Int64)})
+	require.NoError(t, err)
+	tableFunc := instance.(*TableFunctionWrapper)
+
+	iter, err := tableFunc.RowIter(ctx, nil)
+	require.NoError(t, err)
+	rows, err := sql.RowIterToRows(ctx, iter)
+	require.NoError(t, err)
+	require.Equal(t, []sql.Row{{nil}}, rows)
+}
+
+func TestTableFunctionWrapperPreservesMultiColumnRows(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	fn := sql.Function1{
+		Name: "multi_column_set",
+		Fn: func(_ *sql.Context, _ sql.Expression) sql.Expression {
+			return &multiColumnSetExpression{Literal: expression.NewLiteral(nil, types.Int64)}
+		},
+	}
+	wrapper := NewTableFunctionWrapper(fn)
+	instance, err := wrapper.NewInstance(ctx, nil, []sql.Expression{expression.NewLiteral(1, types.Int64)})
+	require.NoError(t, err)
+	tableFunc := instance.(*TableFunctionWrapper)
+
+	iter, err := tableFunc.RowIter(ctx, nil)
+	require.NoError(t, err)
+	rows, err := sql.RowIterToRows(ctx, iter)
+	require.NoError(t, err)
+	require.Equal(t, []sql.Row{{int64(1), int64(2)}}, rows)
+}
+
+type emptySetExpression struct {
+	*expression.Literal
+}
+
+func (e *emptySetExpression) EvalRowIter(*sql.Context, sql.Row) (sql.RowIter, error) {
+	// Doltgres SRFs return nil, nil for an empty set. The table-function wrapper
+	// converts that representation to an iterator whose first Next returns io.EOF.
+	return nil, nil
+}
+
+func (e *emptySetExpression) ReturnsRowIter() bool {
+	return true
+}
+
+type multiColumnSetExpression struct {
+	*expression.Literal
+}
+
+func (e *multiColumnSetExpression) Eval(*sql.Context, sql.Row) (any, error) {
+	return sql.RowsToRowIter(sql.Row{int64(1), int64(2)}), nil
+}
+
+func (e *multiColumnSetExpression) EvalRowIter(*sql.Context, sql.Row) (sql.RowIter, error) {
+	return sql.RowsToRowIter(sql.Row{sql.Row{int64(1), int64(2)}}), nil
+}
+
+func (e *multiColumnSetExpression) ReturnsRowIter() bool {
+	return true
+}
+
+func (e *multiColumnSetExpression) OutParametersSchema() sql.Schema {
+	return sql.Schema{
+		{Name: "first", Type: types.Int64},
+		{Name: "second", Type: types.Int64},
+	}
+}
+
+func (e *multiColumnSetExpression) Unwrap(v any) sql.Row {
+	return v.(sql.Row)
+}

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -547,11 +547,15 @@ func (b *Builder) buildTableFunc(inScope *scope, t *ast.TableFuncExpr) (outScope
 		// native table functions unchanged: their aliases name the relation only,
 		// especially when they return a record with named output columns.
 		if _, ok := newInstance.(*dtablefunctions.TableFunctionWrapper); ok {
-			tableAlias, ok := newAlias.(*plan.TableAlias)
-			if !ok {
-				b.handleErr(sql.ErrUnsupportedSyntax.New(ast.String(t)))
+			// A regular function may still return a record with named OUT parameters.
+			// Only a single-column result uses the relation alias as its column name.
+			if len(newAlias.Schema(b.ctx)) == 1 {
+				tableAlias, ok := newAlias.(*plan.TableAlias)
+				if !ok {
+					b.handleErr(sql.ErrUnsupportedSyntax.New(ast.String(t)))
+				}
+				newAlias = tableAlias.WithColumnNames([]string{name})
 			}
-			newAlias = tableAlias.WithColumnNames([]string{name})
 		}
 	}
 

--- a/sql/planbuilder/from_test.go
+++ b/sql/planbuilder/from_test.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/expression/function"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 func TestScalarFunctionTableAliasColumnName(t *testing.T) {
@@ -78,6 +80,34 @@ func TestNativeTableFunctionAliasPreservesColumnName(t *testing.T) {
 	require.Equal(t, "named_column", outScope.node.Schema(ctx)[0].Name)
 }
 
+func TestRecordReturningFunctionAliasPreservesColumnNames(t *testing.T) {
+	db := memory.NewDatabase("mydb")
+	ctx := sql.NewContext(context.Background(), sql.WithSession(memory.NewSession(sql.NewBaseSession(), memory.NewDBProvider(db))))
+	ctx.SetCurrentDatabase("mydb")
+	funcs := function.NewRegistry()
+	require.NoError(t, funcs.Register(sql.Function1{
+		Name: "record_func",
+		Fn: func(_ *sql.Context, _ sql.Expression) sql.Expression {
+			return &recordFunctionExpression{Literal: expression.NewLiteral(nil, types.Int64)}
+		},
+	}))
+	cat := tableFunctionTestCatalog{
+		MapCatalog: sql.MapCatalog{
+			Databases: map[string]sql.Database{"mydb": db},
+			Funcs:     funcs,
+		},
+		overrides: sql.EngineOverrides{Builder: sql.BuilderOverrides{ScalarFunctionAliasAsColumn: true}},
+	}
+	b := New(ctx, cat, nil)
+	outScope := b.buildTableFunc(b.newScope(), tableFuncExpr("record_func", "r", ast.NewIntVal([]byte("1"))))
+
+	require.Equal(t, "r", outScope.node.(sql.Nameable).Name())
+	require.Equal(t, []string{"first", "second"}, []string{
+		outScope.node.Schema(ctx)[0].Name,
+		outScope.node.Schema(ctx)[1].Name,
+	})
+}
+
 func tableFuncExpr(name, alias string, exprs ...ast.Expr) *ast.TableFuncExpr {
 	aliasedExprs := make(ast.SelectExprs, len(exprs))
 	for i, expr := range exprs {
@@ -99,4 +129,19 @@ func (c tableFunctionTestCatalog) TableFunction(_ *sql.Context, name string) (sq
 
 func (c tableFunctionTestCatalog) Overrides() sql.EngineOverrides {
 	return c.overrides
+}
+
+type recordFunctionExpression struct {
+	*expression.Literal
+}
+
+func (e *recordFunctionExpression) OutParametersSchema() sql.Schema {
+	return sql.Schema{
+		{Name: "first", Type: types.Int64},
+		{Name: "second", Type: types.Int64},
+	}
+}
+
+func (e *recordFunctionExpression) Unwrap(v any) sql.Row {
+	return v.(sql.Row)
 }


### PR DESCRIPTION
Handle strict set-returning functions used in `FROM` without fabricating a NULL row, while preserving ordinary scalar NULL behavior and multi-column SRF row shapes.

Restrict PostgreSQL scalar alias-as-column behavior to one-column function results. Regular functions with multiple named OUT parameters retain those output names instead of being misclassified as scalar. MySQL-compatible callers remain unchanged because the alias behavior is opt-in.

Added focused wrapper and planbuilder coverage for empty strict SRFs, scalar NULLs, multi-column rows, scalar aliases, native table functions, and record-returning regular functions. Verified with `go test ./sql/expression/tablefunction -count=1` and `go test ./sql/planbuilder -count=1`.