### PR TITLE
Return an error for a bind variable in an AS OF clause

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10239,6 +10239,14 @@ var ErrorQueries = []QueryErrorTest{
 		ExpectedErrStr: "invalid AS OF expression type",
 	},
 	{
+		Query:       "SELECT i FROM myhistorytable AS OF ?",
+		ExpectedErr: sql.ErrInvalidAsOfExpression,
+	},
+	{
+		Query:       "SELECT i FROM myhistorytable AS OF :rev",
+		ExpectedErr: sql.ErrInvalidAsOfExpression,
+	},
+	{
 		Query:       "SELECT pk FROM one_pk WHERE pk > ?",
 		ExpectedErr: sql.ErrUnboundPreparedStatementVariable,
 	},

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -634,6 +634,10 @@ func (b *Builder) buildShowVariables(inScope *scope, s *ast.Show) (outScope *sco
 
 func (b *Builder) buildAsOfLit(inScope *scope, t ast.Expr) interface{} {
 	expr := b.buildAsOfExpr(inScope, t)
+	if expr == nil {
+		// buildAsOfExpr returns nil for a bind variable with no value to substitute.
+		b.handleErr(sql.ErrInvalidAsOfExpression.New(t))
+	}
 	res, err := expr.Eval(b.ctx, nil)
 	if err != nil {
 		b.handleErr(err)


### PR DESCRIPTION
An unresolved bind variable in an AS OF clause caused the query planner to evaluate a nil expression, triggering a panic instead of returning a SQL error. This change detects that case and returns ErrInvalidAsOfExpression, preventing callers from hanging during transaction cleanup.

Now, the bigger question if this PR should be accepted or not, si that this can silently return the current db state when "AS OF" cannot be resolved. Not sure if semantically this is acceptable or not.

Other paths, notably SHOW TABLES and CALL, allow an unresolved AS OF placeholder during the initial prepare pass and bind it on execution. This change intentionally leaves those paths unchanged.