### PR TITLE
Fix HAVING aggregate alias resolution

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -1431,6 +1431,26 @@ var JoinScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/11627
+		Name: "HAVING resolves aggregate inputs from separate aliases",
+		SetUpScript: []string{
+			"CREATE TABLE customers (id BIGINT PRIMARY KEY)",
+			"CREATE TABLE orders (id BIGINT PRIMARY KEY, customer_id BIGINT, status VARCHAR(16), total BIGINT)",
+			"INSERT INTO customers VALUES (1)",
+			"INSERT INTO orders VALUES (1, 1, 'paid', 10), (2, 1, 'paid', 20)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "WITH paid AS (SELECT id, customer_id, total FROM orders WHERE status = 'paid') SELECT c.id, COUNT(p1.total) AS total_count, COUNT(p2.id) AS peer_orders FROM customers c JOIN paid p1 ON p1.customer_id = c.id LEFT JOIN paid p2 ON p2.customer_id = c.id AND p2.id <> p1.id GROUP BY c.id HAVING COUNT(p2.id) > 0",
+				Expected: []sql.Row{{int64(1), int64(2), int64(2)}},
+			},
+			{
+				Query:    "SELECT c.id, COUNT(p1.total) AS total_count, COUNT(p2.id) AS peer_orders FROM customers c JOIN orders p1 ON p1.customer_id = c.id LEFT JOIN orders p2 ON p2.customer_id = c.id AND p2.id <> p1.id WHERE p1.status = 'paid' AND p2.status = 'paid' GROUP BY c.id HAVING COUNT(p2.id) > 0",
+				Expected: []sql.Row{{int64(1), int64(2), int64(2)}},
+			},
+		},
+	},
 }
 
 var LateralJoinScriptTests = []ScriptTest{

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -903,16 +903,6 @@ func (b *Builder) buildInnerProj(fromScope, projScope *scope) *scope {
 	return outScope
 }
 
-// getMatchingCol returns the column in cols that matches the name, if it exists
-func getMatchingCol(cols []scopeColumn, name string) (scopeColumn, bool) {
-	for _, c := range cols {
-		if strings.EqualFold(c.col, name) {
-			return c, true
-		}
-	}
-	return scopeColumn{}, false
-}
-
 func (b *Builder) buildHaving(fromScope, projScope, outScope *scope, having *ast.Where) {
 	// expressions in having can be from aggOut or projScop
 	if having == nil {
@@ -938,7 +928,7 @@ func (b *Builder) buildHaving(fromScope, projScope, outScope *scope, having *ast
 		transform.InspectExpr(b.ctx, c.scalar, func(ctx *sql.Context, e sql.Expression) bool {
 			switch e := e.(type) {
 			case *expression.GetField:
-				col, found := getMatchingCol(fromScope.cols, e.Name())
+				col, found := fromScope.resolveColumn(e.Database(), e.Table(), e.Name(), false, false)
 				if found && !havingScope.colset.Contains(sql.ColumnId(col.id)) {
 					havingScope.addColumn(col)
 				}
@@ -963,7 +953,7 @@ func (b *Builder) buildHaving(fromScope, projScope, outScope *scope, having *ast
 		if !isGetField {
 			continue
 		}
-		col, found := getMatchingCol(fromScope.cols, gf.Name())
+		col, found := fromScope.resolveColumn(gf.Database(), gf.Table(), gf.Name(), false, false)
 		if found && !havingScope.colset.Contains(sql.ColumnId(col.id)) {
 			havingScope.addColumn(col)
 		}


### PR DESCRIPTION
Resolve HAVING aggregate inputs using their full table qualifiers so joins with duplicate column names do not bind the wrong source.

Fixes dolthub/dolt#11627