### PR TITLE
Limit PostgreSQL conflict ignores to duplicate keys

### DIFF
--- a/memory/table_editor.go
+++ b/memory/table_editor.go
@@ -44,6 +44,7 @@ var _ sql.CommentedTable = (*tableEditor)(nil)
 var _ sql.RowReplacer = (*tableEditor)(nil)
 var _ sql.RowUpdater = (*tableEditor)(nil)
 var _ sql.RowInserter = (*tableEditor)(nil)
+var _ sql.UniqueKeyConflictCheckingRowInserter = (*tableEditor)(nil)
 var _ sql.RowDeleter = (*tableEditor)(nil)
 var _ sql.AutoIncrementSetter = (*tableEditor)(nil)
 var _ sql.ForeignKeyEditor = (*tableEditor)(nil)
@@ -188,6 +189,63 @@ func (t *tableEditor) Insert(ctx *sql.Context, row sql.Row) error {
 	}
 
 	return nil
+}
+
+// HasUniqueKeyConflict implements sql.UniqueKeyConflictCheckingRowInserter.
+func (t *tableEditor) HasUniqueKeyConflict(ctx *sql.Context, row sql.Row, columns []string) (bool, error) {
+	if err := checkRow(ctx, t.editedTable.data.schema.Schema, row); err != nil {
+		return false, err
+	}
+	target := make([]int, len(columns))
+	for idx, column := range columns {
+		target[idx] = t.Schema(ctx).IndexOfColName(column)
+		if target[idx] < 0 {
+			return false, fmt.Errorf("unique key conflict target column %q not found", column)
+		}
+	}
+
+	pkCols := t.pkColumnIndexes()
+	if len(columns) == 0 || sameColumnSet(target, pkCols) {
+		_, found, err := t.ea.Get(row)
+		if err != nil || found || len(columns) > 0 {
+			return found, err
+		}
+	}
+	for idx, uniqueCols := range t.uniqueIdxCols {
+		if (len(columns) > 0 && !sameColumnSet(target, uniqueCols)) || hasNullForAnyCols(row, uniqueCols) {
+			continue
+		}
+		_, found, err := t.ea.GetByCols(row, uniqueCols, t.prefixLengths[idx])
+		if err != nil || found || len(columns) > 0 {
+			return found, err
+		}
+	}
+	if len(columns) == 0 {
+		return false, nil
+	}
+	return false, fmt.Errorf("unique key conflict target does not match a unique key")
+}
+
+// sameColumnSet reports whether two column-index slices contain the same indexes regardless of order.
+func sameColumnSet(left, right []int) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	matched := make([]bool, len(right))
+	for _, leftIdx := range left {
+		found := false
+		for idx, rightIdx := range right {
+			if !matched[idx] && leftIdx == rightIdx {
+				matched[idx] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // Delete the given row from the table.

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -111,11 +111,12 @@ func applyForeignKeysToNodes(ctx *sql.Context, a *Analyzer, n sql.Node, cache *f
 			return n, transform.SameTree, nil
 		}
 		nn, err := n.WithChildren(ctx, &plan.ForeignKeyHandler{
-			Table:        tbl,
-			Sch:          insertableDest.Schema(ctx),
-			OriginalNode: n.Destination,
-			Editor:       fkEditor,
-			AllUpdaters:  fkChain.GetUpdaters(),
+			Table:                      tbl,
+			Sch:                        insertableDest.Schema(ctx),
+			OriginalNode:               n.Destination,
+			Editor:                     fkEditor,
+			AllUpdaters:                fkChain.GetUpdaters(),
+			CheckReferencesAfterInsert: n.Ignore && n.IgnoreMode == sql.InsertIgnoreModeDuplicateKeysOnly,
 		})
 		return nn, transform.NewTree, err
 	case *plan.Update:

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -134,6 +134,9 @@ var (
 	// This is meant to wrap a sql.UniqueKey error, which provides the key string
 	ErrUniqueKeyViolation = errors.NewKind("duplicate unique key given")
 
+	// ErrInsertConflictTarget is returned when an insert conflict target does not identify a unique or primary key.
+	ErrInsertConflictTarget = errors.NewKind("there is no unique or exclusion constraint matching the ON CONFLICT specification")
+
 	// ErrMisusedAlias is returned when a alias is defined and used in the same projection.
 	ErrMisusedAlias = errors.NewKind("column %q does not exist in scope, but there is an alias defined in" +
 		" this projection with that name. Aliases cannot be used in the same projection they're defined in")

--- a/sql/fulltext/multi_editor.go
+++ b/sql/fulltext/multi_editor.go
@@ -29,6 +29,7 @@ type MultiTableEditor struct {
 var _ sql.TableEditor = MultiTableEditor{}
 var _ sql.ForeignKeyEditor = MultiTableEditor{}
 var _ sql.AutoIncrementSetter = MultiTableEditor{}
+var _ sql.UniqueKeyConflictCheckingRowInserter = MultiTableEditor{}
 
 // CreateMultiTableEditor creates a TableEditor that writes to both the primary and secondary editors. The primary
 // editor must implement ForeignKeyEditor and AutoIncrementSetter in addition to TableEditor.
@@ -103,6 +104,15 @@ func (editor MultiTableEditor) Insert(ctx *sql.Context, row sql.Row) error {
 		}
 	}
 	return editor.primary.Insert(ctx, row)
+}
+
+// HasUniqueKeyConflict implements sql.UniqueKeyConflictCheckingRowInserter.
+func (editor MultiTableEditor) HasUniqueKeyConflict(ctx *sql.Context, row sql.Row, columns []string) (bool, error) {
+	checker, ok := editor.primary.(sql.UniqueKeyConflictCheckingRowInserter)
+	if !ok {
+		return false, nil
+	}
+	return checker.HasUniqueKeyConflict(ctx, row, columns)
 }
 
 // Update implements the interface sql.TableEditor.

--- a/sql/overrides.go
+++ b/sql/overrides.go
@@ -62,7 +62,19 @@ type BuilderOverrides struct {
 	ScalarFunctionAliasAsColumn bool
 	// Represents the parser to use. If this is nil, then the MySQL parser will be used.
 	Parser Parser
+	// InsertIgnoreMode controls the error-handling semantics for ignored inserts.
+	InsertIgnoreMode InsertIgnoreMode
 }
+
+// InsertIgnoreMode controls which compatibility semantics an ignored insert uses.
+type InsertIgnoreMode uint8
+
+const (
+	// InsertIgnoreModeMySQL preserves MySQL's broad INSERT IGNORE behavior.
+	InsertIgnoreModeMySQL InsertIgnoreMode = iota
+	// InsertIgnoreModeDuplicateKeysOnly suppresses only duplicate-key errors.
+	InsertIgnoreModeDuplicateKeysOnly
+)
 
 // ExecutionHooks contain various hooks that are called within a statement's lifecycle. Each inner struct represents a
 // specific statement.

--- a/sql/plan/foreign_key_handler.go
+++ b/sql/plan/foreign_key_handler.go
@@ -23,11 +23,12 @@ import (
 // ForeignKeyHandler handles all referencing and cascading operations that would need to be executed for an operation
 // on a table.
 type ForeignKeyHandler struct {
-	Table        sql.ForeignKeyTable
-	Sch          sql.Schema
-	OriginalNode sql.Node
-	Editor       *ForeignKeyEditor
-	AllUpdaters  []sql.ForeignKeyEditor
+	Table                      sql.ForeignKeyTable
+	Sch                        sql.Schema
+	OriginalNode               sql.Node
+	Editor                     *ForeignKeyEditor
+	AllUpdaters                []sql.ForeignKeyEditor
+	CheckReferencesAfterInsert bool // allows a duplicate-key error to take precedence over FK validation
 }
 
 func (n *ForeignKeyHandler) Underlying() sql.Table {
@@ -176,12 +177,33 @@ func (n *ForeignKeyHandler) StatementComplete(ctx *sql.Context) error {
 
 // Insert implements the interface sql.RowInserter.
 func (n *ForeignKeyHandler) Insert(ctx *sql.Context, row sql.Row) error {
-	for _, reference := range n.Editor.References {
-		if err := reference.CheckReference(ctx, row); err != nil {
-			return err
+	if !n.CheckReferencesAfterInsert {
+		for _, reference := range n.Editor.References {
+			if err := reference.CheckReference(ctx, row); err != nil {
+				return err
+			}
 		}
 	}
-	return n.Editor.Editor.Insert(ctx, row)
+	if err := n.Editor.Editor.Insert(ctx, row); err != nil {
+		return err
+	}
+	if n.CheckReferencesAfterInsert {
+		for _, reference := range n.Editor.References {
+			if err := reference.CheckReference(ctx, row); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// HasUniqueKeyConflict implements sql.UniqueKeyConflictCheckingRowInserter.
+func (n *ForeignKeyHandler) HasUniqueKeyConflict(ctx *sql.Context, row sql.Row, columns []string) (bool, error) {
+	checker, ok := n.Editor.Editor.(sql.UniqueKeyConflictCheckingRowInserter)
+	if !ok {
+		return false, nil
+	}
+	return checker.HasUniqueKeyConflict(ctx, row, columns)
 }
 
 // Update implements the interface sql.RowUpdater.

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -85,6 +85,10 @@ type InsertInto struct {
 
 	IsReplace bool
 	Ignore    bool
+	// IgnoreMode controls the compatibility semantics used when Ignore is true.
+	IgnoreMode sql.InsertIgnoreMode
+	// IgnoreTarget limits duplicate suppression to conflicts matching these columns. An empty target matches any key.
+	IgnoreTarget []string
 	// LiteralValueSource is set to |true| when |Source| is
 	// a |Values| node with only literal expressions.
 	LiteralValueSource bool

--- a/sql/plan/table_editor.go
+++ b/sql/plan/table_editor.go
@@ -55,7 +55,9 @@ func (s *TableEditorIter) Next(ctx *sql.Context) (sql.Row, error) {
 	})
 	row, err := s.inner.Next(ctx)
 	if err != nil && err != io.EOF {
-		s.errorEncountered = err
+		if _, ignoreError := err.(sql.IgnorableError); !ignoreError {
+			s.errorEncountered = err
+		}
 		return row, err
 	}
 	select {
@@ -69,9 +71,7 @@ func (s *TableEditorIter) Next(ctx *sql.Context) (sql.Row, error) {
 // Close implements the interface sql.RowIter.
 func (s *TableEditorIter) Close(ctx *sql.Context) error {
 	err := s.errorEncountered
-	_, ignoreError := err.(sql.IgnorableError)
-
-	if err != nil && !ignoreError {
+	if err != nil {
 		for _, openerCloser := range s.openerClosers {
 			tempErr := openerCloser.DiscardChanges(ctx, s.errorEncountered)
 			if tempErr != nil {

--- a/sql/planbuilder/conflict_target_test.go
+++ b/sql/planbuilder/conflict_target_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planbuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConflictTargetMatches verifies order-independent conflict-target matching.
+func TestConflictTargetMatches(t *testing.T) {
+	require.True(t, conflictTargetMatches([]string{"id"}, []string{"table.id"}))
+	require.True(t, conflictTargetMatches([]string{"a", "b"}, []string{"table.b", "table.a"}))
+	require.False(t, conflictTargetMatches([]string{"a"}, []string{"table.a", "table.b"}))
+	require.False(t, conflictTargetMatches([]string{"missing"}, []string{"table.id"}))
+	require.False(t, conflictTargetMatches(nil, []string{"table.id"}))
+}

--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -168,6 +168,16 @@ func (b *Builder) buildInsert(inScope *scope, i *ast.Insert) (outScope *scope) {
 	ins.OnDupValuesAlias = i.OnDupValuesAlias
 	ins.OnDupWhere = onDupWhere
 	ins.CountOnDuplicateUpdateAsOneRow = i.CountOnDuplicateUpdateAsOneRow
+	ins.IgnoreMode = b.overrides.InsertIgnoreMode
+	if len(i.ConflictTarget) > 0 {
+		ins.IgnoreTarget = make([]string, len(i.ConflictTarget))
+		for idx, column := range i.ConflictTarget {
+			ins.IgnoreTarget[idx] = column.String()
+		}
+		if rt != nil {
+			b.validateInsertIgnoreTarget(rt, ins.IgnoreTarget)
+		}
+	}
 	ins.LiteralValueSource = srcLiteralOnly
 
 	if len(i.Returning) > 0 {
@@ -186,6 +196,60 @@ func (b *Builder) buildInsert(inScope *scope, i *ast.Insert) (outScope *scope) {
 	}
 
 	return
+}
+
+// validateInsertIgnoreTarget verifies that the requested columns identify a non-partial unique key.
+func (b *Builder) validateInsertIgnoreTarget(rt *plan.ResolvedTable, target []string) {
+	schema := rt.Schema(b.ctx)
+	for _, column := range target {
+		if schema.IndexOfColName(column) < 0 {
+			b.handleErr(sql.ErrColumnNotFound.New(column))
+		}
+	}
+	var primary []string
+	for _, column := range schema {
+		if column.PrimaryKey {
+			primary = append(primary, column.Name)
+		}
+	}
+	if conflictTargetMatches(target, primary) {
+		return
+	}
+	indexed, ok := sql.GetUnderlyingTable(rt.Table).(sql.IndexAddressableTable)
+	if ok {
+		indexes, err := indexed.GetIndexes(b.ctx)
+		if err != nil {
+			b.handleErr(err)
+		}
+		for _, index := range indexes {
+			if partial, ok := index.(sql.PartialIndex); ok && partial.Predicate() != "" {
+				continue
+			}
+			if index.IsUnique() && conflictTargetMatches(target, index.Expressions()) {
+				return
+			}
+		}
+	}
+	b.handleErr(sql.ErrInsertConflictTarget.New())
+}
+
+// conflictTargetMatches reports whether target names the same columns as the indexed expressions.
+func conflictTargetMatches(target, expressions []string) bool {
+	if len(target) == 0 || len(target) != len(expressions) {
+		return false
+	}
+	wanted := make(map[string]struct{}, len(target))
+	for _, column := range target {
+		wanted[strings.ToLower(column)] = struct{}{}
+	}
+	for _, expression := range expressions {
+		parts := strings.Split(expression, ".")
+		column := strings.Trim(parts[len(parts)-1], "`\"")
+		if _, ok := wanted[strings.ToLower(column)]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (b *Builder) insertRowsToNode(inScope *scope, ir ast.InsertRows, columnNames []string, tableName string, destSchema sql.Schema) (outScope *scope, literalOnly bool) {

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -90,6 +90,8 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 		checks:                         ii.Checks(),
 		ctx:                            ctx,
 		ignore:                         ii.Ignore,
+		ignoreMode:                     ii.IgnoreMode,
+		ignoreTarget:                   ii.IgnoreTarget,
 		firstGeneratedAutoIncRowIdx:    ii.FirstGeneratedAutoIncRowIdx,
 		returnExprs:                    ii.Returning,
 		returnSchema:                   ii.Schema(ctx),
@@ -104,11 +106,12 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 		ed = inserter
 	}
 
-	if ii.Ignore {
-		// If ignore is set, then we are either replacing or inserting, but not updating on conflicts
+	if ii.Ignore && ii.IgnoreMode == sql.InsertIgnoreModeMySQL {
+		// MySQL INSERT IGNORE may suppress a row error and continue, so each row needs its own rollback checkpoint.
 		return plan.NewCheckpointingTableEditorIter(insertIter, ed), nil
 	} else {
-		// Otherwise, we are potentially inserting AND updating if there are conflicts
+		// PostgreSQL ON CONFLICT only suppresses matching uniqueness errors. Any other row error must roll back the
+		// entire statement, so duplicate-key-only inserts share one statement boundary with conflict updates.
 		eds := []sql.EditOpenerCloser{ed}
 		if updater != nil {
 			eds = append(eds, updater)

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -55,6 +55,8 @@ type insertIter struct {
 	rowNumber                   int64
 	closed                      bool
 	ignore                      bool
+	ignoreMode                  sql.InsertIgnoreMode
+	ignoreTarget                []string
 	hasAfterTrigger             bool
 }
 
@@ -75,6 +77,9 @@ func (i *insertIter) Next(ctx *sql.Context) (returnRow sql.Row, returnErr error)
 	for {
 		row, skipped, err := i.next(ctx)
 		if skipped || errors.Is(err, sql.ErrRowEditCanceled) {
+			continue
+		}
+		if _, ok := err.(sql.IgnorableError); ok && i.ignoreMode == sql.InsertIgnoreModeDuplicateKeysOnly && len(i.returnExprs) > 0 {
 			continue
 		}
 		return row, err
@@ -160,7 +165,7 @@ func (i *insertIter) next(ctx *sql.Context) (returnRow sql.Row, skipped bool, re
 				// IGNORE is specified:
 				// ERROR 3140 (22032): Invalid JSON text: "Invalid value." at position 0 in value for column
 				// 'table.column'.
-				if i.ignore && col.Type.Type() != query.Type_JSON {
+				if i.ignore && i.ignoreMode == sql.InsertIgnoreModeMySQL && col.Type.Type() != query.Type_JSON {
 					if sql.IsNumberType(col.Type) {
 						if converted == nil {
 							converted = i.schema[idx].Type.Zero()
@@ -224,6 +229,17 @@ func (i *insertIter) next(ctx *sql.Context) (returnRow sql.Row, skipped bool, re
 		}
 		return toReturn, false, nil
 	} else {
+		if i.ignore && i.ignoreMode == sql.InsertIgnoreModeDuplicateKeysOnly {
+			if checker, ok := i.inserter.(sql.UniqueKeyConflictCheckingRowInserter); ok {
+				conflict, err := checker.HasUniqueKeyConflict(ctx, row, i.ignoreTarget)
+				if err != nil {
+					return nil, false, sql.NewWrappedInsertError(row, err)
+				}
+				if conflict {
+					return nil, false, sql.NewIgnorableError(row)
+				}
+			}
+		}
 		if err := i.inserter.Insert(ctx, row); err != nil {
 			if (sql.ErrPrimaryKeyViolation.Is(err) || sql.ErrUniqueKeyViolation.Is(err)) &&
 				i.onDupKeyUpdateExprs.HasUpdates() {
@@ -400,8 +416,53 @@ func (i *insertIter) ignoreOrClose(ctx *sql.Context, row sql.Row, err error) err
 	if !i.ignore {
 		return sql.NewWrappedInsertError(row, err)
 	}
+	if i.ignoreMode == sql.InsertIgnoreModeDuplicateKeysOnly &&
+		!sql.ErrPrimaryKeyViolation.Is(err) &&
+		!sql.ErrUniqueKeyViolation.Is(err) &&
+		!sql.ErrDuplicateEntry.Is(err) {
+		return sql.NewWrappedInsertError(row, err)
+	}
+	if i.ignoreMode == sql.InsertIgnoreModeDuplicateKeysOnly && len(i.ignoreTarget) > 0 {
+		matches, probeErr := i.matchesIgnoreTarget(ctx, row, err)
+		if probeErr != nil {
+			return sql.NewWrappedInsertError(row, probeErr)
+		}
+		if !matches {
+			return sql.NewWrappedInsertError(row, err)
+		}
+	}
 
 	return warnOnIgnorableError(ctx, row, err)
+}
+
+// matchesIgnoreTarget reports whether a duplicate row conflicts with the selected unique-key target.
+func (i *insertIter) matchesIgnoreTarget(ctx *sql.Context, row sql.Row, err error) (bool, error) {
+	wrapped, ok := err.(*errors.Error)
+	if ok {
+		if uniqueErr, ok := wrapped.Cause().(sql.UniqueKeyError); ok && uniqueErr.Existing != nil && i.rowsMatchTarget(ctx, row, uniqueErr.Existing) {
+			return true, nil
+		}
+	}
+	checker, ok := i.inserter.(sql.UniqueKeyConflictCheckingRowInserter)
+	if !ok {
+		return false, nil
+	}
+	return checker.HasUniqueKeyConflict(ctx, row, i.ignoreTarget)
+}
+
+// rowsMatchTarget compares two rows using only the selected conflict-target columns.
+func (i *insertIter) rowsMatchTarget(ctx *sql.Context, row, existing sql.Row) bool {
+	for _, name := range i.ignoreTarget {
+		idx := i.schema.IndexOfColName(name)
+		if idx < 0 || idx >= len(row) || idx >= len(existing) || row[idx] == nil || existing[idx] == nil {
+			return false
+		}
+		equal, err := i.schema[idx].Type.Compare(ctx, row[idx], existing[idx])
+		if err != nil || equal != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // convertDataAndWarn modifies a row with data conversion issues in INSERT/UPDATE IGNORE calls
@@ -492,7 +553,7 @@ func (i *insertIter) validateNullability(ctx *sql.Context, dstSchema sql.Schema,
 	for count, col := range dstSchema {
 		if !col.Nullable && row[count] == nil {
 			// In the case of an IGNORE we set the nil value to a default and add a warning
-			if !i.ignore {
+			if !i.ignore || i.ignoreMode == sql.InsertIgnoreModeDuplicateKeysOnly {
 				if i.deferredDefaults.Contains(count) {
 					return sql.ErrFieldNoDefaultValue.New(col.Name)
 				}

--- a/sql/rowexec/insert_test.go
+++ b/sql/rowexec/insert_test.go
@@ -15,6 +15,7 @@
 package rowexec
 
 import (
+	"io"
 	"math"
 	"testing"
 
@@ -310,3 +311,338 @@ func TestOnDuplicateUpdateAffectedRows(t *testing.T) {
 		})
 	}
 }
+
+// TestInsertIgnoreModeErrorScopes verifies the error classes suppressed by each insert-ignore mode.
+func TestInsertIgnoreModeErrorScopes(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	row := sql.Row{1}
+	fkErr := sql.ErrForeignKeyChildViolation.New("fk", "child", "parent", "1")
+	duplicateErr := sql.ErrPrimaryKeyViolation.New()
+
+	t.Run("MySQL INSERT IGNORE suppresses foreign key errors", func(t *testing.T) {
+		iter := &insertIter{ignore: true}
+		_, ok := iter.ignoreOrClose(ctx, row, fkErr).(sql.IgnorableError)
+		require.True(t, ok)
+	})
+
+	t.Run("duplicate-key-only mode returns foreign key errors", func(t *testing.T) {
+		iter := &insertIter{ignore: true, ignoreMode: sql.InsertIgnoreModeDuplicateKeysOnly}
+		_, ok := iter.ignoreOrClose(ctx, row, fkErr).(sql.WrappedInsertError)
+		require.True(t, ok)
+	})
+
+	t.Run("duplicate-key-only mode suppresses duplicate key errors", func(t *testing.T) {
+		iter := &insertIter{ignore: true, ignoreMode: sql.InsertIgnoreModeDuplicateKeysOnly}
+		_, ok := iter.ignoreOrClose(ctx, row, duplicateErr).(sql.IgnorableError)
+		require.True(t, ok)
+	})
+}
+
+// TestInsertIgnoreTarget verifies that only conflicts on the selected unique key are suppressed.
+func TestInsertIgnoreTarget(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	iter := &insertIter{
+		schema:       sql.Schema{{Name: "id", Source: "t", Type: types.Int64, PrimaryKey: true}, {Name: "u", Source: "t", Type: types.Int64}},
+		ignore:       true,
+		ignoreMode:   sql.InsertIgnoreModeDuplicateKeysOnly,
+		ignoreTarget: []string{"id"},
+	}
+
+	t.Run("matching target is ignored", func(t *testing.T) {
+		err := sql.NewUniqueKeyErr("id", true, sql.Row{int64(1), int64(10)})
+		_, ok := iter.ignoreOrClose(ctx, sql.Row{int64(1), int64(11)}, err).(sql.IgnorableError)
+		require.True(t, ok)
+	})
+	t.Run("different unique key is returned", func(t *testing.T) {
+		err := sql.NewUniqueKeyErr("u", false, sql.Row{int64(1), int64(10)})
+		_, ok := iter.ignoreOrClose(ctx, sql.Row{int64(2), int64(10)}, err).(sql.WrappedInsertError)
+		require.True(t, ok)
+	})
+	t.Run("crossed conflict probes target independently", func(t *testing.T) {
+		db := memory.NewDatabase("db")
+		ctx := newContext(memory.NewDBProvider(db))
+		table := memory.NewTable(ctx, db, "t", sql.NewPrimaryKeySchema(iter.schema), nil)
+		require.NoError(t, table.CreateIndex(ctx, sql.IndexDef{
+			Name:       "u_idx",
+			Columns:    []sql.IndexColumn{{Name: "u"}},
+			Constraint: sql.IndexConstraint_Unique,
+		}))
+		inserter := table.Inserter(ctx)
+		require.NoError(t, inserter.Insert(ctx, sql.Row{int64(1), int64(10)}))
+		require.NoError(t, inserter.Insert(ctx, sql.Row{int64(2), int64(20)}))
+
+		iter.inserter = inserter
+		iter.ignoreTarget = []string{"u"}
+		err := sql.NewUniqueKeyErr("id", true, sql.Row{int64(1), int64(10)})
+		_, ok := iter.ignoreOrClose(ctx, sql.Row{int64(1), int64(20)}, err).(sql.IgnorableError)
+		require.True(t, ok)
+		require.NoError(t, inserter.Close(ctx))
+	})
+}
+
+// TestInsertIgnoreModes verifies check-constraint handling for MySQL and duplicate-only modes.
+func TestInsertIgnoreModes(t *testing.T) {
+	tests := []struct {
+		name string
+		mode sql.InsertIgnoreMode
+	}{
+		{name: "MySQL INSERT IGNORE suppresses check violations"},
+		{name: "duplicate-key-only mode returns check violations", mode: sql.InsertIgnoreModeDuplicateKeysOnly},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := memory.NewDatabase("db")
+			ctx := newContext(memory.NewDBProvider(db))
+			table := memory.NewTable(ctx, db.BaseDatabase, "t", sql.NewPrimaryKeySchema(sql.Schema{
+				{Name: "id", Source: "t", Type: types.Int64, PrimaryKey: true},
+			}), nil)
+			insert := plan.NewInsertInto(
+				sql.UnresolvedDatabase(""),
+				plan.NewResolvedTable(table, db, nil),
+				plan.NewValues([][]sql.Expression{{expression.NewLiteral(int64(1), types.Int64)}}),
+				false,
+				[]string{"id"},
+				nil,
+				true,
+			)
+			insert.IgnoreMode = tt.mode
+			insert = insert.WithChecks(sql.CheckConstraints{{
+				Name:     "positive",
+				Expr:     expression.NewLiteral(false, types.Boolean),
+				Enforced: true,
+			}}).(*plan.InsertInto)
+
+			iter, err := DefaultBuilder.Build(ctx, insert, nil)
+			require.NoError(t, err)
+			_, err = iter.Next(ctx)
+			if tt.mode == sql.InsertIgnoreModeDuplicateKeysOnly {
+				wrappedErr, ok := err.(sql.WrappedInsertError)
+				require.True(t, ok)
+				require.True(t, sql.ErrCheckConstraintViolated.Is(wrappedErr.Cause))
+				require.Error(t, iter.Close(ctx))
+			} else {
+				_, ok := err.(sql.IgnorableError)
+				require.True(t, ok)
+				require.NoError(t, iter.Close(ctx))
+			}
+		})
+	}
+}
+
+// TestInsertDuplicateKeysOnlyReturnsConversionErrors verifies that PostgreSQL-style ignores do not hide conversion failures.
+func TestInsertDuplicateKeysOnlyReturnsConversionErrors(t *testing.T) {
+	db := memory.NewDatabase("db")
+	ctx := newContext(memory.NewDBProvider(db))
+	table := memory.NewTable(ctx, db.BaseDatabase, "t", sql.NewPrimaryKeySchema(sql.Schema{
+		{Name: "id", Source: "t", Type: types.Int8, PrimaryKey: true},
+	}), nil)
+
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "conversion", value: "not a number"},
+		{name: "out of range", value: int64(128)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newContext(memory.NewDBProvider(db))
+			insert := plan.NewInsertInto(
+				sql.UnresolvedDatabase(""),
+				plan.NewResolvedTable(table, db, nil),
+				plan.NewValues([][]sql.Expression{{expression.NewLiteral(tt.value, types.LongText)}}),
+				false, []string{"id"}, nil, true,
+			)
+			insert.IgnoreMode = sql.InsertIgnoreModeDuplicateKeysOnly
+
+			iter, err := DefaultBuilder.Build(ctx, insert, nil)
+			require.NoError(t, err)
+			_, err = iter.Next(ctx)
+			require.Error(t, err)
+			require.Zero(t, ctx.WarningCount())
+			require.Error(t, iter.Close(ctx))
+		})
+	}
+}
+
+// TestInsertIgnoreModeNullability verifies mode-specific handling of nulls in non-nullable columns.
+func TestInsertIgnoreModeNullability(t *testing.T) {
+	tests := []struct {
+		name      string
+		mode      sql.InsertIgnoreMode
+		wantError bool
+	}{
+		{name: "MySQL mode substitutes zero value"},
+		{name: "duplicate-key-only mode returns not null error", mode: sql.InsertIgnoreModeDuplicateKeysOnly, wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := sql.NewEmptyContext()
+			inserter := &recordingInserter{}
+			iter := &insertIter{
+				schema:     sql.Schema{{Name: "id", Type: types.Int64, PrimaryKey: true}},
+				inserter:   inserter,
+				rowSource:  sql.RowsToRowIter(sql.Row{nil}),
+				ignore:     true,
+				ignoreMode: tt.mode,
+			}
+
+			row, err := iter.Next(ctx)
+			if tt.wantError {
+				require.Error(t, err)
+				wrapped, ok := err.(sql.WrappedInsertError)
+				require.True(t, ok)
+				require.True(t, sql.ErrInsertIntoNonNullableProvidedNull.Is(wrapped.Cause))
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, sql.Row{int64(0)}, row)
+				require.Equal(t, uint16(1), ctx.WarningCount())
+			}
+		})
+	}
+}
+
+// TestInsertDuplicateKeysOnlyReturnsNotNullErrorBeforeDuplicate verifies validation precedes duplicate probing.
+func TestInsertDuplicateKeysOnlyReturnsNotNullErrorBeforeDuplicate(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	inserter := &recordingInserter{insertErr: sql.ErrPrimaryKeyViolation.New()}
+	iter := &insertIter{
+		schema:     sql.Schema{{Name: "id", Type: types.Int64, PrimaryKey: true}},
+		inserter:   inserter,
+		rowSource:  sql.RowsToRowIter(sql.Row{nil}),
+		ignore:     true,
+		ignoreMode: sql.InsertIgnoreModeDuplicateKeysOnly,
+	}
+
+	_, err := iter.Next(ctx)
+	require.Error(t, err)
+	wrapped, ok := err.(sql.WrappedInsertError)
+	require.True(t, ok)
+	require.True(t, sql.ErrInsertIntoNonNullableProvidedNull.Is(wrapped.Cause))
+	require.Zero(t, inserter.insertCalls, "invalid rows must be rejected before duplicate detection")
+}
+
+// TestInsertDuplicateKeysOnlyStatementAtomicity verifies that a fatal row discards earlier statement edits.
+func TestInsertDuplicateKeysOnlyStatementAtomicity(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	inserter := &recordingInserter{}
+	insert := &insertIter{
+		schema:     sql.Schema{{Name: "id", Type: types.Int64, PrimaryKey: true}},
+		inserter:   inserter,
+		rowSource:  sql.RowsToRowIter(sql.Row{int64(1)}, sql.Row{nil}),
+		ignore:     true,
+		ignoreMode: sql.InsertIgnoreModeDuplicateKeysOnly,
+	}
+	iter := plan.NewTableEditorIter(insert, inserter)
+
+	row, err := iter.Next(ctx)
+	require.NoError(t, err)
+	require.Equal(t, sql.Row{int64(1)}, row)
+	_, err = iter.Next(ctx)
+	require.Error(t, err)
+	require.Error(t, iter.Close(ctx))
+	require.Empty(t, inserter.rows, "a later invalid row must roll back the whole statement")
+}
+
+// TestInsertDuplicateKeysOnlyPreflightsConflicts verifies ignored rows cause no editor side effects.
+func TestInsertDuplicateKeysOnlyPreflightsConflicts(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		target []string
+	}{
+		{name: "explicit target", target: []string{"id"}},
+		{name: "empty target"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := sql.NewEmptyContext()
+			inserter := &recordingInserter{conflict: true}
+			iter := &insertIter{
+				schema:       sql.Schema{{Name: "id", Type: types.Int64, PrimaryKey: true}},
+				inserter:     inserter,
+				rowSource:    sql.RowsToRowIter(sql.Row{int64(1)}),
+				ignore:       true,
+				ignoreMode:   sql.InsertIgnoreModeDuplicateKeysOnly,
+				ignoreTarget: tt.target,
+			}
+
+			_, err := iter.Next(ctx)
+			_, ok := err.(sql.IgnorableError)
+			require.True(t, ok)
+			require.Zero(t, inserter.insertCalls, "preflighted conflicts must not reach a side-effecting editor")
+			require.Equal(t, tt.target, inserter.checkedTarget)
+		})
+	}
+}
+
+// TestInsertDuplicateKeysOnlyReturningSkipsConflicts verifies RETURNING emits only inserted rows.
+func TestInsertDuplicateKeysOnlyReturningSkipsConflicts(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	inserter := &recordingInserter{conflictingRows: map[int64]struct{}{1: {}}}
+	iter := &insertIter{
+		schema:       sql.Schema{{Name: "id", Type: types.Int64, PrimaryKey: true}},
+		inserter:     inserter,
+		rowSource:    sql.RowsToRowIter(sql.Row{int64(1)}, sql.Row{int64(2)}),
+		ignore:       true,
+		ignoreMode:   sql.InsertIgnoreModeDuplicateKeysOnly,
+		returnExprs:  []sql.Expression{expression.NewGetField(0, types.Int64, "id", false)},
+		returnSchema: sql.Schema{{Name: "id", Type: types.Int64}},
+	}
+
+	row, err := iter.Next(ctx)
+	require.NoError(t, err)
+	require.Equal(t, sql.Row{int64(2)}, row)
+	_, err = iter.Next(ctx)
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, []sql.Row{{int64(2)}}, inserter.rows)
+}
+
+type recordingInserter struct {
+	rows            []sql.Row
+	checkpoint      []sql.Row
+	insertErr       error
+	insertCalls     int
+	conflict        bool
+	conflictingRows map[int64]struct{}
+	checkedTarget   []string
+}
+
+// HasUniqueKeyConflict implements sql.UniqueKeyConflictCheckingRowInserter.
+func (r *recordingInserter) HasUniqueKeyConflict(_ *sql.Context, row sql.Row, columns []string) (bool, error) {
+	r.checkedTarget = append([]string(nil), columns...)
+	if len(r.conflictingRows) > 0 {
+		_, ok := r.conflictingRows[row[0].(int64)]
+		return ok, nil
+	}
+	return r.conflict, nil
+}
+
+// StatementBegin implements sql.RowInserter.
+func (r *recordingInserter) StatementBegin(*sql.Context) {
+	r.checkpoint = append([]sql.Row(nil), r.rows...)
+}
+
+// DiscardChanges implements sql.RowInserter.
+func (r *recordingInserter) DiscardChanges(*sql.Context, error) error {
+	r.rows = append([]sql.Row(nil), r.checkpoint...)
+	return nil
+}
+
+// StatementComplete implements sql.RowInserter.
+func (r *recordingInserter) StatementComplete(*sql.Context) error { return nil }
+
+// Insert implements sql.RowInserter.
+func (r *recordingInserter) Insert(_ *sql.Context, row sql.Row) error {
+	r.insertCalls++
+	if r.insertErr != nil {
+		return r.insertErr
+	}
+	r.rows = append(r.rows, row.Copy())
+	return nil
+}
+
+// Close implements sql.RowInserter.
+func (r *recordingInserter) Close(*sql.Context) error { return nil }
+
+var _ sql.RowInserter = (*recordingInserter)(nil)
+var _ sql.UniqueKeyConflictCheckingRowInserter = (*recordingInserter)(nil)

--- a/sql/tables.go
+++ b/sql/tables.go
@@ -335,6 +335,15 @@ type RowInserter interface {
 	Closer
 }
 
+// UniqueKeyConflictCheckingRowInserter is a RowInserter that can detect conflicts against unique keys, including edits
+// pending in this inserter.
+type UniqueKeyConflictCheckingRowInserter interface {
+	RowInserter
+	// HasUniqueKeyConflict reports whether the row conflicts with the unique key identified by columns. An empty
+	// column list checks every unique key.
+	HasUniqueKeyConflict(*Context, Row, []string) (bool, error)
+}
+
 // DeletableTable is a table that can delete rows.
 type DeletableTable interface {
 	Table


### PR DESCRIPTION
Add a row-inserter contract for probing unique-key conflicts and use it to implement targetless ON CONFLICT DO NOTHING semantics. Duplicate-key conflicts are skipped while foreign-key, check, and NOT NULL errors remain errors, preserving the existing MySQL INSERT IGNORE path.

Part of dolthub/doltgresql#3091

Depends on: https://github.com/dolthub/vitess/pull/485