### PR TITLE
Expose DISTINCT aggregate retention

### DIFF
--- a/sql/expression/distinct.go
+++ b/sql/expression/distinct.go
@@ -100,24 +100,27 @@ func (de *DistinctExpression) IsNullable(ctx *sql.Context) bool {
 	return true
 }
 
-// Returns the child value if the cache hasn't seen the value before otherwise returns nil.
-// Since NULLs are ignored in aggregate expressions that use DISTINCT this is a valid return scheme.
-func (de *DistinctExpression) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+// EvalDistinct returns the child value and whether it has not been seen before.
+func (de *DistinctExpression) EvalDistinct(ctx *sql.Context, row sql.Row) (interface{}, bool, error) {
 	val, err := de.Child.Eval(ctx, row)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	should, err := de.seenValue(ctx, val)
+	seen, err := de.seenValue(ctx, val)
 	if err != nil {
+		return nil, false, err
+	}
+	return val, seen, nil
+}
+
+// Eval implements sql.Expression.
+func (de *DistinctExpression) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	val, seen, err := de.EvalDistinct(ctx, row)
+	if err != nil || !seen {
 		return nil, err
 	}
-
-	if should {
-		return val, nil
-	}
-
-	return nil, nil
+	return val, nil
 }
 
 func (de *DistinctExpression) Children() []sql.Expression {

--- a/sql/expression/distinct_test.go
+++ b/sql/expression/distinct_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+func TestDistinctExpressionEvalDistinct(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	expr := NewDistinctExpression(NewGetField(0, types.Int32, "v", true))
+
+	tests := []struct {
+		name    string
+		value   any
+		include bool
+	}{
+		{name: "first null", value: nil, include: true},
+		{name: "duplicate null", value: nil, include: false},
+		{name: "first value", value: int32(1), include: true},
+		{name: "duplicate value", value: int32(1), include: false},
+		{name: "different value", value: int32(2), include: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, include, err := expr.EvalDistinct(ctx, sql.Row{tt.value})
+			require.NoError(t, err)
+			require.Equal(t, tt.value, value)
+			require.Equal(t, tt.include, include)
+		})
+	}
+}


### PR DESCRIPTION
Expose whether a DISTINCT aggregate argument was retained separately from its evaluated value. This lets aggregates distinguish a retained SQL NULL from a duplicate that should be skipped while preserving existing Eval behavior.

Part of dolthub/doltgresql#3099