### PR TITLE
Evaluate sort key expressions once per row instead of once per comparison

### DIFF
--- a/sql/iters/top_rows_iters.go
+++ b/sql/iters/top_rows_iters.go
@@ -103,6 +103,9 @@ func (i *topRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 		return nil, err
 	}
 	sorter := sorters.NewRowSorter(ctx, i.sortConditions)
+	// Sort keys are evaluated exactly once per row: re-evaluating a non-deterministic sort expression
+	// (e.g. ORDER BY RAND()) on every comparison would bias which row is returned.
+	topKey := sorter.EvalKey(topRow)
 	for {
 		var row sql.Row
 		row, err = i.childIter.Next(ctx)
@@ -113,9 +116,16 @@ func (i *topRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 			return nil, err
 		}
 		i.numFoundRows++
-		if sorter.IsLesserRow(row, topRow) {
-			topRow = row
+		key := sorter.EvalKey(row)
+		if sorter.CompareKeys(key, topKey) < 0 {
+			topRow, topKey = row, key
 		}
+		if err = sorter.GetError(); err != nil {
+			return nil, err
+		}
+	}
+	if err = sorter.GetError(); err != nil {
+		return nil, err
 	}
 	return topRow, nil
 }

--- a/sql/iters/top_rows_iters_test.go
+++ b/sql/iters/top_rows_iters_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// countingExpr wraps an expression and counts Eval calls. Sort key expressions must be evaluated at most once
+// per row: re-evaluating a non-deterministic expression (e.g. ORDER BY RAND()) on every comparison biases
+// which row a top-1 scan returns.
+type countingExpr struct {
+	sql.Expression
+	count *int
+}
+
+func (c *countingExpr) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	*c.count++
+	return c.Expression.Eval(ctx, row)
+}
+
+func TestTopRowIterEvaluatesKeysOncePerRow(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	const numRows = 100
+
+	var evalCount int
+	sortConditions := sql.SortConditions{
+		{
+			Expr:         &countingExpr{expression.NewGetField(0, types.Int32, "col1", false), &evalCount},
+			Order:        sql.Ascending,
+			NullOrdering: sql.NullsFirst,
+		},
+	}
+
+	rows := make([]sql.Row, numRows)
+	for i := range rows {
+		rows[i] = sql.NewRow(int32((i * 7) % numRows))
+	}
+
+	iter := NewTopRowIter(sortConditions, false, sql.RowsToRowIter(rows...))
+	row, err := iter.Next(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int32(0), row[0])
+	require.Equal(t, numRows, evalCount)
+}

--- a/sql/sorters/row_sorter.go
+++ b/sql/sorters/row_sorter.go
@@ -19,20 +19,22 @@ import (
 )
 
 // RowSorter is a sorter implementation for Row slices using SortFields for the comparison.
-// Sort key expressions are evaluated at most once per row and the resulting keys are cached, rather than
-// re-evaluating expressions on every comparison. This matters for correctness, not just speed: a
-// non-deterministic sort expression (e.g. ORDER BY RAND()) must produce a single stable key per row, or the
-// resulting order is biased by comparison order.
+// RowSorter can act as simply a container for sort conditions, or as a sorter for a slice of rows.
+// If the latter, it caches the evaluated sort keys for each row to avoid re-evaluating them during sorting,
+// which is necessary for correctness and desirable for performance.
 type RowSorter struct {
 	lastError      error
 	ctx            *sql.Context
 	sortConditions sql.SortConditions
 	types          []sql.Type
-	rows           []sql.Row
+	// rows is the slice of rows to be sorted. Only used with NewSorterWithRows
+	rows []sql.Row
 	// keys[i] caches the evaluated sort condition expressions for rows[i]; a nil slice means not yet evaluated
+	// Only used with NewSorterWithRows.
 	keys [][]interface{}
 }
 
+// NewRowSorter creates a RowSorter for the given sort conditions
 func NewRowSorter(ctx *sql.Context, sortConditions sql.SortConditions) *RowSorter {
 	return &RowSorter{
 		ctx:            ctx,
@@ -41,6 +43,7 @@ func NewRowSorter(ctx *sql.Context, sortConditions sql.SortConditions) *RowSorte
 	}
 }
 
+// NewRowSorterWithRows creates a RowSorter for the given sort conditions and rows.
 func NewRowSorterWithRows(ctx *sql.Context, sortConditions sql.SortConditions, rows []sql.Row) *RowSorter {
 	return &RowSorter{
 		ctx:            ctx,
@@ -132,17 +135,6 @@ func (s *RowSorter) CompareKeys(a, b []interface{}) int {
 		}
 	}
 	return 0
-}
-
-// CompareRows compares rows a and b based on s.sortConditions. The sort keys are freshly evaluated on each
-// call; prefer EvalKey/CompareKeys when a row participates in more than one comparison.
-func (s *RowSorter) CompareRows(a, b sql.Row) int {
-	return s.CompareKeys(s.EvalKey(a), s.EvalKey(b))
-}
-
-// IsLesserRow determines if sql.Row `a` is less than sql.Row `b` based off s.sortConditions
-func (s *RowSorter) IsLesserRow(a, b sql.Row) bool {
-	return s.CompareRows(a, b) < 0
 }
 
 // Less implements sort.Interface interface.

