### PR TITLE
Fix STR_TO_DATE NULL propagation

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -9984,6 +9984,10 @@ var DateParseQueries = []QueryTest{
 		Expected: []sql.Row{{time.Date(2013, time.May, 1, 0, 0, 0, 0, time.UTC)}},
 	},
 	{
+		Query:    "SELECT STR_TO_DATE(FIRST_VALUE(NULL) OVER (), '%Y-%m-%d')",
+		Expected: []sql.Row{{nil}},
+	},
+	{
 		Query:    "SELECT STR_TO_DATE('May 1, 2013','%M %d,%Y')",
 		Expected: []sql.Row{{time.Date(2013, time.May, 1, 0, 0, 0, 0, time.UTC)}},
 	},

--- a/sql/expression/function/str_to_date.go
+++ b/sql/expression/function/str_to_date.go
@@ -107,9 +107,15 @@ func (s *StrToDate) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	if date == nil {
+		return nil, nil
+	}
 	format, err := s.Format.Eval(ctx, row)
 	if err != nil {
 		return nil, err
+	}
+	if format == nil {
+		return nil, nil
 	}
 
 	dateStr, ok := date.(string)


### PR DESCRIPTION
Propagates NULL arguments through STR_TO_DATE.

Fixes https://github.com/dolthub/dolt/issues/11509