### PR TITLE
sql.ValueRows: Correctly handle NULLs in comparisons.

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3468,6 +3468,13 @@ SELECT * FROM cte WHERE  d = 2;`,
 		Expected: []sql.Row{{int64(6)}},
 	},
 	{
+		Query: "SELECT * FROM niltable WHERE b >= 1",
+		Expected: []sql.Row{
+			{int64(2), int64(2), int32(1), nil},
+			{int64(5), nil, int32(1), 5.0},
+		},
+	},
+	{
 		Query:    "SELECT i FROM niltable WHERE b IS NOT FALSE",
 		Expected: []sql.Row{{int64(1)}, {int64(2)}, {int64(4)}, {int64(5)}},
 	},

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -230,7 +230,7 @@ func (c *comparison) CompareValue(ctx *sql.Context, row sql.ValueRow) (int, erro
 	}
 
 	if lv.IsNull() || rv.IsNull() {
-		return 0, nil
+		return 0, ErrNilOperand.New()
 	}
 
 	lTyp, rTyp := c.LeftChild.Type(ctx).(sql.ValueType), c.RightChild.Type(ctx).(sql.ValueType)
@@ -693,6 +693,9 @@ func (gt *GreaterThan) DebugString(ctx *sql.Context) string {
 func (gt *GreaterThan) EvalValue(ctx *sql.Context, row sql.ValueRow) (sql.Value, error) {
 	cmp, err := gt.CompareValue(ctx, row)
 	if err != nil {
+		if ErrNilOperand.Is(err) {
+			return sql.NullValue, nil
+		}
 		return sql.NullValue, err
 	}
 	if cmp != 1 {
@@ -760,6 +763,9 @@ func (lt *LessThan) DebugString(ctx *sql.Context) string {
 func (lt *LessThan) EvalValue(ctx *sql.Context, row sql.ValueRow) (sql.Value, error) {
 	cmp, err := lt.CompareValue(ctx, row)
 	if err != nil {
+		if ErrNilOperand.Is(err) {
+			return sql.NullValue, nil
+		}
 		return sql.NullValue, err
 	}
 	if cmp != -1 {
@@ -828,6 +834,9 @@ func (gte *GreaterThanOrEqual) DebugString(ctx *sql.Context) string {
 func (gte *GreaterThanOrEqual) EvalValue(ctx *sql.Context, row sql.ValueRow) (sql.Value, error) {
 	cmp, err := gte.CompareValue(ctx, row)
 	if err != nil {
+		if ErrNilOperand.Is(err) {
+			return sql.NullValue, nil
+		}
 		return sql.NullValue, err
 	}
 	if cmp == -1 {
@@ -898,6 +907,9 @@ func (lte *LessThanOrEqual) DebugString(ctx *sql.Context) string {
 func (lte *LessThanOrEqual) EvalValue(ctx *sql.Context, row sql.ValueRow) (sql.Value, error) {
 	cmp, err := lte.CompareValue(ctx, row)
 	if err != nil {
+		if ErrNilOperand.Is(err) {
+			return sql.NullValue, nil
+		}
 		return sql.NullValue, err
 	}
 	if cmp == 1 {


### PR DESCRIPTION

This fixes a correctness issue running a query against a Dolt MySQL server:

The test currently passes prior to this PR. This is because the test harness needs to be updated to more accurately reflect running against a Dolt MySQL server, but this currently causes other tests to fail. Instead, this change was tested locally to with the new test harness, and I confirmed that this PR fixes some of the failing tests and does not introduce any new failures.