### PR TITLE
Validate DISTINCT windows after function resolution

### DIFF
--- a/sql/functions.go
+++ b/sql/functions.go
@@ -31,6 +31,17 @@ type FunctionProvider interface {
 	Function(ctx *Context, schema, name string) (Function, bool)
 }
 
+// DistinctWindowFunctionValidator lets a resolved function expression validate DISTINCT window usage.
+// Function providers that need dialect-specific validation must implement this interface on the
+// FunctionExpression returned by Function.NewInstance, not on the provider or function definition.
+type DistinctWindowFunctionValidator interface {
+	FunctionExpression
+
+	// ValidateDistinctWindow returns an engine-specific error for DISTINCT window usage after the
+	// function expression has resolved its exact overload.
+	ValidateDistinctWindow(schema, name string) error
+}
+
 type CreateFunc0Args func(ctx *Context) Expression
 type CreateFunc1Args func(ctx *Context, e1 Expression) Expression
 type CreateFunc2Args func(ctx *Context, e1, e2 Expression) Expression

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -558,13 +558,14 @@ func (b *Builder) buildWindowFunc(inScope *scope, name string, e *ast.FuncExpr, 
 		}
 
 		newInst, err := f.NewInstance(b.ctx, args)
+		if err != nil {
+			b.handleErr(err)
+		}
+		b.validateDistinctWindow(e, name, newInst)
 
 		win, ok = newInst.(sql.WindowAdaptableExpression)
 		if !ok {
 			err := fmt.Errorf("function is not a window adaptable exprssion: %s", f.FunctionName())
-			b.handleErr(err)
-		}
-		if err != nil {
 			b.handleErr(err)
 		}
 	}
@@ -583,6 +584,18 @@ func (b *Builder) buildWindowFunc(inScope *scope, name string, e *ast.FuncExpr, 
 	col.scalar = win
 	inScope.windowFuncs = append(inScope.windowFuncs, col)
 	return col.scalarGf()
+}
+
+// validateDistinctWindow lets resolved function implementations reject unsupported DISTINCT window calls.
+func (b *Builder) validateDistinctWindow(e *ast.FuncExpr, name string, expr sql.Expression) {
+	if !e.Distinct {
+		return
+	}
+	if validator, ok := expr.(sql.DistinctWindowFunctionValidator); ok {
+		if err := validator.ValidateDistinctWindow(e.Qualifier.String(), name); err != nil {
+			b.handleErr(err)
+		}
+	}
 }
 
 func (b *Builder) buildWindow(fromScope, projScope *scope) *scope {

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -329,6 +329,9 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 		if err != nil {
 			b.handleErr(err)
 		}
+		if v.Over != nil && v.Distinct {
+			b.validateDistinctWindow(v, name, rf)
+		}
 
 		switch rf.(type) {
 		case *function.Sleep, sql.NonDeterministicExpression:


### PR DESCRIPTION
Add an optional validation hook for engine-specific DISTINCT window-function behavior after the exact function overload has been resolved. This lets consumers enforce their compatibility policy without changing native MySQL behavior.