### PR TITLE
Don't set the max1Row query flag for plans containing RowIter exprs

### DIFF
--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/apd/v3"
@@ -62,6 +63,7 @@ func costedIndexScans(
 	node sql.Node,
 	qFlags *sql.QueryFlags,
 ) (sql.Node, transform.TreeIdentity, error) {
+	planReturnsRowIter := rowIterExprChecker(ctx, node)
 	return transform.Node(ctx, node, func(ctx *sql.Context, n sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		filter, ok := n.(*plan.Filter)
 		if !ok {
@@ -91,7 +93,7 @@ func costedIndexScans(
 				return n, transform.SameTree, err
 			}
 			if ok {
-				return indexSearchableLookup(ctx, n, tblNode, lookup, filter.Expression, newFilter, lookupFds, qFlags)
+				return indexSearchableLookup(ctx, n, tblNode, lookup, filter.Expression, newFilter, lookupFds, qFlags, planReturnsRowIter)
 			}
 			if idxTbl.SkipIndexCosting() {
 				return n, transform.SameTree, nil
@@ -105,7 +107,7 @@ func costedIndexScans(
 			}
 
 			exprs := expression.SplitConjunction(ctx, filter.Expression)
-			idxedTbl, stats, filters, err := getCostedIndexScan(ctx, a.Catalog, a.Catalog, tblNode, idxs, exprs, qFlags)
+			idxedTbl, stats, filters, err := getCostedIndexScan(ctx, a.Catalog, a.Catalog, tblNode, idxs, exprs, qFlags, planReturnsRowIter)
 			if err != nil || idxedTbl == nil {
 				return n, transform.SameTree, err
 			}
@@ -129,6 +131,23 @@ func costedIndexScans(
 	})
 }
 
+// rowIterExprChecker returns a memoized predicate reporting whether any expression in the tree rooted at
+// |node| returns a RowIter rather than a scalar value (sql.RowIterExpression), e.g. a set-returning function
+// such as Postgres's unnest. Such expressions can multiply the number of output rows, so a plan containing one
+// can return more than one row even when an index lookup proves at most one source row.
+func rowIterExprChecker(ctx *sql.Context, node sql.Node) func() bool {
+	return sync.OnceValue(func() bool {
+		found := false
+		transform.InspectExpressions(ctx, node, func(ctx *sql.Context, e sql.Expression) bool {
+			if rie, ok := e.(sql.RowIterExpression); ok && rie.ReturnsRowIter() {
+				found = true
+			}
+			return !found
+		})
+		return found
+	})
+}
+
 func indexSearchableLookup(
 	ctx *sql.Context,
 	node sql.Node,
@@ -137,6 +156,7 @@ func indexSearchableLookup(
 	oldFilter, newFilter sql.Expression,
 	fds *sql.FuncDepSet,
 	qFlags *sql.QueryFlags,
+	planReturnsRowIter func() bool,
 ) (sql.Node, transform.TreeIdentity, error) {
 
 	if lookup.IsEmpty() {
@@ -164,10 +184,12 @@ func indexSearchableLookup(
 		ret = plan.NewFilter(ctx, newFilter, ret)
 	}
 
-	if fds != nil && fds.HasMax1Row() && !qFlags.JoinIsSet() && !qFlags.SubqueryIsSet() && lookup.Ranges.Len() == 1 {
+	if fds != nil && fds.HasMax1Row() && !qFlags.JoinIsSet() && !qFlags.SubqueryIsSet() && lookup.Ranges.Len() == 1 && !planReturnsRowIter() {
 		// Strict index lookup without a join or subquery scope will return
 		// at most one row. We could also use some sort of scope counting
-		// to check for single scope.
+		// to check for single scope. Expressions that return a RowIter
+		// (set-returning functions) can multiply output rows, so their
+		// presence also disqualifies the plan.
 		qFlags.Set(sql.QFlagMax1Row)
 	}
 
@@ -202,6 +224,7 @@ func getCostedIndexScan(
 	indexes []sql.Index,
 	filters []sql.Expression,
 	qFlags *sql.QueryFlags,
+	planReturnsRowIter func() bool,
 ) (*plan.IndexedTableAccess, sql.Statistic, []sql.Expression, error) {
 	// run each index through coster, save the cheapest
 	tbl := tblNode.UnderlyingTable()
@@ -422,10 +445,12 @@ func getCostedIndexScan(
 		bestStat = stats.UpdateCounts(bestStat)
 	}
 
-	if bestStat.FuncDeps().HasMax1Row() && !qFlags.JoinIsSet() && !qFlags.SubqueryIsSet() && lookup.Ranges.Len() == 1 {
+	if bestStat.FuncDeps().HasMax1Row() && !qFlags.JoinIsSet() && !qFlags.SubqueryIsSet() && lookup.Ranges.Len() == 1 && !planReturnsRowIter() {
 		// Strict index lookup without a join or subquery scope will return
 		// at most one row. We could also use some sort of scope counting
-		// to check for single scope.
+		// to check for single scope. Expressions that return a RowIter
+		// (set-returning functions) can multiply output rows, so their
+		// presence also disqualifies the plan.
 		qFlags.Set(sql.QFlagMax1Row)
 	}
 
@@ -433,6 +458,10 @@ func getCostedIndexScan(
 }
 
 func addIndexScans(ctx *sql.Context, m *memo.Memo, catalog *Catalog) error {
+	// This is only reached when replanning a join, and the memo does not have access to the full plan, so we
+	// conservatively report that the plan may contain RowIter expressions. This cannot cost us the max1Row
+	// shortcut: the join query flag set during replanning already disqualifies it.
+	planReturnsRowIter := func() bool { return true }
 	m.Tracer.PushDebugContext("addIndexScans")
 	defer m.Tracer.PopDebugContext()
 
@@ -505,7 +534,7 @@ func addIndexScans(ctx *sql.Context, m *memo.Memo, catalog *Catalog) error {
 		for i, idx := range indexes {
 			sqlIndexes[i] = idx.SqlIdx()
 		}
-		ita, stat, filters, err := getCostedIndexScan(ctx, m.StatsProvider(), catalog, rt, sqlIndexes, filter.Filters, m.QFlags)
+		ita, stat, filters, err := getCostedIndexScan(ctx, m.StatsProvider(), catalog, rt, sqlIndexes, filter.Filters, m.QFlags, planReturnsRowIter)
 		if err != nil {
 			m.HandleErr(err)
 		}

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -458,10 +458,6 @@ func getCostedIndexScan(
 }
 
 func addIndexScans(ctx *sql.Context, m *memo.Memo, catalog *Catalog) error {
-	// This is only reached when replanning a join, and the memo does not have access to the full plan, so we
-	// conservatively report that the plan may contain RowIter expressions. This cannot cost us the max1Row
-	// shortcut: the join query flag set during replanning already disqualifies it.
-	planReturnsRowIter := func() bool { return true }
 	m.Tracer.PushDebugContext("addIndexScans")
 	defer m.Tracer.PopDebugContext()
 
@@ -534,6 +530,11 @@ func addIndexScans(ctx *sql.Context, m *memo.Memo, catalog *Catalog) error {
 		for i, idx := range indexes {
 			sqlIndexes[i] = idx.SqlIdx()
 		}
+
+		// the rowIter analysis is a no-op here as it only impacts the QFlagMax1Row setting, which doesn't apply to
+		// this phase of join planning
+		planReturnsRowIter := func() bool { return false }
+
 		ita, stat, filters, err := getCostedIndexScan(ctx, m.StatsProvider(), catalog, rt, sqlIndexes, filter.Filters, m.QFlags, planReturnsRowIter)
 		if err != nil {
 			m.HandleErr(err)

--- a/sql/analyzer/costed_index_scan_test.go
+++ b/sql/analyzer/costed_index_scan_test.go
@@ -1172,3 +1172,78 @@ func (i *indexSearchableTable) LookupPartitions(context *sql.Context, lookup sql
 	// TODO implement me
 	panic("implement me")
 }
+
+// TestMax1RowRowIterExprs checks that a strict single-row index lookup sets the max1Row query flag, unless the
+// plan contains an expression that returns a RowIter (e.g. a set-returning function), which can multiply the
+// number of output rows.
+func TestMax1RowRowIterExprs(t *testing.T) {
+	buildPlan := func(proj sql.Expression) sql.Node {
+		return plan.NewProject(
+			sql.NewEmptyContext(),
+			[]sql.Expression{proj},
+			plan.NewFilter(
+				sql.NewEmptyContext(),
+				expression.NewEquals(
+					expression.NewGetFieldWithTable(0, 0, types.Int64, "mydb", "xy", "x", false),
+					expression.NewLiteral(1, types.Int64),
+				),
+				plan.NewResolvedTable(&max1RowIndexSearchableTable{&indexSearchableTable{underlying: plan.NewDualSqlTable()}}, nil, nil),
+			),
+		)
+	}
+
+	t.Run("scalar projection sets max1Row", func(t *testing.T) {
+		qFlags := &sql.QueryFlags{}
+		input := buildPlan(expression.NewGetFieldWithTable(0, 0, types.Int64, "mydb", "xy", "x", false))
+		_, same, err := costedIndexScans(nil, nil, input, qFlags)
+		require.NoError(t, err)
+		require.False(t, bool(same))
+		require.True(t, qFlags.IsSet(sql.QFlagMax1Row))
+	})
+
+	t.Run("RowIter projection does not set max1Row", func(t *testing.T) {
+		qFlags := &sql.QueryFlags{}
+		input := buildPlan(&testRowIterExpr{})
+		_, same, err := costedIndexScans(nil, nil, input, qFlags)
+		require.NoError(t, err)
+		require.False(t, bool(same))
+		require.False(t, qFlags.IsSet(sql.QFlagMax1Row))
+	})
+}
+
+// max1RowIndexSearchableTable is an indexSearchableTable whose lookups report a strict single-row guarantee.
+type max1RowIndexSearchableTable struct {
+	*indexSearchableTable
+}
+
+func (i *max1RowIndexSearchableTable) LookupForExpressions(ctx *sql.Context, exprs ...sql.Expression) (sql.IndexLookup, *sql.FuncDepSet, sql.Expression, bool, error) {
+	lookup, _, _, ok, err := i.indexSearchableTable.LookupForExpressions(ctx, exprs...)
+	if !ok || err != nil {
+		return lookup, nil, nil, ok, err
+	}
+	return lookup, sql.NewMax1RowFDs(sql.NewColSet(1), sql.NewColSet(1)), nil, true, nil
+}
+
+// testRowIterExpr is an expression that returns a RowIter rather than a scalar, like a set-returning function.
+type testRowIterExpr struct{}
+
+var _ sql.RowIterExpression = (*testRowIterExpr)(nil)
+
+func (t *testRowIterExpr) Resolved() bool               { return true }
+func (t *testRowIterExpr) String() string               { return "test_row_iter()" }
+func (t *testRowIterExpr) Type(*sql.Context) sql.Type   { return types.Int64 }
+func (t *testRowIterExpr) IsNullable(*sql.Context) bool { return false }
+func (t *testRowIterExpr) Eval(*sql.Context, sql.Row) (interface{}, error) {
+	return nil, fmt.Errorf("test_row_iter must be evaluated as a RowIter")
+}
+func (t *testRowIterExpr) Children() []sql.Expression { return nil }
+func (t *testRowIterExpr) WithChildren(_ *sql.Context, children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(t, len(children), 0)
+	}
+	return t, nil
+}
+func (t *testRowIterExpr) EvalRowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
+	return sql.RowsToRowIter(sql.Row{int64(1)}, sql.Row{int64(2)}), nil
+}
+func (t *testRowIterExpr) ReturnsRowIter() bool { return true }


### PR DESCRIPTION
Set-returning functions multiply output rows, so a strict index lookup no longer guarantees at most one result row when the plan contains one.

See https://github.com/dolthub/doltgresql/pull/3151