--- a/sql/sorters/row_sorter.go
+++ b/sql/sorters/row_sorter.go
@@ -18,18 +18,26 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
-// RowSorter is a sorter implementation for Row slices using SortFields for the comparison
+// RowSorter is a sorter implementation for Row slices using SortFields for the comparison.
+// Sort key expressions are evaluated at most once per row and the resulting keys are cached, rather than
+// re-evaluating expressions on every comparison. This matters for correctness, not just speed: a
+// non-deterministic sort expression (e.g. ORDER BY RAND()) must produce a single stable key per row, or the
+// resulting order is biased by comparison order.
 type RowSorter struct {
 	lastError      error
 	ctx            *sql.Context
 	sortConditions sql.SortConditions
+	types          []sql.Type
 	rows           []sql.Row
+	// keys[i] caches the evaluated sort condition expressions for rows[i]; a nil slice means not yet evaluated
+	keys [][]interface{}
 }
 
 func NewRowSorter(ctx *sql.Context, sortConditions sql.SortConditions) *RowSorter {
 	return &RowSorter{
 		ctx:            ctx,
 		sortConditions: sortConditions,
+		types:          sortConditionTypes(ctx, sortConditions),
 	}
 }
 
@@ -37,8 +45,18 @@ func NewRowSorterWithRows(ctx *sql.Context, sortConditions sql.SortConditions, r
 	return &RowSorter{
 		ctx:            ctx,
 		sortConditions: sortConditions,
+		types:          sortConditionTypes(ctx, sortConditions),
 		rows:           rows,
+		keys:           make([][]interface{}, len(rows)),
 	}
+}
+
+func sortConditionTypes(ctx *sql.Context, sortConditions sql.SortConditions) []sql.Type {
+	types := make([]sql.Type, len(sortConditions))
+	for i, sc := range sortConditions {
+		types[i] = sc.Expr.Type(ctx)
+	}
+	return types
 }
 
 func (s *RowSorter) GetError() error {
@@ -53,25 +71,40 @@ func (s *RowSorter) Len() int {
 // Swap implements sort.Interface
 func (s *RowSorter) Swap(i, j int) {
 	s.rows[i], s.rows[j] = s.rows[j], s.rows[i]
+	s.keys[i], s.keys[j] = s.keys[j], s.keys[i]
 }
 
-// CompareRows compares rows a and b based on s.SortFields
-func (s *RowSorter) CompareRows(a, b sql.Row) int {
-	for _, sc := range s.sortConditions {
-		typ := sc.Expr.Type(s.ctx)
-		// TODO: For complex SortFields, like Subqueries, recalculating the value may be costly. We should find some way
-		//  to cache it.
-		av, err := sc.Expr.Eval(s.ctx, a)
+// EvalKey evaluates the sort condition expressions for the given row, returning the resulting sort key. If any
+// expression fails to evaluate, EvalKey records the error (see GetError) and returns nil.
+func (s *RowSorter) EvalKey(row sql.Row) []interface{} {
+	key := make([]interface{}, len(s.sortConditions))
+	for i, sc := range s.sortConditions {
+		v, err := sc.Expr.Eval(s.ctx, row)
 		if err != nil {
 			s.lastError = sql.ErrUnableSort.Wrap(err)
-			return 0
+			return nil
 		}
-		bv, err := sc.Expr.Eval(s.ctx, b)
-		if err != nil {
-			s.lastError = sql.ErrUnableSort.Wrap(err)
-			return 0
-		}
+		key[i] = v
+	}
+	return key
+}
 
+// keyAt returns the cached sort key for rows[i], evaluating and caching it first if necessary.
+func (s *RowSorter) keyAt(i int) []interface{} {
+	if s.keys[i] == nil {
+		s.keys[i] = s.EvalKey(s.rows[i])
+	}
+	return s.keys[i]
+}
+
+// CompareKeys compares two sort keys produced by EvalKey based on s.sortConditions. Either key may be nil (a
+// failed evaluation), in which case the comparison result is 0.
+func (s *RowSorter) CompareKeys(a, b []interface{}) int {
+	if a == nil || b == nil {
+		return 0
+	}
+	for i, sc := range s.sortConditions {
+		av, bv := a[i], b[i]
 		if sc.Order == sql.Descending {
 			av, bv = bv, av
 		}
@@ -88,7 +121,7 @@ func (s *RowSorter) CompareRows(a, b sql.Row) int {
 			}
 		}
 
-		cmp, err := typ.Compare(s.ctx, av, bv)
+		cmp, err := s.types[i].Compare(s.ctx, av, bv)
 		if err != nil {
 			s.lastError = err
 			return 0
@@ -101,7 +134,13 @@ func (s *RowSorter) CompareRows(a, b sql.Row) int {
 	return 0
 }
 
-// IsLesserRow determines if sql.Row `a` is less than sql.Row `b` based off s.SortFields
+// CompareRows compares rows a and b based on s.sortConditions. The sort keys are freshly evaluated on each
+// call; prefer EvalKey/CompareKeys when a row participates in more than one comparison.
+func (s *RowSorter) CompareRows(a, b sql.Row) int {
+	return s.CompareKeys(s.EvalKey(a), s.EvalKey(b))
+}
+
+// IsLesserRow determines if sql.Row `a` is less than sql.Row `b` based off s.sortConditions
 func (s *RowSorter) IsLesserRow(a, b sql.Row) bool {
 	return s.CompareRows(a, b) < 0
 }
@@ -111,5 +150,5 @@ func (s *RowSorter) Less(i, j int) bool {
 	if s.lastError != nil {
 		return false
 	}
-	return s.IsLesserRow(s.rows[i], s.rows[j])
+	return s.CompareKeys(s.keyAt(i), s.keyAt(j)) < 0
 }

--- a/sql/sorters/row_sorter_test.go
+++ b/sql/sorters/row_sorter_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sorters
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// countingExpr wraps an expression and counts Eval calls. Sort key expressions must be evaluated at most once
+// per row: re-evaluating a non-deterministic expression (e.g. ORDER BY RAND()) on every comparison biases the
+// resulting order.
+type countingExpr struct {
+	sql.Expression
+	count *int
+}
+
+func (c *countingExpr) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	*c.count++
+	return c.Expression.Eval(ctx, row)
+}
+
+func testRows(n int) []sql.Row {
+	rows := make([]sql.Row, n)
+	for i := range rows {
+		rows[i] = sql.NewRow(int32((i * 7) % n))
+	}
+	return rows
+}
+
+func countingSortConditions(count *int) sql.SortConditions {
+	return sql.SortConditions{
+		{
+			Expr:         &countingExpr{expression.NewGetField(0, types.Int32, "col1", false), count},
+			Order:        sql.Ascending,
+			NullOrdering: sql.NullsFirst,
+		},
+	}
+}
+
+func TestRowSorterEvaluatesKeysOncePerRow(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	const numRows = 100
+
+	var evalCount int
+	rows := testRows(numRows)
+	sorter := NewRowSorterWithRows(ctx, countingSortConditions(&evalCount), rows)
+	sort.Stable(sorter)
+	require.NoError(t, sorter.GetError())
+
+	for i, row := range rows {
+		require.Equal(t, int32(i), row[0])
+	}
+	require.LessOrEqual(t, evalCount, numRows)
+}
+
+func TestGetTopNRowsEvaluatesKeysOncePerRow(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	const numRows = 100
+
+	var evalCount int
+	iter := sql.RowsToRowIter(testRows(numRows)...)
+	topRows, rowCount, err := GetTopNRows(ctx, iter, countingSortConditions(&evalCount), 5)
+	require.NoError(t, err)
+	require.Equal(t, int64(numRows), rowCount)
+
+	require.Len(t, topRows, 5)
+	for i, row := range topRows {
+		require.Equal(t, int32(i), row[0])
+	}
+	require.LessOrEqual(t, evalCount, numRows)
+}

--- a/sql/sorters/rows_heap.go
+++ b/sql/sorters/rows_heap.go
@@ -72,7 +72,7 @@ type maxRowsHeap struct {
 
 // Less implements heap.Interface. It is inverted to implement a max-heap.
 func (h *maxRowsHeap) Less(i, j int) bool {
-	cmp := h.RowSorter.CompareRows(h.RowSorter.rows[i], h.RowSorter.rows[j])
+	cmp := h.RowSorter.CompareKeys(h.RowSorter.keyAt(i), h.RowSorter.keyAt(j))
 	if cmp == 0 {
 		return h.order[i] > h.order[j]
 	}
@@ -89,6 +89,7 @@ func (h *maxRowsHeap) Swap(i, j int) {
 func (h *maxRowsHeap) Push(x interface{}) {
 	e := x.(rowWithOrder)
 	h.RowSorter.rows = append(h.RowSorter.rows, e.row)
+	h.RowSorter.keys = append(h.RowSorter.keys, nil)
 	h.order = append(h.order, e.order)
 }
 
@@ -97,6 +98,7 @@ func (h *maxRowsHeap) Pop() interface{} {
 	n := len(h.RowSorter.rows)
 	row := h.RowSorter.rows[n-1]
 	h.RowSorter.rows = h.RowSorter.rows[:n-1]
+	h.RowSorter.keys = h.RowSorter.keys[:n-1]
 	h.order = h.order[:n-1]
 	return row
 }


### PR DESCRIPTION
Sort comparators previously re-evaluated ORDER BY expressions on every comparison. For non-deterministic expressions (e.g. ORDER BY RAND()), this biased the result heavily toward rows late in the scan: with ORDER BY RAND() LIMIT 1 each comparison was a fresh coin flip, so the last row won ~50% of the time instead of 1/N. It was also wasteful for expensive sort keys, evaluating them O(n log n) times instead of O(n).

Sort keys are now evaluated at most once per row and cached, in the full sort, Top-N heap, and top-1 paths. The top-1 path also now surfaces sort expression evaluation errors instead of swallowing them.