### PR TITLE
Allow REGEXP_REPLACE position after source

### DIFF
--- a/sql/expression/function/regexp_replace.go
+++ b/sql/expression/function/regexp_replace.go
@@ -256,8 +256,12 @@ func (r *RegexpReplace) Eval(ctx *sql.Context, row sql.Row) (val interface{}, er
 		return nil, sql.ErrInvalidArgumentDetails.New(r.FunctionName(), fmt.Sprintf("%d", pos.(int32)))
 	}
 
-	if len(text.(string)) != 0 && int(pos.(int32)) > len(text.(string)) {
+	textLength := len([]rune(text.(string)))
+	if textLength != 0 && int(pos.(int32)) > textLength+1 {
 		return nil, errors.NewKind("Index out of bounds for regular expression search.").New()
+	}
+	if int(pos.(int32)) == textLength+1 {
+		return text, nil
 	}
 
 	occurrence, err := r.Occurrence.Eval(ctx, row)

--- a/sql/expression/function/regexp_replace.go
+++ b/sql/expression/function/regexp_replace.go
@@ -260,10 +260,6 @@ func (r *RegexpReplace) Eval(ctx *sql.Context, row sql.Row) (val interface{}, er
 	if textLength != 0 && int(pos.(int32)) > textLength+1 {
 		return nil, errors.NewKind("Index out of bounds for regular expression search.").New()
 	}
-	if int(pos.(int32)) == textLength+1 {
-		return text, nil
-	}
-
 	occurrence, err := r.Occurrence.Eval(ctx, row)
 	if err != nil {
 		return nil, err
@@ -274,6 +270,9 @@ func (r *RegexpReplace) Eval(ctx *sql.Context, row sql.Row) (val interface{}, er
 	occurrence, _, err = types.Int32.Convert(ctx, occurrence)
 	if err != nil {
 		return nil, err
+	}
+	if int(pos.(int32)) == textLength+1 {
+		return text, nil
 	}
 
 	err = r.re.SetMatchString(ctx, text.(string))

--- a/sql/expression/function/regexp_replace.go
+++ b/sql/expression/function/regexp_replace.go
@@ -19,8 +19,6 @@ import (
 	"strings"
 	"sync"
 
-	"gopkg.in/src-d/go-errors.v1"
-
 	"github.com/dolthub/go-mysql-server/internal/regex"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -257,9 +255,7 @@ func (r *RegexpReplace) Eval(ctx *sql.Context, row sql.Row) (val interface{}, er
 	}
 
 	textLength := len([]rune(text.(string)))
-	if textLength != 0 && int(pos.(int32)) > textLength+1 {
-		return nil, errors.NewKind("Index out of bounds for regular expression search.").New()
-	}
+	positionAfterText := int(pos.(int32)) > textLength
 	occurrence, err := r.Occurrence.Eval(ctx, row)
 	if err != nil {
 		return nil, err
@@ -271,7 +267,7 @@ func (r *RegexpReplace) Eval(ctx *sql.Context, row sql.Row) (val interface{}, er
 	if err != nil {
 		return nil, err
 	}
-	if int(pos.(int32)) == textLength+1 {
+	if positionAfterText {
 		return text, nil
 	}
 

--- a/sql/expression/function/regexp_replace_test.go
+++ b/sql/expression/function/regexp_replace_test.go
@@ -184,6 +184,12 @@ func TestRegexpReplaceWithPosition(t *testing.T) {
 			true,
 		},
 		{
+			"position immediately after string",
+			sql.NewRow("abc", "a", "X", 4),
+			"abc",
+			false,
+		},
+		{
 			"string type position",
 			sql.NewRow("abc def ghi", `[a-z]`, "X", "1"),
 			"XXX XXX XXX",

--- a/sql/expression/function/regexp_replace_test.go
+++ b/sql/expression/function/regexp_replace_test.go
@@ -180,13 +180,19 @@ func TestRegexpReplaceWithPosition(t *testing.T) {
 		{
 			"too large position",
 			sql.NewRow("abc def ghi", `[a-z]`, "X", 1000),
-			nil,
-			true,
+			"abc def ghi",
+			false,
 		},
 		{
 			"position immediately after string",
 			sql.NewRow("abc", "a", "X", 4),
 			"abc",
+			false,
+		},
+		{
+			"position after empty string",
+			sql.NewRow("", "a", "X", 1000),
+			"",
 			false,
 		},
 		{


### PR DESCRIPTION
Allows REGEXP_REPLACE to start immediately after the source string.

Fixes https://github.com/dolthub/dolt/issues/11547