### PR TITLE
String inputs to integer division should be treated as decimals to match MySQL

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3692,7 +3692,15 @@ SELECT * FROM cte WHERE  d = 2;`,
 		Expected: []sql.Row{{6}},
 	},
 	{
+		Query:    "select '1.2' div '0.2';",
+		Expected: []sql.Row{{6}},
+	},
+	{
 		Query:    "select 1.2 div 0.4;",
+		Expected: []sql.Row{{3}},
+	},
+	{
+		Query:    "select '1.2' div '0.4';",
 		Expected: []sql.Row{{3}},
 	},
 	{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1222,7 +1222,7 @@ FROM task_instance INNER JOIN job ON job.id = task_instance.queued_by_job_id INN
 				Expected:                        []sql.Row{{0}},
 				ExpectedWarningsCount:           1,
 				ExpectedWarning:                 mysql.ERTruncatedWrongValue,
-				ExpectedWarningMessageSubstring: "Truncated incorrect double value: 'a'",
+				ExpectedWarningMessageSubstring: "Truncated incorrect DECIMAL value: 'a'",
 			},
 			{
 				Query:                 "select 4 div 'a';",
@@ -1243,7 +1243,7 @@ FROM task_instance INNER JOIN job ON job.id = task_instance.queued_by_job_id INN
 				Expected:                        []sql.Row{{4}},
 				ExpectedWarningsCount:           1,
 				ExpectedWarning:                 mysql.ERTruncatedWrongValue,
-				ExpectedWarningMessageSubstring: "Truncated incorrect double value: '12a'",
+				ExpectedWarningMessageSubstring: "Truncated incorrect DECIMAL value: '12a'",
 			},
 			{
 				Query:                 "select 'a' mod 'a';",

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/apd/v3"
+	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"gopkg.in/src-d/go-errors.v1"
 
@@ -414,10 +415,11 @@ func convertToDecimalValue(ctx *sql.Context, val interface{}, isTimeType bool) i
 		if err != nil {
 			val = apd.New(0, 0)
 		}
-		val, _, err = dtyp.Convert(ctx, val)
+		convertedVal, _, err := dtyp.Convert(ctx, val)
 		if err != nil {
-			val = apd.New(0, 0)
+			arithmeticWarning(ctx, mysql.ERTruncatedWrongValue, fmt.Sprintf("Truncated incorrect DECIMAL value: '%v'", val))
 		}
+		return convertedVal
 	}
 
 	return val
@@ -727,23 +729,18 @@ func (i *IntDiv) convertLeftRight(ctx *sql.Context, left interface{}, right inte
 	lIsTimeType := types.IsTime(lTyp)
 	rIsTimeType := types.IsTime(rTyp)
 
-	if types.IsText(lTyp) || types.IsText(rTyp) {
-		typ = types.Float64
-	} else if types.IsUnsigned(lTyp) && types.IsUnsigned(rTyp) {
+	if types.IsUnsigned(lTyp) && types.IsUnsigned(rTyp) {
 		typ = types.Uint64
 	} else if (lIsTimeType && rIsTimeType) || (types.IsSigned(lTyp) && types.IsSigned(rTyp)) {
 		typ = types.Int64
 	} else {
-		typ = types.MustCreateDecimalType(types.DecimalTypeMaxPrecision, 0)
-	}
-
-	if types.IsInteger(typ) || types.IsFloat(typ) {
-		left = convertValueToType(ctx, typ, left, lIsTimeType)
-		right = convertValueToType(ctx, typ, right, rIsTimeType)
-	} else {
 		left = convertToDecimalValue(ctx, left, lIsTimeType)
 		right = convertToDecimalValue(ctx, right, rIsTimeType)
+		return left, right
 	}
+
+	left = convertValueToType(ctx, typ, left, lIsTimeType)
+	right = convertValueToType(ctx, typ, right, rIsTimeType)
 
 	return left, right
 }

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -390,7 +390,7 @@ func getFloatOrMaxDecimalType(ctx *sql.Context, e sql.Expression, treatIntsAsFlo
 // If the value is invalid, it returns decimal 0. This function
 // is used for 'div' or 'mod' arithmetic operation, which requires
 // the result value to have precise precision and scale.
-func convertToDecimalValue(ctx *sql.Context, val interface{}, isTimeType bool) interface{} {
+func convertToDecimalValue(ctx *sql.Context, val interface{}, isTimeType bool) *apd.Decimal {
 	if isTimeType {
 		val = convertTimeTypeToString(val)
 	}
@@ -403,26 +403,29 @@ func convertToDecimalValue(ctx *sql.Context, val interface{}, isTimeType bool) i
 	default:
 	}
 
-	if _, ok := val.(*apd.Decimal); !ok {
-		p, s := GetPrecisionAndScale(val)
-		if p > types.DecimalTypeMaxPrecision {
-			p = types.DecimalTypeMaxPrecision
-		}
-		if s > types.DecimalTypeMaxScale {
-			s = types.DecimalTypeMaxScale
-		}
-		dtyp, err := types.CreateDecimalType(p, s)
-		if err != nil {
-			val = apd.New(0, 0)
-		}
-		convertedVal, _, err := dtyp.Convert(ctx, val)
-		if err != nil {
-			arithmeticWarning(ctx, mysql.ERTruncatedWrongValue, fmt.Sprintf("Truncated incorrect DECIMAL value: '%v'", val))
-		}
-		return convertedVal
+	if decimalVal, ok := val.(*apd.Decimal); ok {
+		return decimalVal
 	}
 
-	return val
+	p, s := GetPrecisionAndScale(val)
+	if p > types.DecimalTypeMaxPrecision {
+		p = types.DecimalTypeMaxPrecision
+	}
+	if s > types.DecimalTypeMaxScale {
+		s = types.DecimalTypeMaxScale
+	}
+	dtyp, err := types.CreateDecimalType(p, s)
+	if err != nil {
+		val = apd.New(0, 0)
+	}
+	convertedVal, _, err := dtyp.Convert(ctx, val)
+	if err != nil {
+		arithmeticWarning(ctx, mysql.ERTruncatedWrongValue, fmt.Sprintf("Truncated incorrect DECIMAL value: '%v'", val))
+	}
+	if convertedDecimal, ok := convertedVal.(*apd.Decimal); ok {
+		return convertedDecimal
+	}
+	return apd.New(0, 0)
 }
 
 // countDivs returns the number of division operators in order on the left child node of the current node.


### PR DESCRIPTION
This is necessary to return the correct results. Because integer division takes the floor of the result, floating point error on a div operation that appears to divide evenly might even up returning a value one lower than expected.

This PR also fixes a related issue, where a division operation that converts its input to a decimal will silently convert the input to 0 when the input must be truncated, without emitting a warning. This changes the behavior to match MySQL, producing a result from the truncated input and emitting a warning.