### PR TITLE
Fix recursive CTE result type coercion

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2782,6 +2782,52 @@ CREATE TABLE tab3 (
 				},
 			},
 			{
+				Query: "with recursive cte(x) as (select 1 union select 2 union select x in (select i from t1) from cte) select x, row_number() over (order by x) as rn from cte order by x;",
+				Expected: []sql.Row{
+					{1, 1},
+					{2, 2},
+				},
+				// PostgreSQL rejects UNION between integer and boolean instead of coercing boolean to integer.
+				Dialect: "mysql",
+			},
+			{
+				Query:    "with recursive cte(x) as (select cast(1 as signed) union select cast(x as unsigned) from cte) select count(*) from cte;",
+				Expected: []sql.Row{{1}},
+				Dialect:  "mysql",
+			},
+			{
+				Query:    "with recursive cte(x) as (select cast('1' as char(3)) union select cast(x as signed) from cte) select count(*) from cte;",
+				Expected: []sql.Row{{1}},
+				Dialect:  "mysql",
+			},
+			{
+				Query:    "with recursive cte(d, f, n) as (select cast('2024-01-02' as date), cast(1.5 as double), cast(2.50 as decimal(5,2)) union select cast(d as char), cast(f as decimal(5,2)), cast(n as double) from cte) select count(*) from cte;",
+				Expected: []sql.Row{{1}},
+				Dialect:  "mysql",
+			},
+			{
+				Query: "with recursive cte(x) as (select cast(null as signed) union select ifnull(x, 0) from cte) select x from cte order by x;",
+				Expected: []sql.Row{
+					{nil},
+					{0},
+				},
+				Dialect: "mysql",
+			},
+			{
+				Query:    "with recursive cte(x) as (select cast('a' as binary(1)) union select cast(x as char) from cte) select count(*), hex(min(x)) from cte;",
+				Expected: []sql.Row{{1, "61"}},
+				Dialect:  "mysql",
+			},
+			{
+				Query: "with recursive cte(x, n) as (select cast(1 as signed), 1 union all select cast(x as unsigned), n + 1 from cte where n < 3) select x, n from cte order by n;",
+				Expected: []sql.Row{
+					{1, 1},
+					{1, 2},
+					{1, 3},
+				},
+				Dialect: "mysql",
+			},
+			{
 				Query: "WITH RECURSIVE\n" +
 					"    rt (foo) AS (\n" +
 					"        SELECT 1 as foo\n" +

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -455,6 +455,7 @@ func (b *BaseBuilder) buildRecursiveCte(ctx *sql.Context, n *plan.RecursiveCte, 
 		working:     n.Working,
 		temp:        make([]sql.Row, 0),
 		deduplicate: n.Union().Distinct,
+		schema:      n.Schema(ctx),
 		b:           b,
 	}
 	if n.Union().Limit != nil && len(n.Union().SortConditions) > 0 {

--- a/sql/rowexec/rel_iters.go
+++ b/sql/rowexec/rel_iters.go
@@ -16,6 +16,7 @@ package rowexec
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -572,6 +573,8 @@ type recursiveCteIter struct {
 	cycle int
 	// true if UNION, false if UNION ALL
 	deduplicate bool
+	// output schema inherited from the non-recursive term
+	schema sql.Schema
 }
 
 var _ sql.RowIter = (*recursiveCteIter)(nil)
@@ -606,6 +609,10 @@ func (r *recursiveCteIter) Next(ctx *sql.Context) (sql.Row, error) {
 		} else if err != nil {
 			return nil, err
 		}
+		row, err = r.convertRow(ctx, row)
+		if err != nil {
+			return nil, err
+		}
 
 		var key uint64
 		if r.deduplicate {
@@ -622,6 +629,24 @@ func (r *recursiveCteIter) Next(ctx *sql.Context) (sql.Row, error) {
 		break
 	}
 	return row, nil
+}
+
+// convertRow coerces recursive results to the CTE's established column types.
+func (r *recursiveCteIter) convertRow(ctx *sql.Context, row sql.Row) (sql.Row, error) {
+	start := len(row) - len(r.schema)
+	if start < 0 {
+		return nil, fmt.Errorf("recursive CTE row has %d columns, expected at least %d", len(row), len(r.schema))
+	}
+	converted := make(sql.Row, len(row))
+	copy(converted, row[:start])
+	for i, column := range r.schema {
+		var err error
+		converted[start+i], _, err = column.Type.Convert(ctx, row[start+i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return converted, nil
 }
 
 // store saves a row to the [temp] buffer, and hashes if [deduplicated] = true


### PR DESCRIPTION
Recursive CTEs establish their output schema from the non-recursive term, but the executor previously hashed, buffered, and returned raw child values. This allowed a recursive boolean true to remain distinct from an existing integer 1 under UNION DISTINCT.

Coerce the CTE-result suffix to the established schema before deduplication and buffering while preserving any correlated outer-row prefix. Add the reported windowed recursive UNION regression. Full GMS sql and enginetest suites, focused Dolt normal and prepared engine tests, MySQL 8.0.45 differential validation, and diff checks pass.

Fixes dolthub/dolt#11563