### PR TITLE
Reject ABS of minimum BIGINT

### DIFF
--- a/sql/expression/function/absval.go
+++ b/sql/expression/function/absval.go
@@ -73,6 +73,9 @@ func (t *AbsVal) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		}
 	case int64:
 		if x < 0 {
+			if x == math.MinInt64 {
+				return nil, sql.ErrValueOutOfRange.New("BIGINT", t.FunctionName())
+			}
 			return -x, nil
 		} else {
 			return x, nil

--- a/sql/expression/function/absval_test.go
+++ b/sql/expression/function/absval_test.go
@@ -15,6 +15,7 @@
 package function
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -121,4 +122,10 @@ func TestAbsValue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAbsMinInt64(t *testing.T) {
+	f := NewAbsVal(sql.NewEmptyContext(), expression.NewGetField(0, types.Int64, "value", false))
+	_, err := f.Eval(sql.NewEmptyContext(), sql.NewRow(int64(math.MinInt64)))
+	require.True(t, sql.ErrValueOutOfRange.Is(err))
 }


### PR DESCRIPTION
Returns an out-of-range error for ABS of the minimum signed BIGINT.

Fixes https://github.com/dolthub/dolt/issues/11412