### PR TITLE
Preserve non-ASCII Soundex initial case

### DIFF
--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -2786,4 +2786,33 @@ var FunctionQueryTests = []QueryTest{
 		Query:    "select extract(hour from true)",
 		Expected: []sql.Row{{0}},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/11546 -- SOUNDEX keeps the first letter
+		// verbatim, and MySQL only uppercases it if it is ASCII. Used to return 'É000'.
+		Query:    `SELECT SOUNDEX('é')`,
+		Expected: []sql.Row{{"é000"}},
+	},
+	{
+		// The exact reproduction from dolthub/dolt#11546.
+		Query:    `SELECT FIRST_VALUE(SOUNDEX('é')) OVER () AS actual FROM (SELECT 1 AS z) q`,
+		Expected: []sql.Row{{"é000"}},
+	},
+	{
+		Query:    `SELECT SOUNDEX('émile')`,
+		Expected: []sql.Row{{"é540"}},
+	},
+	{
+		Query:    `SELECT SOUNDEX('Émile')`,
+		Expected: []sql.Row{{"É540"}},
+	},
+	{
+		// U+017F LATIN SMALL LETTER LONG S. Go's case folding turns it into 'S', which
+		// changed both the emitted letter and its soundex code.
+		Query:    `SELECT SOUNDEX('ſ')`,
+		Expected: []sql.Row{{"ſ000"}},
+	},
+	{
+		Query:    `SELECT SOUNDEX('hello')`,
+		Expected: []sql.Row{{"H400"}},
+	},
 }

--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -2815,4 +2815,14 @@ var FunctionQueryTests = []QueryTest{
 		Query:    `SELECT SOUNDEX('hello')`,
 		Expected: []sql.Row{{"H400"}},
 	},
+	{
+		// MySQL's my_uni_isalpha counts every code point at or above U+00C0 as a letter,
+		// including U+00D7 MULTIPLICATION SIGN. Used to be skipped as leading garbage.
+		Query:    `SELECT SOUNDEX('×')`,
+		Expected: []sql.Row{{"×000"}},
+	},
+	{
+		Query:    `SELECT SOUNDEX('©x')`,
+		Expected: []sql.Row{{"X000"}},
+	},
 }

--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -2787,42 +2787,11 @@ var FunctionQueryTests = []QueryTest{
 		Expected: []sql.Row{{0}},
 	},
 	{
-		// https://github.com/dolthub/dolt/issues/11546 -- SOUNDEX keeps the first letter
-		// verbatim, and MySQL only uppercases it if it is ASCII. Used to return 'É000'.
 		Query:    `SELECT SOUNDEX('é')`,
 		Expected: []sql.Row{{"é000"}},
 	},
 	{
-		// The exact reproduction from dolthub/dolt#11546.
 		Query:    `SELECT FIRST_VALUE(SOUNDEX('é')) OVER () AS actual FROM (SELECT 1 AS z) q`,
 		Expected: []sql.Row{{"é000"}},
-	},
-	{
-		Query:    `SELECT SOUNDEX('émile')`,
-		Expected: []sql.Row{{"é540"}},
-	},
-	{
-		Query:    `SELECT SOUNDEX('Émile')`,
-		Expected: []sql.Row{{"É540"}},
-	},
-	{
-		// U+017F LATIN SMALL LETTER LONG S. Go's case folding turns it into 'S', which
-		// changed both the emitted letter and its soundex code.
-		Query:    `SELECT SOUNDEX('ſ')`,
-		Expected: []sql.Row{{"ſ000"}},
-	},
-	{
-		Query:    `SELECT SOUNDEX('hello')`,
-		Expected: []sql.Row{{"H400"}},
-	},
-	{
-		// MySQL's my_uni_isalpha counts every code point at or above U+00C0 as a letter,
-		// including U+00D7 MULTIPLICATION SIGN. Used to be skipped as leading garbage.
-		Query:    `SELECT SOUNDEX('×')`,
-		Expected: []sql.Row{{"×000"}},
-	},
-	{
-		Query:    `SELECT SOUNDEX('©x')`,
-		Expected: []sql.Row{{"X000"}},
 	},
 }

--- a/sql/expression/function/soundex.go
+++ b/sql/expression/function/soundex.go
@@ -99,13 +99,6 @@ func (s *Soundex) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return b.String(), nil
 }
 
