### PR TITLE
Preserve empty strings in GROUP_CONCAT

### DIFF
--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -27,6 +27,13 @@ import (
 
 // FunctionQueryTests contains queries that primarily test SQL function calls
 var FunctionQueryTests = []QueryTest{
+	{
+		Query: `SELECT FIRST_VALUE(x) OVER () FROM (
+			SELECT GROUP_CONCAT(v ORDER BY id SEPARATOR '|') AS x
+			FROM (SELECT 1 AS id, '' AS v UNION ALL SELECT 2, 'a' UNION ALL SELECT 3, '') t
+		) q`,
+		Expected: []sql.Row{{"|a|"}},
+	},
 	// Truncate function https://github.com/dolthub/dolt/issues/9916
 	{
 		Query: "SELECT TRUNCATE(1.223,1)",

--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -28,13 +28,6 @@ import (
 // FunctionQueryTests contains queries that primarily test SQL function calls
 var FunctionQueryTests = []QueryTest{
 	{
-		Query: `SELECT FIRST_VALUE(x) OVER () FROM (
-			SELECT GROUP_CONCAT(v ORDER BY id SEPARATOR '|') AS x
-			FROM (SELECT 1 AS id, '' AS v UNION ALL SELECT 2, 'a' UNION ALL SELECT 3, '') t
-		) q`,
-		Expected: []sql.Row{{"|a|"}},
-	},
-	{
 		Query:    `SELECT FIRST_VALUE(TIME_TO_SEC('25:00:00')) OVER ()`,
 		Expected: []sql.Row{{uint64(90000)}},
 	},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -123,23 +123,6 @@ type ScriptTestAssertion struct {
 // the tests.
 var ScriptTests = []ScriptTest{
 	{
-		Name: "GROUP_CONCAT with multiple expressions",
-		SetUpScript: []string{
-			"CREATE TABLE group_concat_students (id INT PRIMARY KEY, first_name VARCHAR(20), last_name VARCHAR(20))",
-			"INSERT INTO group_concat_students VALUES (1, 'Alice', 'Smith'), (2, 'Bob', 'Jones'), (3, 'Alice', 'Brown'), (4, 'Eve', NULL), (5, '', 'White')",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:    "SELECT GROUP_CONCAT(first_name, ' ', last_name ORDER BY id SEPARATOR '; ') FROM group_concat_students",
-				Expected: []sql.Row{{"Alice Smith; Bob Jones; Alice Brown;  White"}},
-			},
-			{
-				Query:    "SELECT GROUP_CONCAT(DISTINCT first_name, ' ', last_name ORDER BY id SEPARATOR '; ') FROM group_concat_students",
-				Expected: []sql.Row{{"Alice Smith; Bob Jones; Alice Brown;  White"}},
-			},
-		},
-	},
-	{
 		// https://github.com/dolthub/dolt/issues/10113
 		Name: "DELETE with NOT EXISTS subquery",
 		SetUpScript: []string{
@@ -4336,8 +4319,26 @@ CREATE TABLE tab3 (
 
 			"create table nulls(pk int)",
 			"INSERT INTO nulls VALUES (NULL)",
+
+			"CREATE TABLE group_concat_students (id INT PRIMARY KEY, first_name VARCHAR(20), last_name VARCHAR(20))",
+			"INSERT INTO group_concat_students VALUES (1, 'Alice', 'Smith'), (2, 'Bob', 'Jones'), (3, 'Alice', 'Brown'), (4, 'Eve', NULL), (5, '', 'White')",
 		},
 		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT GROUP_CONCAT(first_name, ' ', last_name ORDER BY id SEPARATOR '; ') FROM group_concat_students",
+				Expected: []sql.Row{{"Alice Smith; Bob Jones; Alice Brown;  White"}},
+			},
+			{
+				Query:    "SELECT GROUP_CONCAT(DISTINCT first_name, ' ', last_name ORDER BY id SEPARATOR '; ') FROM group_concat_students",
+				Expected: []sql.Row{{"Alice Smith; Bob Jones; Alice Brown;  White"}},
+			},
+			{
+				Query: `SELECT FIRST_VALUE(x) OVER () FROM (
+					SELECT GROUP_CONCAT(v ORDER BY id SEPARATOR '|') AS x
+					FROM (SELECT 1 AS id, '' AS v UNION ALL SELECT 2, 'a' UNION ALL SELECT 3, '') t
+				) q`,
+				Expected: []sql.Row{{"|a|"}},
+			},
 			{
 				Query:    `SELECT group_concat(pk ORDER BY pk) FROM x;`,
 				Expected: []sql.Row{{"1,2,3,4"}},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -123,6 +123,23 @@ type ScriptTestAssertion struct {
 // the tests.
 var ScriptTests = []ScriptTest{
 	{
+		Name: "GROUP_CONCAT with multiple expressions",
+		SetUpScript: []string{
+			"CREATE TABLE group_concat_students (id INT PRIMARY KEY, first_name VARCHAR(20), last_name VARCHAR(20))",
+			"INSERT INTO group_concat_students VALUES (1, 'Alice', 'Smith'), (2, 'Bob', 'Jones'), (3, 'Alice', 'Brown'), (4, 'Eve', NULL), (5, '', 'White')",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT GROUP_CONCAT(first_name, ' ', last_name ORDER BY id SEPARATOR '; ') FROM group_concat_students",
+				Expected: []sql.Row{{"Alice Smith; Bob Jones; Alice Brown;  White"}},
+			},
+			{
+				Query:    "SELECT GROUP_CONCAT(DISTINCT first_name, ' ', last_name ORDER BY id SEPARATOR '; ') FROM group_concat_students",
+				Expected: []sql.Row{{"Alice Smith; Bob Jones; Alice Brown;  White"}},
+			},
+		},
+	},
+	{
 		// https://github.com/dolthub/dolt/issues/10113
 		Name: "DELETE with NOT EXISTS subquery",
 		SetUpScript: []string{

--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -25,6 +25,19 @@ import (
 // first_value, last_value, lead, lag, and the bitwise aggregate functions.
 var WindowFunctionsScriptTests = []ScriptTest{
 	{
+		Name: "window partition with NULL keys",
+		SetUpScript: []string{
+			"CREATE TABLE nullable_partition_keys (id INT PRIMARY KEY, g INT NULL)",
+			"INSERT INTO nullable_partition_keys VALUES (1, NULL), (2, NULL), (3, 1)",
+		},
+		Query: "SELECT id, ROW_NUMBER() OVER (PARTITION BY g ORDER BY id) FROM nullable_partition_keys ORDER BY id",
+		Expected: []sql.Row{
+			{int64(1), int64(1)},
+			{int64(2), int64(2)},
+			{int64(3), int64(1)},
+		},
+	},
+	{
 		Name: "ceil and floor do not mutate shared decimal window results",
 		SetUpScript: []string{
 			"CREATE TABLE decimal_window_values (id BIGINT, d DECIMAL(10,2))",

--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -25,19 +25,6 @@ import (
 // first_value, last_value, lead, lag, and the bitwise aggregate functions.
 var WindowFunctionsScriptTests = []ScriptTest{
 	{
-		Name: "window partition with NULL keys",
-		SetUpScript: []string{
-			"CREATE TABLE nullable_partition_keys (id INT PRIMARY KEY, g INT NULL)",
-			"INSERT INTO nullable_partition_keys VALUES (1, NULL), (2, NULL), (3, 1)",
-		},
-		Query: "SELECT id, ROW_NUMBER() OVER (PARTITION BY g ORDER BY id) FROM nullable_partition_keys ORDER BY id",
-		Expected: []sql.Row{
-			{int64(1), int64(1)},
-			{int64(2), int64(2)},
-			{int64(3), int64(1)},
-		},
-	},
-	{
 		Name: "ceil and floor do not mutate shared decimal window results",
 		SetUpScript: []string{
 			"CREATE TABLE decimal_window_values (id BIGINT, d DECIMAL(10,2))",
@@ -645,6 +632,19 @@ var WindowFunctionsScriptTests = []ScriptTest{
 					{1, 1, 1},
 				},
 			},
+		},
+	},
+	{
+		Name: "window functions, row_number partitioned by NULL keys",
+		SetUpScript: []string{
+			"CREATE TABLE nullable_partition_keys (id INT PRIMARY KEY, g INT NULL)",
+			"INSERT INTO nullable_partition_keys VALUES (1, NULL), (2, NULL), (3, 1)",
+		},
+		Query: "SELECT id, ROW_NUMBER() OVER (PARTITION BY g ORDER BY id) FROM nullable_partition_keys ORDER BY id",
+		Expected: []sql.Row{
+			{int64(1), int64(1)},
+			{int64(2), int64(2)},
+			{int64(3), int64(1)},
 		},
 	},
 	{

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -264,11 +264,9 @@ func (g *groupConcatBuffer) Update(ctx *sql.Context, originalRow sql.Row) error 
 
 	g.gc.returnType = retType
 
-	// GROUP_CONCAT skips a row when any selected expression is NULL.
-	for _, value := range evalRow {
-		if value == nil {
-			return nil
-		}
+	// GROUP_CONCAT skips a row when its selected value is NULL.
+	if evalRow[0] == nil {
+		return nil
 	}
 
 	var v interface{}

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -264,43 +264,12 @@ func (g *groupConcatBuffer) Update(ctx *sql.Context, originalRow sql.Row) error 
 
 	g.gc.returnType = retType
 
-	// GROUP_CONCAT skips a row when its selected value is NULL.
-	if evalRow[0] == nil {
-		return nil
+	vs, isNull, err := groupConcatValue(ctx, g.gc.selectExprs, evalRow, retType)
+	if err != nil {
+		return err
 	}
-
-	var v interface{}
-	var vs string
-	if types.IsBlobType(retType) {
-		v, _, err = types.Blob.Convert(ctx, evalRow[0])
-		if err != nil {
-			return err
-		}
-		vb, _, err := sql.Unwrap[[]byte](ctx, v)
-		if err != nil {
-			return err
-		}
-		vs = string(vb)
-	} else {
-		// Use type-aware conversion for enum types
-		if len(g.gc.selectExprs) > 0 {
-			vs, _, err = types.ConvertToCollatedString(ctx, evalRow[0], g.gc.selectExprs[0].Type(ctx))
-			if err != nil {
-				return err
-			}
-		} else {
-			v, _, err = types.LongText.Convert(ctx, evalRow[0])
-			if err != nil {
-				return err
-			}
-			if v == nil {
-				return nil
-			}
-			vs, _, err = sql.Unwrap[string](ctx, v)
-			if err != nil {
-				return err
-			}
-		}
+	if isNull {
+		return nil
 	}
 
 	// Get the current array of rows and the map
@@ -390,4 +359,32 @@ func evalExprs(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (sql.Row, 
 	}
 
 	return result, retType, nil
+}
+
+func groupConcatValue(ctx *sql.Context, exprs []sql.Expression, values sql.Row, retType sql.Type) (string, bool, error) {
+	var sb strings.Builder
+	for i, value := range values {
+		if value == nil {
+			return "", true, nil
+		}
+
+		if types.IsBlobType(retType) {
+			converted, _, err := types.Blob.Convert(ctx, value)
+			if err != nil {
+				return "", false, err
+			}
+			bytes, _, err := sql.Unwrap[[]byte](ctx, converted)
+			if err != nil {
+				return "", false, err
+			}
+			sb.Write(bytes)
+		} else {
+			converted, _, err := types.ConvertToCollatedString(ctx, value, exprs[i].Type(ctx))
+			if err != nil {
+				return "", false, err
+			}
+			sb.WriteString(converted)
+		}
+	}
+	return sb.String(), false, nil
 }

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -361,6 +361,8 @@ func evalExprs(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (sql.Row, 
 	return result, retType, nil
 }
 
+// groupConcatValue returns the concatenated value of the evaluated expressions, a boolean that is true when any
+// expression evaluates to NULL, and any conversion error encountered.
 func groupConcatValue(ctx *sql.Context, exprs []sql.Expression, values sql.Row, retType sql.Type) (string, bool, error) {
 	var sb strings.Builder
 	for i, value := range values {

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -264,9 +264,11 @@ func (g *groupConcatBuffer) Update(ctx *sql.Context, originalRow sql.Row) error 
 
 	g.gc.returnType = retType
 
-	// Skip if this is a null row
-	if evalRow == nil {
-		return nil
+	// GROUP_CONCAT skips a row when any selected expression is NULL.
+	for _, value := range evalRow {
+		if value == nil {
+			return nil
+		}
 	}
 
 	var v interface{}
@@ -376,7 +378,6 @@ func (g *groupConcatBuffer) Dispose(ctx *sql.Context) {
 func evalExprs(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (sql.Row, sql.Type, error) {
 	result := make(sql.Row, len(exprs))
 	retType := types.Blob
-	hasNull := false
 	for i, expr := range exprs {
 		var err error
 		result[i], err = expr.Eval(ctx, row)
@@ -388,12 +389,6 @@ func evalExprs(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (sql.Row, 
 		if expr.Type(ctx) != types.Blob {
 			retType = types.Text
 		}
-		if result[i] == nil {
-			hasNull = true
-		}
-	}
-	if hasNull {
-		return nil, retType, nil
 	}
 
 	return result, retType, nil

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -281,18 +281,12 @@ func (g *groupConcatBuffer) Update(ctx *sql.Context, originalRow sql.Row) error 
 			return err
 		}
 		vs = string(vb)
-		if len(vs) == 0 {
-			return nil
-		}
 	} else {
 		// Use type-aware conversion for enum types
 		if len(g.gc.selectExprs) > 0 {
 			vs, _, err = types.ConvertToCollatedString(ctx, evalRow[0], g.gc.selectExprs[0].Type(ctx))
 			if err != nil {
 				return err
-			}
-			if vs == "" {
-				return nil
 			}
 		} else {
 			v, _, err = types.LongText.Convert(ctx, evalRow[0])
@@ -382,6 +376,7 @@ func (g *groupConcatBuffer) Dispose(ctx *sql.Context) {
 func evalExprs(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (sql.Row, sql.Type, error) {
 	result := make(sql.Row, len(exprs))
 	retType := types.Blob
+	hasNull := false
 	for i, expr := range exprs {
 		var err error
 		result[i], err = expr.Eval(ctx, row)
@@ -393,6 +388,12 @@ func evalExprs(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (sql.Row, 
 		if expr.Type(ctx) != types.Blob {
 			retType = types.Text
 		}
+		if result[i] == nil {
+			hasNull = true
+		}
+	}
+	if hasNull {
+		return nil, retType, nil
 	}
 
 	return result, retType, nil

--- a/sql/expression/function/aggregation/group_concat_test.go
+++ b/sql/expression/function/aggregation/group_concat_test.go
@@ -73,6 +73,20 @@ func TestGroupConcat_PastMaxLen(t *testing.T) {
 	require.Equal(t, int(maxLen), len(rs))
 }
 
+func TestGroupConcat_EmptyStrings(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	gc := NewGroupConcat("", nil, "|", []sql.Expression{expression.NewGetField(0, types.Text, "text", true)}, 1024)
+	buf, err := gc.NewBuffer(ctx)
+	require.NoError(t, err)
+
+	for _, row := range []sql.Row{{""}, {"a"}, {""}, {nil}} {
+		require.NoError(t, buf.Update(ctx, row))
+	}
+	result, err := buf.Eval(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "|a|", result)
+}
+
 // Validate that group_concat returns the correct return type
 func TestGroupConcat_ReturnType(t *testing.T) {
 	ctx := sql.NewEmptyContext()

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -935,15 +935,8 @@ func (a *GroupConcatAgg) filterToDistinct(ctx *sql.Context, buf sql.WindowBuffer
 
 		a.gc.returnType = retType
 
-		// GROUP_CONCAT skips a row when any selected expression is NULL.
-		hasNull := false
-		for _, value := range evalRow {
-			if value == nil {
-				hasNull = true
-				break
-			}
-		}
-		if hasNull {
+		// GROUP_CONCAT skips a row when its selected value is NULL.
+		if evalRow[0] == nil {
 			continue
 		}
 

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -935,27 +935,13 @@ func (a *GroupConcatAgg) filterToDistinct(ctx *sql.Context, buf sql.WindowBuffer
 
 		a.gc.returnType = retType
 
-		// GROUP_CONCAT skips a row when its selected value is NULL.
-		if evalRow[0] == nil {
-			continue
-		}
-
-		var v interface{}
-		if retType == types.Blob {
-			v, _, err = types.Blob.Convert(ctx, evalRow[0])
-		} else {
-			v, _, err = types.LongText.Convert(ctx, evalRow[0])
-		}
-
+		vs, isNull, err := groupConcatValue(ctx, a.gc.selectExprs, evalRow, retType)
 		if err != nil {
 			return nil, nil, err
 		}
-
-		if v == nil {
+		if isNull {
 			continue
 		}
-
-		vs := v.(string)
 
 		// Get the current array of rows and the map
 		// Check if distinct is active if so look at and update our map

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -935,8 +935,15 @@ func (a *GroupConcatAgg) filterToDistinct(ctx *sql.Context, buf sql.WindowBuffer
 
 		a.gc.returnType = retType
 
-		// Skip if this is a null row
-		if evalRow == nil {
+		// GROUP_CONCAT skips a row when any selected expression is NULL.
+		hasNull := false
+		for _, value := range evalRow {
+			if value == nil {
+				hasNull = true
+				break
+			}
+		}
+		if hasNull {
 			continue
 		}
 

--- a/sql/expression/function/aggregation/window_functions_test.go
+++ b/sql/expression/function/aggregation/window_functions_test.go
@@ -154,6 +154,24 @@ func TestGroupedAggFuncs(t *testing.T) {
 			Expected: sql.Row{"1,2,3,4", "1,2,3,4", "1,2,3,4,5,6"},
 		},
 		{
+			Name: "group concat multiple expressions",
+			Agg: NewGroupConcatAgg(NewGroupConcat("", nil, ",", []sql.Expression{
+				expression.NewGetField(0, types.LongText, "x", true),
+				expression.NewLiteral("-", types.LongText),
+				expression.NewGetField(1, types.LongText, "y", true),
+			}, 1042)),
+			Expected: sql.Row{"1-1,3-3,4-4", "1-1,3-3,4-4", "1-1,2-2,5-5,6-6"},
+		},
+		{
+			Name: "group concat multiple expressions with later null",
+			Agg: NewGroupConcatAgg(NewGroupConcat("", nil, ",", []sql.Expression{
+				expression.NewGetField(1, types.LongText, "x", true),
+				expression.NewLiteral("-", types.LongText),
+				expression.NewGetField(0, types.LongText, "y", true),
+			}, 1042)),
+			Expected: sql.Row{"1-1,3-3,4-4", "1-1,3-3,4-4", "1-1,2-2,5-5,6-6"},
+		},
+		{
 			Name: "json array null",
 			Agg:  NewJsonArrayAgg(expression.NewGetField(0, types.LongText, "x", true)),
 			Expected: sql.Row{


### PR DESCRIPTION
Fixes GROUP_CONCAT to preserve empty non-NULL strings while continuing to skip NULL values.

Fixes https://github.com/dolthub/dolt/issues/11561

Fixes https://github.com/dolthub/dolt/issues/11427