### PR TITLE
Support extended types in COUNT DISTINCT

### DIFF
--- a/sql/expression/function/aggregation/count_test.go
+++ b/sql/expression/function/aggregation/count_test.go
@@ -15,6 +15,7 @@
 package aggregation
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,22 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
+
+type countDistinctExtendedValue struct {
+	serialized byte
+}
+
+func (v countDistinctExtendedValue) String() string {
+	return "same display value"
+}
+
+type countDistinctExtendedType struct {
+	sql.FakeExtendedType
+}
+
+func (t countDistinctExtendedType) SerializeValue(_ context.Context, value any) ([]byte, error) {
+	return []byte{value.(countDistinctExtendedValue).serialized}, nil
+}
 
 func TestCountEval1(t *testing.T) {
 	require := require.New(t)
@@ -117,5 +134,22 @@ func TestCountDistinctEvalString(t *testing.T) {
 	require.NoError(b.Update(ctx, sql.NewRow(nil)))
 	require.NoError(b.Update(ctx, sql.NewRow("foo")))
 	require.NoError(b.Update(ctx, sql.NewRow("bar")))
+	require.Equal(int64(2), evalBuffer(t, b))
+}
+
+func TestCountDistinctEvalExtendedType(t *testing.T) {
+	require := require.New(t)
+	ctx := sql.NewEmptyContext()
+
+	extendedType := countDistinctExtendedType{sql.FakeExtendedType{
+		Name:    "count_distinct_extended_type",
+		ZeroVal: countDistinctExtendedValue{},
+	}}
+	c := NewCountDistinct(expression.NewGetField(0, extendedType, "", true))
+	b, _ := c.NewBuffer(ctx)
+	require.NoError(b.Update(ctx, sql.NewRow(countDistinctExtendedValue{serialized: 1})))
+	require.NoError(b.Update(ctx, sql.NewRow(countDistinctExtendedValue{serialized: 1})))
+	require.NoError(b.Update(ctx, sql.NewRow(countDistinctExtendedValue{serialized: 2})))
+	require.NoError(b.Update(ctx, sql.NewRow(nil)))
 	require.Equal(int64(2), evalBuffer(t, b))
 }

--- a/sql/expression/function/aggregation/unary_agg_buffers.go
+++ b/sql/expression/function/aggregation/unary_agg_buffers.go
@@ -468,6 +468,23 @@ func (c *countDistinctBuffer) Update(ctx *sql.Context, row sql.Row) error {
 		}
 		value = val
 	}
+	if len(c.exprs) == 1 {
+		_, isStar := c.exprs[0].(*expression.Star)
+		if !isStar {
+			if extendedType, ok := c.exprs[0].Type(ctx).(sql.ExtendedType); ok {
+				serializedValue, err := extendedType.SerializeValue(ctx, value.(sql.Row)[0])
+				if err != nil {
+					return err
+				}
+				hash := xxhash.New()
+				if _, err = hash.Write(serializedValue); err != nil {
+					return err
+				}
+				c.seen[hash.Sum64()] = struct{}{}
+				return nil
+			}
+		}
+	}
 
 	var str string
 	for _, val := range value.(sql.Row) {


### PR DESCRIPTION
Hash single-expression extended values using their canonical serialized representation in `COUNT(DISTINCT ...)`. This allows PostgreSQL UUID values to participate in distinct aggregates without changing ordinary or multi-expression aggregate behavior.

Part of dolthub/doltgresql#3099