### PR TITLE
Fix decimal CEIL and FLOOR input mutation

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -25,6 +25,24 @@ import (
 // first_value, last_value, lead, lag, and the bitwise aggregate functions.
 var WindowFunctionsScriptTests = []ScriptTest{
 	{
+		Name: "ceil and floor do not mutate shared decimal window results",
+		SetUpScript: []string{
+			"CREATE TABLE decimal_window_values (id BIGINT, d DECIMAL(10,2))",
+			"INSERT INTO decimal_window_values VALUES (1, 12.34), (2, 12.34), (3, -12.34), (4, -12.34)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT id, d, CEIL(d), FLOOR(d) FROM (SELECT id, MAX(d) OVER (PARTITION BY d) AS d FROM decimal_window_values) s ORDER BY id",
+				Expected: []sql.Row{
+					{int64(1), "12.34", int64(13), int64(12)},
+					{int64(2), "12.34", int64(13), int64(12)},
+					{int64(3), "-12.34", int64(-12), int64(-13)},
+					{int64(4), "-12.34", int64(-12), int64(-13)},
+				},
+			},
+		},
+	},
+	{
 		Name: "window functions, empty table",
 		SetUpScript: []string{
 			"CREATE TABLE empty_tbl (a int, b int)",

--- a/sql/expression/function/ceil_round_floor.go
+++ b/sql/expression/function/ceil_round_floor.go
@@ -122,11 +122,12 @@ func (c *Ceil) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	case float64:
 		child = math.Ceil(num)
 	case *apd.Decimal:
-		_, err = sql.DecimalCtx.Ceil(num, num)
+		result := new(apd.Decimal)
+		_, err = sql.DecimalCtx.Ceil(result, num)
 		if err != nil {
 			return nil, err
 		}
-		child = num
+		child = result
 	}
 	child, _, _ = c.Type(ctx).Convert(ctx, child)
 	return child, nil
@@ -209,11 +210,12 @@ func (f *Floor) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	case float64:
 		child = math.Floor(num)
 	case *apd.Decimal:
-		_, err = sql.DecimalCtx.Floor(num, num)
+		result := new(apd.Decimal)
+		_, err = sql.DecimalCtx.Floor(result, num)
 		if err != nil {
 			return nil, err
 		}
-		child = num
+		child = result
 	}
 	child, _, _ = f.Type(ctx).Convert(ctx, child)
 	return child, nil

--- a/sql/expression/function/ceil_round_floor_test.go
+++ b/sql/expression/function/ceil_round_floor_test.go
@@ -17,6 +17,7 @@ package function
 import (
 	"testing"
 
+	"github.com/cockroachdb/apd/v3"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/src-d/go-errors.v1"
 
@@ -24,6 +25,25 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
+
+// TestCeilAndFloorDoNotMutateDecimalInput verifies rounding expressions leave shared decimal values unchanged.
+func TestCeilAndFloorDoNotMutateDecimalInput(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	decimalType := types.MustCreateDecimalType(10, 2)
+	input := apd.New(1234, -2)
+	row := sql.NewRow(input)
+	field := expression.NewGetField(0, decimalType, "", false)
+
+	ceilResult, err := NewCeil(ctx, field).Eval(ctx, row)
+	require.NoError(t, err)
+	require.Equal(t, int64(13), ceilResult)
+	require.Equal(t, "12.34", input.String())
+
+	floorResult, err := NewFloor(ctx, field).Eval(ctx, row)
+	require.NoError(t, err)
+	require.Equal(t, int64(12), floorResult)
+	require.Equal(t, "12.34", input.String())
+}
 
 func TestCeil(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
Decimal `CEIL` and `FLOOR` now write their results to fresh values instead of mutating their inputs. This prevents shared decimal results, including window aggregate outputs, from being corrupted during projection.

Adds direct input-immutability coverage and an engine regression for positive and negative decimal window peers.

Fixes dolthub/dolt#11542