### PR TITLE
Preserve LEFT JOIN semantics for lateral joins with no join filters

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -1529,6 +1529,24 @@ var LateralJoinScriptTests = []ScriptTest{
 					{3, 5},
 				},
 			},
+			{
+				// A left lateral join with a trivially true condition must still null-extend
+				// left rows for which the lateral subquery produces no rows.
+				Query: "select * from t left join lateral (select * from t1 where t.i = t1.j) as tt on true order by t.i, tt.j",
+				Expected: []sql.Row{
+					{1, 1},
+					{2, nil},
+					{3, nil},
+				},
+			},
+			{
+				Query: "select * from t left join lateral (select * from t1 where t.i = t1.j) as tt on 1 = 1 order by t.i, tt.j",
+				Expected: []sql.Row{
+					{1, 1},
+					{2, nil},
+					{3, nil},
+				},
+			},
 
 			// Lateral Right Join
 			{

--- a/sql/memo/exec_builder.go
+++ b/sql/memo/exec_builder.go
@@ -299,7 +299,9 @@ func (b *ExecBuilder) buildMergeJoin(ctx *sql.Context, j *MergeJoin, children ..
 }
 
 func (b *ExecBuilder) buildLateralJoin(ctx *sql.Context, j *LateralJoin, children ...sql.Node) (sql.Node, error) {
-	if len(j.Filter) == 0 {
+	// An outer lateral join must keep its join type even with no filters (e.g. a LEFT JOIN LATERAL with a
+	// trivially true condition), since it null-extends left rows when the lateral subquery produces no rows.
+	if len(j.Filter) == 0 && j.Op.AsLateral() != plan.JoinTypeLateralLeft {
 		return plan.NewLateralCrossJoin(ctx, children[0], children[1]), nil
 	}
 	filters := b.buildFilterConjunction(ctx, j.Filter...)


### PR DESCRIPTION
A LEFT JOIN LATERAL with a trivially true condition (e.g. ON true) had its filter simplified away, and the memo exec builder then rebuilt every filterless lateral join as a lateral cross join incorrectly.