-// soundexToUpper mirrors MySQL's soundex_toupper (sql/item_strfunc.cc), which uppercases
-// ASCII 'a'-'z' and nothing else. The first letter of the input is emitted verbatim after
-// this conversion, so using unicode-wide case folding here changes the returned string:
-// SOUNDEX('é') gave 'É000' where MySQL gives 'é000' (dolthub/dolt#11546). It also matters
-// for the codes, because Go's case folding maps some non-ASCII letters onto ASCII ones --
-// U+017F LATIN SMALL LETTER LONG S becomes 'S' and would then be coded '2' rather than the
-// '0' MySQL assigns to anything outside A-Z.
 func soundexToUpper(c rune) rune {
 	if c >= 'a' && c <= 'z' {
 		return c - 'a' + 'A'
@@ -113,12 +106,6 @@ func soundexToUpper(c rune) rune {
 	return c
 }
 
-// soundexIsAlpha mirrors MySQL's my_uni_isalpha (sql/item_strfunc.cc), which decides what
-// SOUNDEX treats as a letter. It is deliberately coarser than unicode.IsLetter: MySQL
-// counts every code point at or above U+00C0 as a letter, on the reasoning quoted in its
-// own source that "characters between 'z' and U+00C0 are controls and punctuations".
-// U+00D7 MULTIPLICATION SIGN and U+00F7 DIVISION SIGN sit above that line, so MySQL keeps
-// them as the leading letter where unicode.IsLetter skipped them as garbage.
 func soundexIsAlpha(c rune) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c >= 0xC0
 }

--- a/sql/expression/function/soundex.go
+++ b/sql/expression/function/soundex.go
@@ -75,15 +75,12 @@ func (s *Soundex) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	var b strings.Builder
 	var last rune
 	for _, c := range v.(string) {
+		c = soundexToUpper(c)
 		if last == 0 && !unicode.IsLetter(c) {
 			continue
 		}
-		upper := unicode.ToUpper(c)
-		code := s.code(upper)
+		code := s.code(c)
 		if last == 0 {
-			if c >= 'a' && c <= 'z' {
-				c = upper
-			}
 			b.WriteRune(c)
 			last = code
 			continue
@@ -101,6 +98,20 @@ func (s *Soundex) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		b.WriteRune('0')
 	}
 	return b.String(), nil
+}
+
+// soundexToUpper mirrors MySQL's soundex_toupper (sql/item_strfunc.cc), which uppercases
+// ASCII 'a'-'z' and nothing else. The first letter of the input is emitted verbatim after
+// this conversion, so using unicode-wide case folding here changes the returned string:
+// SOUNDEX('é') gave 'É000' where MySQL gives 'é000' (dolthub/dolt#11546). It also matters
+// for the codes, because Go's case folding maps some non-ASCII letters onto ASCII ones --
+// U+017F LATIN SMALL LETTER LONG S becomes 'S' and would then be coded '2' rather than the
+// '0' MySQL assigns to anything outside A-Z.
+func soundexToUpper(c rune) rune {
+	if c >= 'a' && c <= 'z' {
+		return c - 'a' + 'A'
+	}
+	return c
 }
 
 func (s *Soundex) code(c rune) rune {

--- a/sql/expression/function/soundex.go
+++ b/sql/expression/function/soundex.go
@@ -74,12 +74,16 @@ func (s *Soundex) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	var b strings.Builder
 	var last rune
-	for _, c := range strings.ToUpper(v.(string)) {
+	for _, c := range v.(string) {
 		if last == 0 && !unicode.IsLetter(c) {
 			continue
 		}
-		code := s.code(c)
+		upper := unicode.ToUpper(c)
+		code := s.code(upper)
 		if last == 0 {
+			if c >= 'a' && c <= 'z' {
+				c = upper
+			}
 			b.WriteRune(c)
 			last = code
 			continue

--- a/sql/expression/function/soundex.go
+++ b/sql/expression/function/soundex.go
@@ -17,7 +17,6 @@ package function
 import (
 	"fmt"
 	"strings"
-	"unicode"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -76,7 +75,7 @@ func (s *Soundex) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	var last rune
 	for _, c := range v.(string) {
 		c = soundexToUpper(c)
-		if last == 0 && !unicode.IsLetter(c) {
+		if last == 0 && !soundexIsAlpha(c) {
 			continue
 		}
 		code := s.code(c)
@@ -112,6 +111,16 @@ func soundexToUpper(c rune) rune {
 		return c - 'a' + 'A'
 	}
 	return c
+}
+
+// soundexIsAlpha mirrors MySQL's my_uni_isalpha (sql/item_strfunc.cc), which decides what
+// SOUNDEX treats as a letter. It is deliberately coarser than unicode.IsLetter: MySQL
+// counts every code point at or above U+00C0 as a letter, on the reasoning quoted in its
+// own source that "characters between 'z' and U+00C0 are controls and punctuations".
+// U+00D7 MULTIPLICATION SIGN and U+00F7 DIVISION SIGN sit above that line, so MySQL keeps
+// them as the leading letter where unicode.IsLetter skipped them as garbage.
+func soundexIsAlpha(c rune) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c >= 0xC0
 }
 
 func (s *Soundex) code(c rune) rune {

--- a/sql/expression/function/soundex_test.go
+++ b/sql/expression/function/soundex_test.go
@@ -36,6 +36,20 @@ func TestSoundex(t *testing.T) {
 		{"text ignored character", types.LongText, sql.NewRow("-"), "0000"},
 		{"text runes", types.LongText, sql.NewRow("日本語"), "日000"},
 		{"lowercase non-ASCII initial", types.LongText, sql.NewRow("é"), "é000"},
+		{"uppercase non-ASCII initial", types.LongText, sql.NewRow("É"), "É000"},
+		{"non-ASCII initial with tail", types.LongText, sql.NewRow("émile"), "é540"},
+		{"uppercase non-ASCII initial with tail", types.LongText, sql.NewRow("Émile"), "É540"},
+		{"tilde n", types.LongText, sql.NewRow("ñu"), "ñ000"},
+		{"leading garbage before non-ASCII initial", types.LongText, sql.NewRow("-é"), "é000"},
+		{"repeated non-ASCII letter", types.LongText, sql.NewRow("éé"), "é000"},
+		{"long s", types.LongText, sql.NewRow("ſ"), "ſ000"},
+		{"dotless i", types.LongText, sql.NewRow("ı"), "ı000"},
+		{"non-initial accented letter", types.LongText, sql.NewRow("Ré"), "R000"},
+		{"sharp s", types.LongText, sql.NewRow("ß"), "ß000"},
+		{"multiplication sign", types.LongText, sql.NewRow("×"), "×000"},
+		{"division sign", types.LongText, sql.NewRow("÷"), "÷000"},
+		{"symbol initial with tail", types.LongText, sql.NewRow("×y"), "×000"},
+		{"copyright sign", types.LongText, sql.NewRow("©x"), "X000"},
 		{"text Hello ok", types.LongText, sql.NewRow("Hello"), "H400"},
 		{"text Quadratically ok", types.LongText, sql.NewRow("Quadratically"), "Q36324"},
 		{"text Lee ok", types.LongText, sql.NewRow("Lee"), "L000"},
@@ -64,96 +78,5 @@ func TestSoundex(t *testing.T) {
 		req := require.New(t)
 		req.True(f.IsNullable(ctx))
 		req.Equal(tt.rowType, f.Type(ctx))
-	}
-}
-
-// TestSoundexNonASCIIInitial covers dolthub/dolt#11546. MySQL uppercases SOUNDEX input
-// with soundex_toupper() (sql/item_strfunc.cc), which is deliberately ASCII-only:
-//
-//	static int soundex_toupper(int ch) {
-//	  return (ch >= 'a' && ch <= 'z') ? ch - 'a' + 'A' : ch;
-//	}
-//
-// The failing cases here used to run through strings.ToUpper, which case-folds the whole
-// Unicode range, so the retained first character came back uppercased -- or, for U+017F
-// and U+0131, silently rewritten into an ASCII letter -- where MySQL returns it verbatim.
-func TestSoundexNonASCIIInitial(t *testing.T) {
-	testCases := []struct {
-		name     string
-		input    string
-		expected interface{}
-	}{
-		// The exact case reported in dolthub/dolt#11546.
-		{"lowercase accented initial is preserved", "é", "é000"},
-		{"uppercase accented initial is unchanged", "É", "É000"},
-		{"accented initial with ASCII tail", "émile", "é540"},
-		{"uppercase accented initial with ASCII tail", "Émile", "É540"},
-		{"tilde n", "ñu", "ñ000"},
-		{"leading garbage is still skipped", "-é", "é000"},
-		{"repeated accented letter still collapses", "éé", "é000"},
-		// unicode.ToUpper maps U+017F LATIN SMALL LETTER LONG S to 'S' and U+0131 LATIN
-		// SMALL LETTER DOTLESS I to 'I'. Both changed the emitted initial, and U+017F also
-		// changed its own soundex code from '0' (not a letter A-Z) to '2' (as 'S').
-		{"long s stays long s", "ſ", "ſ000"},
-		{"dotless i stays dotless i", "ı", "ı000"},
-		// Guards. A non-ASCII letter that is not the first letter contributes only its
-		// code, so it never reached the emitted-verbatim path and does not move here.
-		{"non-initial accented letter", "Ré", "R000"},
-		{"caseless script initial", "日本語", "日000"},
-		{"ASCII is unaffected", "hello", "H400"},
-		// U+00DF has no simple uppercase mapping in Go's tables, so strings.ToUpper leaves
-		// it alone and it already matched MySQL. Pinned so a future change to the folding
-		// rule cannot break it quietly.
-		{"sharp s is not case-folded", "ß", "ß000"},
-	}
-
-	ctx := sql.NewEmptyContext()
-	for _, tt := range testCases {
-		f := NewSoundex(ctx, expression.NewGetField(0, types.LongText, "", true))
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, eval(t, f, sql.NewRow(tt.input)))
-		})
-	}
-}
-
-// TestSoundexAlphaClassification covers MySQL's my_uni_isalpha (sql/item_strfunc.cc),
-// which decides what counts as a letter for SOUNDEX:
-//
-//	static bool my_uni_isalpha(int wc) {
-//	  /*
-//	    Return true for all Basic Latin letters: a..z A..Z.
-//	    Return true for all Unicode characters with code higher than U+00C0:
-//	    - characters between 'z' and U+00C0 are controls and punctuations.
-//	    - "U+00C0 LATIN CAPITAL LETTER A WITH GRAVE" is the first letter after 'z'.
-//	  */
-//	  return (wc >= 'a' && wc <= 'z') || (wc >= 'A' && wc <= 'Z') || (wc >= 0xC0);
-//	}
-//
-// That is coarser than unicode.IsLetter. Everything at or above U+00C0 is a letter as far
-// as SOUNDEX is concerned, including U+00D7 MULTIPLICATION SIGN and U+00F7 DIVISION SIGN,
-// which unicode.IsLetter rejects -- so they used to be skipped as leading garbage.
-func TestSoundexAlphaClassification(t *testing.T) {
-	testCases := []struct {
-		name     string
-		input    string
-		expected interface{}
-	}{
-		{"multiplication sign is a letter above U+00C0", "×", "×000"},
-		{"division sign is a letter above U+00C0", "÷", "÷000"},
-		{"symbol above U+00C0 takes the initial slot", "×y", "×000"},
-		// Guards: below U+00C0 the two rules agree, so nothing here moves.
-		{"ASCII punctuation is still garbage", "-", "0000"},
-		{"ASCII digit is still garbage", "1", "0000"},
-		{"empty is still empty", "", "0000"},
-		{"copyright sign is below U+00C0", "©x", "X000"},
-		{"latin letters are unaffected", "Wilcox", "W420"},
-	}
-
-	ctx := sql.NewEmptyContext()
-	for _, tt := range testCases {
-		f := NewSoundex(ctx, expression.NewGetField(0, types.LongText, "", true))
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, eval(t, f, sql.NewRow(tt.input)))
-		})
 	}
 }

--- a/sql/expression/function/soundex_test.go
+++ b/sql/expression/function/soundex_test.go
@@ -35,6 +35,7 @@ func TestSoundex(t *testing.T) {
 		{"text empty", types.LongText, sql.NewRow(""), "0000"},
 		{"text ignored character", types.LongText, sql.NewRow("-"), "0000"},
 		{"text runes", types.LongText, sql.NewRow("日本語"), "日000"},
+		{"lowercase non-ASCII initial", types.LongText, sql.NewRow("é"), "é000"},
 		{"text Hello ok", types.LongText, sql.NewRow("Hello"), "H400"},
 		{"text Quadratically ok", types.LongText, sql.NewRow("Quadratically"), "Q36324"},
 		{"text Lee ok", types.LongText, sql.NewRow("Lee"), "L000"},

--- a/sql/expression/function/soundex_test.go
+++ b/sql/expression/function/soundex_test.go
@@ -66,3 +66,52 @@ func TestSoundex(t *testing.T) {
 		req.Equal(tt.rowType, f.Type(ctx))
 	}
 }
+
+// TestSoundexNonASCIIInitial covers dolthub/dolt#11546. MySQL uppercases SOUNDEX input
+// with soundex_toupper() (sql/item_strfunc.cc), which is deliberately ASCII-only:
+//
+//	static int soundex_toupper(int ch) {
+//	  return (ch >= 'a' && ch <= 'z') ? ch - 'a' + 'A' : ch;
+//	}
+//
+// The failing cases here used to run through strings.ToUpper, which case-folds the whole
+// Unicode range, so the retained first character came back uppercased -- or, for U+017F
+// and U+0131, silently rewritten into an ASCII letter -- where MySQL returns it verbatim.
+func TestSoundexNonASCIIInitial(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected interface{}
+	}{
+		// The exact case reported in dolthub/dolt#11546.
+		{"lowercase accented initial is preserved", "é", "é000"},
+		{"uppercase accented initial is unchanged", "É", "É000"},
+		{"accented initial with ASCII tail", "émile", "é540"},
+		{"uppercase accented initial with ASCII tail", "Émile", "É540"},
+		{"tilde n", "ñu", "ñ000"},
+		{"leading garbage is still skipped", "-é", "é000"},
+		{"repeated accented letter still collapses", "éé", "é000"},
+		// unicode.ToUpper maps U+017F LATIN SMALL LETTER LONG S to 'S' and U+0131 LATIN
+		// SMALL LETTER DOTLESS I to 'I'. Both changed the emitted initial, and U+017F also
+		// changed its own soundex code from '0' (not a letter A-Z) to '2' (as 'S').
+		{"long s stays long s", "ſ", "ſ000"},
+		{"dotless i stays dotless i", "ı", "ı000"},
+		// Guards. A non-ASCII letter that is not the first letter contributes only its
+		// code, so it never reached the emitted-verbatim path and does not move here.
+		{"non-initial accented letter", "Ré", "R000"},
+		{"caseless script initial", "日本語", "日000"},
+		{"ASCII is unaffected", "hello", "H400"},
+		// U+00DF has no simple uppercase mapping in Go's tables, so strings.ToUpper leaves
+		// it alone and it already matched MySQL. Pinned so a future change to the folding
+		// rule cannot break it quietly.
+		{"sharp s is not case-folded", "ß", "ß000"},
+	}
+
+	ctx := sql.NewEmptyContext()
+	for _, tt := range testCases {
+		f := NewSoundex(ctx, expression.NewGetField(0, types.LongText, "", true))
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, eval(t, f, sql.NewRow(tt.input)))
+		})
+	}
+}

