### PR TITLE
sql.ValueRows: Correctly handle filter expressions that aren't bools

### DIFF
--- a/sql/core.go
+++ b/sql/core.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/dolthub/vitess/go/vt/proto/query"
 	"math"
 	trace2 "runtime/trace"
 	"strconv"
@@ -28,6 +27,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/apd/v3"
+	"github.com/dolthub/vitess/go/vt/proto/query"
 	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/sql/values"

--- a/sql/core.go
+++ b/sql/core.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/dolthub/vitess/go/vt/proto/query"
 	"math"
 	trace2 "runtime/trace"
 	"strconv"
@@ -345,6 +346,58 @@ func ConvertToBool(ctx *Context, v interface{}) (bool, error) {
 	}
 }
 
+// ConvertValueToBool converts a Value to a boolean
+func ConvertValueToBool(ctx *Context, v Value) (bool, error) {
+	if v.IsNull() {
+		return false, fmt.Errorf("unable to cast nil to bool")
+	}
+	switch v.Typ {
+	case query.Type_INT64:
+		return values.ReadInt64(v.Val) != 0, nil
+	case query.Type_INT32:
+		return values.ReadInt32(v.Val) != 0, nil
+	case query.Type_INT16:
+		return values.ReadInt16(v.Val) != 0, nil
+	case query.Type_INT8:
+		return values.ReadInt8(v.Val) != 0, nil
+	case query.Type_UINT64:
+		return values.ReadUint64(v.Val) != 0, nil
+	case query.Type_UINT32:
+		return values.ReadUint32(v.Val) != 0, nil
+	case query.Type_UINT16:
+		return values.ReadUint16(v.Val) != 0, nil
+	case query.Type_UINT8:
+		return values.ReadUint8(v.Val) != 0, nil
+	case query.Type_FLOAT32:
+		return values.ReadFloat32(v.Val) != 0, nil
+	case query.Type_FLOAT64:
+		return values.ReadFloat64(v.Val) != 0, nil
+	case query.Type_TEXT, query.Type_CHAR, query.Type_BINARY, query.Type_VARCHAR, query.Type_VARBINARY, query.Type_BLOB:
+		bFloat, err := strconv.ParseFloat(TrimStringToNumberPrefix(ctx, string(v.Val), false), 64)
+		if err != nil {
+			return false, nil
+		}
+		return bFloat != 0, nil
+	default:
+		// TODO: Implmement remaining types
+		/*
+			Type_TIMESTAMP Type = 2061
+			Type_DATE Type = 2062
+			Type_TIME Type = 2063
+			Type_DATETIME Type = 2064
+			Type_YEAR Type = 785
+			Type_DECIMAL Type = 18
+			Type_BIT Type = 2073
+			Type_ENUM Type = 2074
+			Type_SET Type = 2075
+			Type_GEOMETRY Type = 2077
+			Type_JSON Type = 2078
+			Type_VECTOR Type = 8224
+		*/
+		return false, fmt.Errorf("unable to cast %#v of type %T to bool", v, v)
+	}
+}
+
 const (
 	// IntCutSet is the set of characters that should be trimmed from the beginning and end of a string
 	//   when converting to a signed or unsigned integer
@@ -439,6 +492,25 @@ func EvaluateCondition(ctx *Context, cond Expression, row Row) (interface{}, err
 	res, err := ConvertToBool(ctx, v)
 	if err != nil {
 		return nil, err
+	}
+	return res, nil
+}
+
+// EvaluateConditionValue evaluates a condition, which is an ValueExpression whose value
+// will be nil or coerced boolean.
+func EvaluateConditionValue(ctx *Context, cond ValueExpression, row ValueRow) (bool, error) {
+	defer trace2.StartRegion(ctx, "EvaluateCondition").End()
+
+	v, err := cond.EvalValue(ctx, row)
+	if err != nil {
+		return false, err
+	}
+	if v.IsNull() {
+		return false, nil
+	}
+	res, err := ConvertValueToBool(ctx, v)
+	if err != nil {
+		return false, err
 	}
 	return res, nil
 }

--- a/sql/plan/filter.go
+++ b/sql/plan/filter.go
@@ -145,11 +145,11 @@ func (i *FilterIter) NextValueRow(ctx *sql.Context) (sql.ValueRow, error) {
 		if err != nil {
 			return nil, err
 		}
-		res, err := i.cond.(sql.ValueExpression).EvalValue(ctx, row)
+		b, err := sql.EvaluateConditionValue(ctx, i.cond.(sql.ValueExpression), row)
 		if err != nil {
 			return nil, err
 		}
-		if res.Val[0] == 1 {
+		if b {
 			return row, nil
 		}
 	}


### PR DESCRIPTION

This fixes a correctness issue running the following queries from `TestQueries` against a Dolt MySQL server:

```
SELECT i,v from stringandtable WHERE i
SELECT i,v from stringandtable WHERE v
SELECT i FROM mytable WHERE NULL > 10;
SELECT i FROM mytable WHERE NULL IN (10);
SELECT i FROM mytable WHERE NULL IN (NULL, NULL);
SELECT i FROM mytable WHERE NOT NULL NOT IN (NULL);
SELECT i FROM mytable WHERE NOT (NULL) <> 10;
SELECT i FROM mytable WHERE NOT NULL <> NULL;
```

There are no test changes because the test harness needs to be updated for every query test at once, once every test passes. I ran the new test harness locally and confirmed that this PR fixes some of the failing tests and does not introduce any new failures.