### PR TITLE
Support extended hours in TIME_TO_SEC

### DIFF
--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -27,6 +27,10 @@ import (
 
 // FunctionQueryTests contains queries that primarily test SQL function calls
 var FunctionQueryTests = []QueryTest{
+	{
+		Query:    `SELECT FIRST_VALUE(TIME_TO_SEC('25:00:00')) OVER ()`,
+		Expected: []sql.Row{{uint64(90000)}},
+	},
 	// Truncate function https://github.com/dolthub/dolt/issues/9916
 	{
 		Query: "SELECT TRUNCATE(1.223,1)",

--- a/sql/expression/function/time.go
+++ b/sql/expression/function/time.go
@@ -1584,20 +1584,20 @@ func (*TimeToSec) CollationCoercibility(ctx *sql.Context) (collation sql.Collati
 }
 
 func (m *TimeToSec) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	val, err := m.EvalChild(ctx, row)
+	val, err := m.Child.Eval(ctx, row)
 	if err != nil {
 		return nil, err
 	}
-
-	switch v := val.(type) {
-	case time.Time:
-		return uint64(v.Hour()*3600 + v.Minute()*60 + v.Second()), nil
-	case nil:
+	if val == nil {
 		return nil, nil
-	default:
+	}
+
+	timespan, err := types.Time.ConvertToTimespan(val)
+	if err != nil {
 		ctx.Warn(1292, "%s", types.ErrConvertingToTime.New(val).Error())
 		return nil, nil
 	}
+	return uint64(timespan.AsMicroseconds() / int64(time.Second/time.Microsecond)), nil
 }
 
 func (m *TimeToSec) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {

--- a/sql/expression/function/time_test.go
+++ b/sql/expression/function/time_test.go
@@ -842,3 +842,24 @@ func TestTime_MonthName(t *testing.T) {
 		})
 	}
 }
+
+func TestTimeToSec(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	f := NewTimeToSec(ctx, expression.NewGetField(0, types.LongText, "foo", true))
+
+	for _, tt := range []struct {
+		name     string
+		value    interface{}
+		expected interface{}
+	}{
+		{"null", nil, nil},
+		{"ordinary time", "01:02:03", uint64(3723)},
+		{"extended hours", "25:00:00", uint64(90000)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := f.Eval(ctx, sql.NewRow(tt.value))
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Fixes TIME_TO_SEC to preserve valid TIME values with more than 24 hours.

Fixes https://github.com/dolthub/dolt/issues/11560