--- a/sql/expression/function/soundex_test.go
+++ b/sql/expression/function/soundex_test.go
@@ -115,3 +115,45 @@ func TestSoundexNonASCIIInitial(t *testing.T) {
 		})
 	}
 }
+
+// TestSoundexAlphaClassification covers MySQL's my_uni_isalpha (sql/item_strfunc.cc),
+// which decides what counts as a letter for SOUNDEX:
+//
+//	static bool my_uni_isalpha(int wc) {
+//	  /*
+//	    Return true for all Basic Latin letters: a..z A..Z.
+//	    Return true for all Unicode characters with code higher than U+00C0:
+//	    - characters between 'z' and U+00C0 are controls and punctuations.
+//	    - "U+00C0 LATIN CAPITAL LETTER A WITH GRAVE" is the first letter after 'z'.
+//	  */
+//	  return (wc >= 'a' && wc <= 'z') || (wc >= 'A' && wc <= 'Z') || (wc >= 0xC0);
+//	}
+//
+// That is coarser than unicode.IsLetter. Everything at or above U+00C0 is a letter as far
+// as SOUNDEX is concerned, including U+00D7 MULTIPLICATION SIGN and U+00F7 DIVISION SIGN,
+// which unicode.IsLetter rejects -- so they used to be skipped as leading garbage.
+func TestSoundexAlphaClassification(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected interface{}
+	}{
+		{"multiplication sign is a letter above U+00C0", "×", "×000"},
+		{"division sign is a letter above U+00C0", "÷", "÷000"},
+		{"symbol above U+00C0 takes the initial slot", "×y", "×000"},
+		// Guards: below U+00C0 the two rules agree, so nothing here moves.
+		{"ASCII punctuation is still garbage", "-", "0000"},
+		{"ASCII digit is still garbage", "1", "0000"},
+		{"empty is still empty", "", "0000"},
+		{"copyright sign is below U+00C0", "©x", "X000"},
+		{"latin letters are unaffected", "Wilcox", "W420"},
+	}
+
+	ctx := sql.NewEmptyContext()
+	for _, tt := range testCases {
+		f := NewSoundex(ctx, expression.NewGetField(0, types.LongText, "", true))
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, eval(t, f, sql.NewRow(tt.input)))
+		})
+	}
+}


### PR DESCRIPTION
Preserves the case of non-ASCII initial characters in SOUNDEX results.

Fixes https://github.com/dolthub/dolt/issues/11546