### PR TITLE
Fix INET_NTOA for unsigned IPv4 values

### DIFF
--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -1286,6 +1286,10 @@ var FunctionQueryTests = []QueryTest{
 		Expected: []sql.Row{{"10.0.5.10"}},
 	},
 	{
+		Query:    `SELECT INET_NTOA(FIRST_VALUE(INET_ATON('192.0.2.1')) OVER ())`,
+		Expected: []sql.Row{{"192.0.2.1"}},
+	},
+	{
 		Query:    `SELECT INET_ATON("10.0.5.11")`,
 		Expected: []sql.Row{{uint64(167773451)}},
 	},

--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -1286,10 +1286,6 @@ var FunctionQueryTests = []QueryTest{
 		Expected: []sql.Row{{"10.0.5.10"}},
 	},
 	{
-		Query:    `SELECT INET_NTOA(FIRST_VALUE(INET_ATON('192.0.2.1')) OVER ())`,
-		Expected: []sql.Row{{"192.0.2.1"}},
-	},
-	{
 		Query:    `SELECT INET_ATON("10.0.5.11")`,
 		Expected: []sql.Row{{uint64(167773451)}},
 	},

--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -25,6 +25,17 @@ import (
 // first_value, last_value, lead, lag, and the bitwise aggregate functions.
 var WindowFunctionsScriptTests = []ScriptTest{
 	{
+		Name: "INET_NTOA round trip above signed 32-bit range",
+		SetUpScript: []string{
+			"CREATE TABLE inet_ntoa_test (ip VARCHAR(15))",
+			"INSERT INTO inet_ntoa_test VALUES ('192.0.2.1')",
+		},
+		Query: `SELECT INET_NTOA(
+			FIRST_VALUE(INET_ATON(ip)) OVER ()
+		) FROM inet_ntoa_test`,
+		Expected: []sql.Row{{"192.0.2.1"}},
+	},
+	{
 		Name: "window functions, empty table",
 		SetUpScript: []string{
 			"CREATE TABLE empty_tbl (a int, b int)",

--- a/sql/expression/function/inet_convert.go
+++ b/sql/expression/function/inet_convert.go
@@ -245,8 +245,9 @@ func (i *InetNtoa) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, nil
 	}
 
-	// Convert val into int
-	ipv4int, _, err := types.Int32.Convert(ctx, val)
+	// Convert val into an unsigned int. IPv4 addresses use the full 32-bit
+	// range, so signed conversion corrupts addresses above 127.255.255.255.
+	ipv4int, _, err := types.Uint32.Convert(ctx, val)
 	if ipv4int != nil && err != nil && !sql.ErrTruncatedIncorrect.Is(err) {
 		return nil, sql.ErrInvalidType.New(reflect.TypeOf(val).String())
 	}
@@ -260,7 +261,7 @@ func (i *InetNtoa) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	// Create new IPv4, and fill with val
 	ipv4 := make(net.IP, 4)
-	binary.BigEndian.PutUint32(ipv4, uint32(ipv4int.(int32)))
+	binary.BigEndian.PutUint32(ipv4, ipv4int.(uint32))
 
 	return ipv4.String(), nil
 }

--- a/sql/expression/function/inet_convert_test.go
+++ b/sql/expression/function/inet_convert_test.go
@@ -69,6 +69,7 @@ func TestInetNtoa(t *testing.T) {
 	}{
 		{"null input", sql.NewRow(nil), nil, false},
 		{"valid ipv4 int", sql.NewRow(uint32(167773450)), "10.0.5.10", false},
+		{"valid ipv4 int above signed range", sql.NewRow(uint32(3221225985)), "192.0.2.1", false},
 		{"valid ipv4 int as string", sql.NewRow("167773450"), "10.0.5.10", false},
 		{"floating point ipv4", sql.NewRow(10.1), "0.0.0.10", false},
 		{"valid ipv6 int", sql.NewRow("\000\000\000\000"), "0.0.0.0", false},


### PR DESCRIPTION
Fixes INET_NTOA conversion for IPv4 values above the signed 32-bit range.

Fixes https://github.com/dolthub/dolt/issues/11510