### PR TITLE
Support binary values in CRC32

### DIFF
--- a/sql/expression/function/math.go
+++ b/sql/expression/function/math.go
@@ -768,6 +768,8 @@ func (c *Crc32) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	switch val := arg.(type) {
 	case string:
 		bytes = []byte(val)
+	case []byte:
+		bytes = val
 	case int8, int16, int32, int64, int:
 		val, _, err := types.Int64.Convert(ctx, arg)
 

--- a/sql/expression/function/math_test.go
+++ b/sql/expression/function/math_test.go
@@ -159,6 +159,7 @@ func TestCRC32(t *testing.T) {
 	}{
 		{"CRC32('MySQL)", "MySQL", 3259397556},
 		{"CRC32('mysql')", "mysql", 2501908538},
+		{"CRC32(binary 0A)", []byte{0x0A}, 852952723},
 
 		{"CRC32('6')", "6", 498629140},
 		{"CRC32(int 6)", 6, 498629140},


### PR DESCRIPTION
Adds CRC32 support for binary string values.

Fixes https://github.com/dolthub/dolt/issues/11507