### PR TITLE
Warn when removing `NO_ZERO_IN_DATE` from `@@SQL_MODE`

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -1163,10 +1163,11 @@ func AssertWarningAndTestQuery(
 			}
 		}
 		if len(expectedWarningMessageSubstring) > 0 {
-			// Not ideal. All messages must have the same substring for a given test.
+			var warningMsg string
 			for _, warning := range ctx.Warnings() {
-				assert.Contains(t, warning.Message, expectedWarningMessageSubstring, "Unexpected warning message")
+				warningMsg += warning.Message
 			}
+			assert.Contains(t, warningMsg, expectedWarningMessageSubstring, "Unexpected warning message")
 		}
 	}
 

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -10874,8 +10874,7 @@ where
 		SetUpScript: []string{},
 		Assertions: []ScriptTestAssertion{
 			{
-				// TODO: prevent this entirely?
-				// Disabling `NO_ZERO_IN_DATE` throws error, and doesn't change SQL_MODE
+				// Disabling `NO_ZERO_IN_DATE` throws additional warning
 				Query: "set @@sql_mode = '" +
 					"STRICT_TRANS_TABLES," +
 					"NO_ZERO_DATE," +
@@ -10883,11 +10882,9 @@ where
 				Expected: []sql.Row{
 					{types.OkResult{}},
 				},
-				ExpectedWarningsCount: 1,
-				ExpectedWarning:       3135,
-				ExpectedWarningMessageSubstring: "'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' " +
-					"sql modes should be used with strict mode. " +
-					"They will be merged with strict mode in a future release",
+				ExpectedWarningsCount:           2,
+				ExpectedWarning:                 3135,
+				ExpectedWarningMessageSubstring: "Removing NO_ZERO_IN_DATE mode is not supported",
 			},
 			{
 				Query: "select @@sql_mode",

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -38,6 +38,9 @@ var (
 	// ErrSystemVariableCodeFail is returned when failing to encode/decode a system variable.
 	ErrSystemVariableCodeFail = errors.NewKind("unable to encode/decode value '%v' for '%s'")
 
+	// ErrMissingNoZeroInDateSQLMode is returned when attempting to set SQL_MODE without NO_ZERO_IN_DATE
+	ErrMissingNoZeroInDateSQLMode = errors.NewKind("SQL_MODE without NO_ZERO_IN_DATE is unsupported")
+
 	// ErrInvalidType is thrown when there is an unexpected type at some part of
 	// the execution tree.
 	ErrInvalidType = errors.NewKind("invalid type: %s")

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -38,9 +38,6 @@ var (
 	// ErrSystemVariableCodeFail is returned when failing to encode/decode a system variable.
 	ErrSystemVariableCodeFail = errors.NewKind("unable to encode/decode value '%v' for '%s'")
 
-	// ErrMissingNoZeroInDateSQLMode is returned when attempting to set SQL_MODE without NO_ZERO_IN_DATE
-	ErrMissingNoZeroInDateSQLMode = errors.NewKind("SQL_MODE without NO_ZERO_IN_DATE is unsupported")
-
 	// ErrInvalidType is thrown when there is an unexpected type at some part of
 	// the execution tree.
 	ErrInvalidType = errors.NewKind("invalid type: %s")

--- a/sql/rowexec/rel_iters.go
+++ b/sql/rowexec/rel_iters.go
@@ -480,8 +480,9 @@ func validateSystemVariableValue(ctx *sql.Context, sysVarName string, val any) e
 			return sql.ErrInvalidTimeZone.New(valStr)
 		}
 	case "sql_mode":
-		// TODO: The Golang time library does not properly support using 0 for Month and Day, so it may be necessary
-		//  for us to prevent users from disabling `NO_ZERO_IN_DATE`
+		// The Golang time library does not properly support using 0 for Month and Day, so we throw a warning for
+		// users attempting to remove NO_ZERO_IN_DATE from sql_mode.
+		// Users are still able to make the SQL_MODE change, but it will still behave as if the mode is enabled.
 		switch v := val.(type) {
 		case uint64:
 			// If the assigned SQL_MODE contains any one of these "strict" modes, it should contain every one of
@@ -493,7 +494,8 @@ func validateSystemVariableValue(ctx *sql.Context, sysVarName string, val any) e
 			hasNoZeroDate := v&sql.MODE_NO_ZERO_DATE != 0
 			hasNoZeroInDate := v&sql.MODE_NO_ZERO_IN_DATE != 0
 			if !hasNoZeroInDate {
-				return sql.ErrMissingNoZeroInDateSQLMode.New()
+				ctx.Warn(3135, "Removing NO_ZERO_IN_DATE mode is not supported. "+
+					"DATEs with zero month or zero day will be treated as if NO_ZERO_IN_DATE is enabled.")
 			}
 			if (hasStrict || hasErrorForDivisionByZero || hasNoZeroDate || hasNoZeroInDate) &&
 				!(hasStrict && hasErrorForDivisionByZero && hasNoZeroDate && hasNoZeroInDate) {
@@ -512,7 +514,8 @@ func validateSystemVariableValue(ctx *sql.Context, sysVarName string, val any) e
 			hasNoZeroDate := strings.Contains(v, sql.NO_ZERO_DATE)
 			hasNoZeroInDate := strings.Contains(v, sql.NO_ZERO_IN_DATE)
 			if !hasNoZeroInDate {
-				return sql.ErrMissingNoZeroInDateSQLMode.New()
+				ctx.Warn(3135, "Removing NO_ZERO_IN_DATE mode is not supported. "+
+					"DATEs with zero month or zero day will be treated as if NO_ZERO_IN_DATE is enabled.")
 			}
 			if (hasStrict || hasErrorForDivisionByZero || hasNoZeroDate || hasNoZeroInDate) &&
 				!(hasStrict && hasErrorForDivisionByZero && hasNoZeroDate && hasNoZeroInDate) {

--- a/sql/rowexec/rel_iters.go
+++ b/sql/rowexec/rel_iters.go
@@ -492,6 +492,9 @@ func validateSystemVariableValue(ctx *sql.Context, sysVarName string, val any) e
 			hasErrorForDivisionByZero := v&sql.MODE_ERROR_FOR_DIVISION_BY_ZERO != 0
 			hasNoZeroDate := v&sql.MODE_NO_ZERO_DATE != 0
 			hasNoZeroInDate := v&sql.MODE_NO_ZERO_IN_DATE != 0
+			if !hasNoZeroInDate {
+				return sql.ErrMissingNoZeroInDateSQLMode.New()
+			}
 			if (hasStrict || hasErrorForDivisionByZero || hasNoZeroDate || hasNoZeroInDate) &&
 				!(hasStrict && hasErrorForDivisionByZero && hasNoZeroDate && hasNoZeroInDate) {
 				ctx.Warn(3135, "'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' "+
@@ -508,6 +511,9 @@ func validateSystemVariableValue(ctx *sql.Context, sysVarName string, val any) e
 			hasErrorForDivisionByZero := strings.Contains(v, sql.ERROR_FOR_DIVISION_BY_ZERO)
 			hasNoZeroDate := strings.Contains(v, sql.NO_ZERO_DATE)
 			hasNoZeroInDate := strings.Contains(v, sql.NO_ZERO_IN_DATE)
+			if !hasNoZeroInDate {
+				return sql.ErrMissingNoZeroInDateSQLMode.New()
+			}
 			if (hasStrict || hasErrorForDivisionByZero || hasNoZeroDate || hasNoZeroInDate) &&
 				!(hasStrict && hasErrorForDivisionByZero && hasNoZeroDate && hasNoZeroInDate) {
 				ctx.Warn(3135, "'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' "+

--- a/sql/rowexec/rel_iters.go
+++ b/sql/rowexec/rel_iters.go
@@ -30,6 +30,16 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
+const (
+	// MissingNoDateInSQLModeWarningMessage is thrown when users remove NO_ZERO_IN_DATE from SQL_MODE.
+	// The Golang Time library does not properly support 0 month and 0 day.
+	// Users are still able to remove the mode, but it will still behave as if the mode is enabled.
+	MissingNoDateInSQLModeWarningMessage = "Removing NO_ZERO_IN_DATE mode is not supported. " +
+		"DATEs with zero month or zero day will be treated as if NO_ZERO_IN_DATE is enabled."
+	MissingStrictModeWarningMessage = "'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. " +
+		"They will be merged with strict mode in a future release."
+)
+
 // windowToIter transforms a plan.Window into a series
 // of aggregation.WindowPartitionIter and a list of output projection indexes
 // for each window partition.
@@ -480,9 +490,6 @@ func validateSystemVariableValue(ctx *sql.Context, sysVarName string, val any) e
 			return sql.ErrInvalidTimeZone.New(valStr)
 		}
 	case "sql_mode":
-		// The Golang time library does not properly support using 0 for Month and Day, so we throw a warning for
-		// users attempting to remove NO_ZERO_IN_DATE from sql_mode.
-		// Users are still able to make the SQL_MODE change, but it will still behave as if the mode is enabled.
 		switch v := val.(type) {
 		case uint64:
 			// If the assigned SQL_MODE contains any one of these "strict" modes, it should contain every one of
@@ -494,14 +501,11 @@ func validateSystemVariableValue(ctx *sql.Context, sysVarName string, val any) e
 			hasNoZeroDate := v&sql.MODE_NO_ZERO_DATE != 0
 			hasNoZeroInDate := v&sql.MODE_NO_ZERO_IN_DATE != 0
 			if !hasNoZeroInDate {
-				ctx.Warn(3135, "Removing NO_ZERO_IN_DATE mode is not supported. "+
-					"DATEs with zero month or zero day will be treated as if NO_ZERO_IN_DATE is enabled.")
+				ctx.Warn(3135, MissingNoDateInSQLModeWarningMessage)
 			}
 			if (hasStrict || hasErrorForDivisionByZero || hasNoZeroDate || hasNoZeroInDate) &&
 				!(hasStrict && hasErrorForDivisionByZero && hasNoZeroDate && hasNoZeroInDate) {
-				ctx.Warn(3135, "'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' "+
-					"sql modes should be used with strict mode. "+
-					"They will be merged with strict mode in a future release.")
+				ctx.Warn(3135, MissingStrictModeWarningMessage)
 			}
 		case string:
 			v = strings.ToUpper(v)
@@ -514,14 +518,11 @@ func validateSystemVariableValue(ctx *sql.Context, sysVarName string, val any) e
 			hasNoZeroDate := strings.Contains(v, sql.NO_ZERO_DATE)
 			hasNoZeroInDate := strings.Contains(v, sql.NO_ZERO_IN_DATE)
 			if !hasNoZeroInDate {
-				ctx.Warn(3135, "Removing NO_ZERO_IN_DATE mode is not supported. "+
-					"DATEs with zero month or zero day will be treated as if NO_ZERO_IN_DATE is enabled.")
+				ctx.Warn(3135, MissingNoDateInSQLModeWarningMessage)
 			}
 			if (hasStrict || hasErrorForDivisionByZero || hasNoZeroDate || hasNoZeroInDate) &&
 				!(hasStrict && hasErrorForDivisionByZero && hasNoZeroDate && hasNoZeroInDate) {
-				ctx.Warn(3135, "'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' "+
-					"sql modes should be used with strict mode. "+
-					"They will be merged with strict mode in a future release.")
+				ctx.Warn(3135, MissingStrictModeWarningMessage)
 			}
 		}
 	}


### PR DESCRIPTION
Because we don't properly support 0 Month and 0 Day for DATE/DATETIME types, we throw a warning when removing the `NO_ZERO_IN_DATE` sql_mode and behave as if it were enabled.