### PR TITLE
Plumb DROP TABLE ... CASCADE through to plan.DropTable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83
 	github.com/dolthub/jsonpath v0.0.2-0.20260807003725-336cd89c1c76
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
-	github.com/dolthub/vitess v0.0.0-20260828193927-f9eb707fd659
+	github.com/dolthub/vitess v0.0.0-20260831192502-e34df639d960
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gocraft/dbr/v2 v2.7.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -20,10 +20,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20260807003725-336cd89c1c76 h1:ZmLDDKnfbWc8
 github.com/dolthub/jsonpath v0.0.2-0.20260807003725-336cd89c1c76/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216 h1:JWkKRE4EHUcEVQCMRBej8DYxjYjRz/9MdF/NNQh0o70=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216/go.mod h1:e/FIZVvT2IR53HBCAo41NjqgtEnjMJGKca3Y/dAmZaA=
-github.com/dolthub/vitess v0.0.0-20260819175407-19559ab533b7 h1:EVQjlsya92uPG2jXtOLTl/bzChZMi27sBbmO8h6G1uI=
-github.com/dolthub/vitess v0.0.0-20260819175407-19559ab533b7/go.mod h1:5SVEJgAhw5nnQUFnGgKI1Svqes1Mw+zKUsalyxmOuG0=
-github.com/dolthub/vitess v0.0.0-20260828193927-f9eb707fd659 h1:DJfoBlihBdLY6KokA+wCXoYYeOgwrKuiZFPHJP8koi8=
-github.com/dolthub/vitess v0.0.0-20260828193927-f9eb707fd659/go.mod h1:5SVEJgAhw5nnQUFnGgKI1Svqes1Mw+zKUsalyxmOuG0=
+github.com/dolthub/vitess v0.0.0-20260831192502-e34df639d960 h1:NMg7ETQiEHsSfH8ckCTI7q0ukycwOF4qEuJ/jO1QUIM=
+github.com/dolthub/vitess v0.0.0-20260831192502-e34df639d960/go.mod h1:5SVEJgAhw5nnQUFnGgKI1Svqes1Mw+zKUsalyxmOuG0=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -447,6 +447,10 @@ type DropTable struct {
 	Tables       []sql.Node
 	TriggerNames []string
 	ifExists     bool
+	// Cascade is set for DROP TABLE ... CASCADE statements: objects that depend on the dropped tables should be
+	// dropped along with them. The MySQL dialect parses but ignores CASCADE, so this is only set by integrators
+	// whose dialects give it meaning (e.g. Postgres); the engine itself does not act on it.
+	Cascade bool
 }
 
 var _ sql.Node = (*DropTable)(nil)

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -274,7 +274,9 @@ func (b *Builder) buildDropTable(inScope *scope, c *ast.DDL) (outScope *scope) {
 		}
 	}
 
-	outScope.node = plan.NewDropTable(dropTables, c.IfExists)
+	dropTable := plan.NewDropTable(dropTables, c.IfExists)
+	dropTable.Cascade = c.Cascade
+	outScope.node = dropTable
 	return
 }
 


### PR DESCRIPTION
Adds a Cascade flag to plan.DropTable (populated from the vitess AST) so that integrator pre-execution hooks can implement dialect-specific cascade semantics; the engine itself does not act on it.

Companion PRs:
- dolthub/vitess: https://github.com/dolthub/vitess/pull/482
- dolthub/doltgresql: https://github.com/dolthub/doltgresql/pull/3155