### PR TITLE
Fix TIME_FORMAT hour specifiers

### DIFF
--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -27,6 +27,10 @@ import (
 
 // FunctionQueryTests contains queries that primarily test SQL function calls
 var FunctionQueryTests = []QueryTest{
+	{
+		Query:    `SELECT TIME_FORMAT('25:01:02', '%H'), TIME_FORMAT('25:01:02', '%k'), TIME_FORMAT('05:01:02', '%k')`,
+		Expected: []sql.Row{{"25", "25", "5"}},
+	},
 	// Truncate function https://github.com/dolthub/dolt/issues/9916
 	{
 		Query: "SELECT TRUNCATE(1.223,1)",

--- a/sql/expression/function/time_format.go
+++ b/sql/expression/function/time_format.go
@@ -16,6 +16,7 @@ package function
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/lestrrat-go/strftime"
@@ -29,6 +30,7 @@ var mysqlTimeFormatSpec = strftime.NewSpecificationSet()
 var timeFormatSpecifierToFunc = map[byte]func(time.Time) string{
 	'f': microsecondsStr,
 	'H': nil,
+	'k': nil,
 	'h': twelveHourPadded,
 	'I': twelveHourPadded,
 	'i': minutesStr,
@@ -68,6 +70,32 @@ func formatTime(format string, t time.Time) (string, error) {
 		return "", err
 	}
 
+	return formatter.FormatString(t), nil
+}
+
+func formatTimeDuration(format string, t time.Time, hours int) (string, error) {
+	spec := strftime.NewSpecificationSet()
+	for specifier, fn := range timeFormatSpecifierToFunc {
+		if fn != nil {
+			panicIfErr(spec.Set(specifier, wrap(fn)))
+		}
+	}
+	panicIfErr(spec.Set('H', wrap(func(time.Time) string { return fmt.Sprintf("%02d", hours) })))
+	panicIfErr(spec.Set('k', wrap(func(time.Time) string { return strconv.Itoa(hours) })))
+
+	for i := byte('A'); i <= 'Z'; i++ {
+		for _, specifier := range []byte{i, i + byte('a'-'A')} {
+			if _, ok := timeFormatSpecifierToFunc[specifier]; !ok {
+				b := specifier
+				panicIfErr(spec.Set(b, wrap(func(time.Time) string { return string(b) })))
+			}
+		}
+	}
+
+	formatter, err := strftime.New(format, strftime.WithSpecificationSet(spec))
+	if err != nil {
+		return "", err
+	}
 	return formatter.FormatString(t), nil
 }
 
@@ -133,9 +161,10 @@ func (f *TimeFormat) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, sql.ErrInvalidArgumentDetails.New("time_format", "format must be a string")
 	}
 
-	return formatTime(
+	return formatTimeDuration(
 		formatStr,
 		time.Date(1980, time.January, 1, int(d.Hours())%24, int(d.Minutes())%60, int(d.Seconds())%60, int(d.Nanoseconds())%1e9, time.UTC),
+		int(d.Hours()),
 	)
 }
 

--- a/sql/expression/function/time_format.go
+++ b/sql/expression/function/time_format.go
@@ -77,17 +77,25 @@ func formatTimeDuration(format string, t time.Time, hours int) (string, error) {
 	spec := strftime.NewSpecificationSet()
 	for specifier, fn := range timeFormatSpecifierToFunc {
 		if fn != nil {
-			panicIfErr(spec.Set(specifier, wrap(fn)))
+			if err := spec.Set(specifier, wrap(fn)); err != nil {
+				return "", err
+			}
 		}
 	}
-	panicIfErr(spec.Set('H', wrap(func(time.Time) string { return fmt.Sprintf("%02d", hours) })))
-	panicIfErr(spec.Set('k', wrap(func(time.Time) string { return strconv.Itoa(hours) })))
+	if err := spec.Set('H', wrap(func(time.Time) string { return fmt.Sprintf("%02d", hours) })); err != nil {
+		return "", err
+	}
+	if err := spec.Set('k', wrap(func(time.Time) string { return strconv.Itoa(hours) })); err != nil {
+		return "", err
+	}
 
 	for i := byte('A'); i <= 'Z'; i++ {
 		for _, specifier := range []byte{i, i + byte('a'-'A')} {
 			if _, ok := timeFormatSpecifierToFunc[specifier]; !ok {
 				b := specifier
-				panicIfErr(spec.Set(b, wrap(func(time.Time) string { return string(b) })))
+				if err := spec.Set(b, wrap(func(time.Time) string { return string(b) })); err != nil {
+					return "", err
+				}
 			}
 		}
 	}

--- a/sql/expression/function/time_format_test.go
+++ b/sql/expression/function/time_format_test.go
@@ -103,3 +103,31 @@ func TestTimeFormatEval(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, res)
 }
+
+func TestTimeFormatErrorsDoNotPanic(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	tests := []struct {
+		name   string
+		value  interface{}
+		format interface{}
+	}{
+		{"invalid time", "not a time", "%H"},
+		{"non-string format", "04:05:06", 1},
+		{"incomplete format specifier", "04:05:06", "%"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := NewTimeFormat(
+				ctx,
+				expression.NewLiteral(tt.value, types.LongText),
+				expression.NewLiteral(tt.format, types.LongText),
+			)
+			var err error
+			assert.NotPanics(t, func() {
+				_, err = fn.Eval(ctx, nil)
+			})
+			assert.Error(t, err)
+		})
+	}
+}

--- a/sql/expression/function/time_format_test.go
+++ b/sql/expression/function/time_format_test.go
@@ -104,7 +104,7 @@ func TestTimeFormatEval(t *testing.T) {
 	assert.Nil(t, res)
 }
 
-func TestTimeFormatErrorsDoNotPanic(t *testing.T) {
+func TestTimeFormatErrors(t *testing.T) {
 	ctx := sql.NewEmptyContext()
 	tests := []struct {
 		name   string
@@ -123,10 +123,7 @@ func TestTimeFormatErrorsDoNotPanic(t *testing.T) {
 				expression.NewLiteral(tt.value, types.LongText),
 				expression.NewLiteral(tt.format, types.LongText),
 			)
-			var err error
-			assert.NotPanics(t, func() {
-				_, err = fn.Eval(ctx, nil)
-			})
+			_, err := fn.Eval(ctx, nil)
 			assert.Error(t, err)
 		})
 	}

--- a/sql/expression/function/time_format_test.go
+++ b/sql/expression/function/time_format_test.go
@@ -73,6 +73,16 @@ func TestTimeFormatEval(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "04-05-06|000007", res)
 
+	timeFormat = NewTimeFormat(ctx, expression.NewLiteral("25:01:02", types.Time), expression.NewLiteral("%H|%k", types.Text))
+	res, err = timeFormat.Eval(nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "25|25", res)
+
+	timeFormat = NewTimeFormat(ctx, expression.NewLiteral("05:01:02", types.Time), expression.NewLiteral("%k", types.Text))
+	res, err = timeFormat.Eval(nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "5", res)
+
 	timeFormat = NewTimeFormat(ctx, timeLit, nil)
 	res, err = timeFormat.Eval(nil, nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixes TIME_FORMAT to preserve extended hours and support the non-padded hour specifier.

Fixes https://github.com/dolthub/dolt/issues/11413