### PR TITLE
Fix aggregate reuse across scalar subquery scopes

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5885,6 +5885,47 @@ CREATE TABLE tab3 (
 		},
 	},
 	{
+		Name: "scalar subquery aggregate is scoped independently of outer aggregate",
+		SetUpScript: []string{
+			"CREATE TABLE subquery_aggregate_scope (id INT PRIMARY KEY, d DATETIME, tag VARCHAR(10));",
+			"INSERT INTO subquery_aggregate_scope VALUES (1, '2020-01-01 00:00:00', 'keep'), (2, '2021-01-01 00:00:00', 'skip'), (3, '2030-01-01 00:00:00', 'skip');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT MAX(d), (SELECT MAX(d) FROM subquery_aggregate_scope WHERE tag = 'keep') FROM subquery_aggregate_scope;",
+				Expected: []sql.Row{{time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}},
+			},
+			{
+				Query:    "SELECT SUM(id), (SELECT SUM(id) FROM subquery_aggregate_scope WHERE tag = 'keep') FROM subquery_aggregate_scope;",
+				Expected: []sql.Row{{float64(6), float64(1)}},
+			},
+			{
+				Query:    "SELECT COUNT(id), (SELECT COUNT(id) FROM subquery_aggregate_scope WHERE tag = 'keep') FROM subquery_aggregate_scope;",
+				Expected: []sql.Row{{int64(3), int64(1)}},
+			},
+			{
+				Query:    "SELECT AVG(id), (SELECT AVG(id) FROM subquery_aggregate_scope WHERE tag = 'keep') FROM subquery_aggregate_scope;",
+				Expected: []sql.Row{{float64(2), float64(1)}},
+			},
+			{
+				Query:    "SELECT MAX(id), (SELECT MAX(id) FROM subquery_aggregate_scope WHERE tag = 'keep') FROM subquery_aggregate_scope;",
+				Expected: []sql.Row{{3, 1}},
+			},
+			{
+				Query:    "SELECT MIN(id), (SELECT MIN(id) FROM subquery_aggregate_scope WHERE tag = 'skip') FROM subquery_aggregate_scope;",
+				Expected: []sql.Row{{1, 2}},
+			},
+			{
+				Query:    "SELECT MIN(d), (SELECT MIN(d) FROM subquery_aggregate_scope WHERE tag = 'skip') FROM subquery_aggregate_scope;",
+				Expected: []sql.Row{{time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)}},
+			},
+			{
+				Query:    "SELECT MIN(d) AS min_d, (SELECT MIN(d) AS min_d FROM subquery_aggregate_scope WHERE tag = 'skip') FROM subquery_aggregate_scope;",
+				Expected: []sql.Row{{time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)}},
+			},
+		},
+	},
+	{
 		Name: "having clause without groupby clause, all rows implicitly form a single aggregate group",
 		SetUpScript: []string{
 			"create table numbers (val int);",

--- a/enginetest/queries/tpch_plans.go
+++ b/enginetest/queries/tpch_plans.go
@@ -1761,34 +1761,37 @@ order by
 			"         │       ├─ cacheable: true\n" +
 			"         │       ├─ alias-string: select sum(ps_supplycost * ps_availqty) * 0.0001000000 from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'GERMANY'\n" +
 			"         │       └─ Project\n" +
-			"         │           ├─ columns: [(sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null * 0.0001000000 (decimal(11,10)))->sum(ps_supplycost * ps_availqty) * 0.0001000000:0]\n" +
-			"         │           └─ LookupJoin\n" +
-			"         │               ├─ LookupJoin\n" +
-			"         │               │   ├─ Table\n" +
-			"         │               │   │   ├─ name: partsupp\n" +
-			"         │               │   │   ├─ columns: [ps_suppkey]\n" +
-			"         │               │   │   ├─ colSet: (19-23)\n" +
-			"         │               │   │   └─ tableId: 4\n" +
-			"         │               │   └─ IndexedTableAccess(supplier)\n" +
-			"         │               │       ├─ index: [supplier.S_SUPPKEY]\n" +
-			"         │               │       ├─ keys: [partsupp.ps_suppkey:5!null]\n" +
-			"         │               │       ├─ colSet: (24-30)\n" +
-			"         │               │       ├─ tableId: 5\n" +
-			"         │               │       └─ Table\n" +
-			"         │               │           ├─ name: supplier\n" +
-			"         │               │           └─ columns: [s_suppkey s_nationkey]\n" +
-			"         │               └─ Filter\n" +
-			"         │                   ├─ Eq\n" +
-			"         │                   │   ├─ nation.n_name:6!null\n" +
-			"         │                   │   └─ GERMANY (longtext)\n" +
-			"         │                   └─ IndexedTableAccess(nation)\n" +
-			"         │                       ├─ index: [nation.N_NATIONKEY]\n" +
-			"         │                       ├─ keys: [supplier.s_nationkey:7!null]\n" +
-			"         │                       ├─ colSet: (31-34)\n" +
-			"         │                       ├─ tableId: 6\n" +
-			"         │                       └─ Table\n" +
-			"         │                           ├─ name: nation\n" +
-			"         │                           └─ columns: [n_nationkey n_name]\n" +
+			"         │           ├─ columns: [(sum((partsupp.ps_supplycost * partsupp.ps_availqty)):5!null * 0.0001000000 (decimal(11,10)))->sum(ps_supplycost * ps_availqty) * 0.0001000000:0]\n" +
+			"         │           └─ GroupBy\n" +
+			"         │               ├─ select: SUM((partsupp.ps_supplycost:7!null * partsupp.ps_availqty:6!null))\n" +
+			"         │               ├─ group: \n" +
+			"         │               └─ LookupJoin\n" +
+			"         │                   ├─ LookupJoin\n" +
+			"         │                   │   ├─ Table\n" +
+			"         │                   │   │   ├─ name: partsupp\n" +
+			"         │                   │   │   ├─ columns: [ps_suppkey ps_availqty ps_supplycost]\n" +
+			"         │                   │   │   ├─ colSet: (19-23)\n" +
+			"         │                   │   │   └─ tableId: 4\n" +
+			"         │                   │   └─ IndexedTableAccess(supplier)\n" +
+			"         │                   │       ├─ index: [supplier.S_SUPPKEY]\n" +
+			"         │                   │       ├─ keys: [partsupp.ps_suppkey:5!null]\n" +
+			"         │                   │       ├─ colSet: (24-30)\n" +
+			"         │                   │       ├─ tableId: 5\n" +
+			"         │                   │       └─ Table\n" +
+			"         │                   │           ├─ name: supplier\n" +
+			"         │                   │           └─ columns: [s_suppkey s_nationkey]\n" +
+			"         │                   └─ Filter\n" +
+			"         │                       ├─ Eq\n" +
+			"         │                       │   ├─ nation.n_name:6!null\n" +
+			"         │                       │   └─ GERMANY (longtext)\n" +
+			"         │                       └─ IndexedTableAccess(nation)\n" +
+			"         │                           ├─ index: [nation.N_NATIONKEY]\n" +
+			"         │                           ├─ keys: [supplier.s_nationkey:9!null]\n" +
+			"         │                           ├─ colSet: (31-34)\n" +
+			"         │                           ├─ tableId: 6\n" +
+			"         │                           └─ Table\n" +
+			"         │                               ├─ name: nation\n" +
+			"         │                               └─ columns: [n_nationkey n_name]\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null, partsupp.ps_partkey:1!null, partsupp.PS_SUPPLYCOST:2!null, partsupp.PS_AVAILQTY:3!null, sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null->value:0]\n" +
 			"             └─ GroupBy\n" +

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -324,9 +324,8 @@ func (b *Builder) buildAggregateFunc(inScope *scope, name string, e *ast.FuncExp
 	aggType := agg.Type(b.ctx)
 
 	aggName := strings.ToLower(plan.AliasSubqueryString(b.ctx, agg))
-	if id, ok := gb.outScope.getExpr(aggName, true); ok {
+	if gf := gb.getAggRef(aggName); gf != nil {
 		// if we've already computed use reference here
-		gf := expression.NewGetFieldWithTable(int(id), 0, aggType, "", "", aggName, agg.IsNullable(b.ctx))
 		return gf
 	}
 


### PR DESCRIPTION
Prevents aggregate functions in scalar subqueries from reusing matching aggregate references from an outer query scope. Aggregate deduplication now considers only the current grouping scope, preserving same-query-block reuse while keeping subqueries independent.

Adds regression coverage for MAX, MIN, SUM, COUNT, and AVG across numeric and datetime values.

Fixes dolthub/dolt#11638