### PR TITLE
Fix EXISTS over ungrouped aggregate subqueries

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -126,6 +126,91 @@ type ScriptTestAssertion struct {
 // the tests.
 var ScriptTests = []ScriptTest{
 	{
+		// https://github.com/dolthub/dolt/issues/11489
+		Name: "EXISTS over an ungrouped aggregate in filters and write queries",
+		SetUpScript: []string{
+			"CREATE TABLE t (id INT PRIMARY KEY, k INT, f INT DEFAULT 0)",
+			"INSERT INTO t (id, k) VALUES (1, 10), (2, 99)",
+			"CREATE TABLE u (k INT PRIMARY KEY)",
+			"INSERT INTO u VALUES (10)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k) ORDER BY id",
+				Expected: []sql.Row{{1}, {2}},
+			},
+			{
+				Query:    "SELECT id FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k) ORDER BY id",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k HAVING COUNT(*) > 0) ORDER BY id",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k LIMIT 0) ORDER BY id",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k LIMIT 1 OFFSET 1) ORDER BY id",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: "DELETE FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
+			},
+			{
+				Query:    "SELECT id FROM t ORDER BY id",
+				Expected: []sql.Row{{1}, {2}},
+			},
+			{
+				Query: "DELETE FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = 99)",
+			},
+			{
+				Query:    "SELECT id FROM t ORDER BY id",
+				Expected: []sql.Row{{1}, {2}},
+			},
+			{
+				Query: "UPDATE t SET f = 9 WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
+			},
+			{
+				Query:    "SELECT id, f FROM t ORDER BY id",
+				Expected: []sql.Row{{1, 0}, {2, 0}},
+			},
+			{
+				Query: "CREATE TABLE r (id INT, k INT)",
+			},
+			{
+				Query: "INSERT INTO r SELECT id, k FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
+			},
+			{
+				Query:    "SELECT id FROM r ORDER BY id",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: "CREATE TABLE c AS SELECT id, k FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
+			},
+			{
+				Query:    "SELECT id FROM c ORDER BY id",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		// https://github.com/dolthub/dolt/issues/11489
+		Name:    "EXISTS over an ungrouped aggregate evaluates input errors",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"CREATE TABLE u (k INT PRIMARY KEY)",
+			"INSERT INTO u VALUES (10)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:          "SELECT 1 WHERE EXISTS(SELECT SUM(REGEXP_LIKE(u.k, '[')) FROM u)",
+				ExpectedErrStr: "the given regular expression is invalid",
+			},
+		},
+	},
+	{
 		// https://github.com/dolthub/dolt/issues/10113
 		Name: "DELETE with NOT EXISTS subquery",
 		SetUpScript: []string{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -126,91 +126,6 @@ type ScriptTestAssertion struct {
 // the tests.
 var ScriptTests = []ScriptTest{
 	{
-		// https://github.com/dolthub/dolt/issues/11489
-		Name: "EXISTS over an ungrouped aggregate in filters and write queries",
-		SetUpScript: []string{
-			"CREATE TABLE t (id INT PRIMARY KEY, k INT, f INT DEFAULT 0)",
-			"INSERT INTO t (id, k) VALUES (1, 10), (2, 99)",
-			"CREATE TABLE u (k INT PRIMARY KEY)",
-			"INSERT INTO u VALUES (10)",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k) ORDER BY id",
-				Expected: []sql.Row{{1}, {2}},
-			},
-			{
-				Query:    "SELECT id FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k) ORDER BY id",
-				Expected: []sql.Row{},
-			},
-			{
-				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k HAVING COUNT(*) > 0) ORDER BY id",
-				Expected: []sql.Row{{1}},
-			},
-			{
-				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k LIMIT 0) ORDER BY id",
-				Expected: []sql.Row{},
-			},
-			{
-				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k LIMIT 1 OFFSET 1) ORDER BY id",
-				Expected: []sql.Row{},
-			},
-			{
-				Query: "DELETE FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
-			},
-			{
-				Query:    "SELECT id FROM t ORDER BY id",
-				Expected: []sql.Row{{1}, {2}},
-			},
-			{
-				Query: "DELETE FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = 99)",
-			},
-			{
-				Query:    "SELECT id FROM t ORDER BY id",
-				Expected: []sql.Row{{1}, {2}},
-			},
-			{
-				Query: "UPDATE t SET f = 9 WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
-			},
-			{
-				Query:    "SELECT id, f FROM t ORDER BY id",
-				Expected: []sql.Row{{1, 0}, {2, 0}},
-			},
-			{
-				Query: "CREATE TABLE r (id INT, k INT)",
-			},
-			{
-				Query: "INSERT INTO r SELECT id, k FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
-			},
-			{
-				Query:    "SELECT id FROM r ORDER BY id",
-				Expected: []sql.Row{},
-			},
-			{
-				Query: "CREATE TABLE c AS SELECT id, k FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
-			},
-			{
-				Query:    "SELECT id FROM c ORDER BY id",
-				Expected: []sql.Row{},
-			},
-		},
-	},
-	{
-		// https://github.com/dolthub/dolt/issues/11489
-		Name:    "EXISTS over an ungrouped aggregate evaluates input errors",
-		Dialect: "mysql",
-		SetUpScript: []string{
-			"CREATE TABLE u (k INT PRIMARY KEY)",
-			"INSERT INTO u VALUES (10)",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:          "SELECT 1 WHERE EXISTS(SELECT SUM(REGEXP_LIKE(u.k, '[')) FROM u)",
-				ExpectedErrStr: "the given regular expression is invalid",
-			},
-		},
-	},
-	{
 		// https://github.com/dolthub/dolt/issues/10113
 		Name: "DELETE with NOT EXISTS subquery",
 		SetUpScript: []string{
@@ -14711,6 +14626,91 @@ select * from t1 except (
 					{1, "-1"},
 					{2, "-2"},
 				},
+			},
+		},
+	},
+	{
+		// https://github.com/dolthub/dolt/issues/11489
+		Name: "EXISTS over an ungrouped aggregate in filters and write queries",
+		SetUpScript: []string{
+			"CREATE TABLE t (id INT PRIMARY KEY, k INT, f INT DEFAULT 0)",
+			"INSERT INTO t (id, k) VALUES (1, 10), (2, 99)",
+			"CREATE TABLE u (k INT PRIMARY KEY)",
+			"INSERT INTO u VALUES (10)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k) ORDER BY id",
+				Expected: []sql.Row{{1}, {2}},
+			},
+			{
+				Query:    "SELECT id FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k) ORDER BY id",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k HAVING COUNT(*) > 0) ORDER BY id",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k LIMIT 0) ORDER BY id",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT id FROM t WHERE EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k LIMIT 1 OFFSET 1) ORDER BY id",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: "DELETE FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
+			},
+			{
+				Query:    "SELECT id FROM t ORDER BY id",
+				Expected: []sql.Row{{1}, {2}},
+			},
+			{
+				Query: "DELETE FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = 99)",
+			},
+			{
+				Query:    "SELECT id FROM t ORDER BY id",
+				Expected: []sql.Row{{1}, {2}},
+			},
+			{
+				Query: "UPDATE t SET f = 9 WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
+			},
+			{
+				Query:    "SELECT id, f FROM t ORDER BY id",
+				Expected: []sql.Row{{1, 0}, {2, 0}},
+			},
+			{
+				Query: "CREATE TABLE r (id INT, k INT)",
+			},
+			{
+				Query: "INSERT INTO r SELECT id, k FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
+			},
+			{
+				Query:    "SELECT id FROM r ORDER BY id",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: "CREATE TABLE c AS SELECT id, k FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
+			},
+			{
+				Query:    "SELECT id FROM c ORDER BY id",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		// https://github.com/dolthub/dolt/issues/11489
+		Name:    "EXISTS over an ungrouped aggregate evaluates input errors",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"CREATE TABLE u (k INT PRIMARY KEY)",
+			"INSERT INTO u VALUES (10)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:          "SELECT 1 WHERE EXISTS(SELECT SUM(REGEXP_LIKE(u.k, '[')) FROM u)",
+				ExpectedErrStr: "the given regular expression is invalid",
 			},
 		},
 	},

--- a/sql/analyzer/unnest_exists_subqueries.go
+++ b/sql/analyzer/unnest_exists_subqueries.go
@@ -106,7 +106,14 @@ func simplifyPartialJoinParents(n sql.Node) (sql.Node, bool) {
 		switch n := ret.(type) {
 		case *plan.Having:
 			return nil, false
-		case *plan.Project, *plan.GroupBy, *plan.Sort, *plan.Distinct, *plan.TopN, *plan.Limit:
+		case *plan.GroupBy:
+			// An aggregate without grouping expressions produces one row even when its child is empty. Removing it
+			// would therefore change the result of the existence check.
+			if len(n.GroupByExprs) == 0 {
+				return nil, false
+			}
+			ret = n.Child
+		case *plan.Project, *plan.Sort, *plan.Distinct, *plan.TopN, *plan.Limit:
 			// TODO: In most cases, it's necessary to remove *plan.Limit because child Filter nodes will have been
 			//  hoisted out. But what if Limit.Limit evals to 0? https://github.com/dolthub/dolt/issues/10493
 			ret = n.Children()[0]

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -81,6 +81,7 @@ var _ sql.Expressioner = (*CreateTable)(nil)
 var _ sql.SchemaTarget = (*CreateTable)(nil)
 var _ sql.CheckConstraintNode = (*CreateTable)(nil)
 var _ sql.CollationCoercible = (*CreateTable)(nil)
+var _ TableCopierCreateTableDestination = (*CreateTable)(nil)
 
 // NewCreateTable creates a new CreateTable node
 func NewCreateTable(db sql.Database, name string, ifn, temp bool, tableSpec *TableSpec) *CreateTable {
@@ -141,6 +142,11 @@ func (c *CreateTable) WithIndexDefs(idxDefs sql.IndexDefs) (*CreateTable, error)
 // Name implements the Nameable interface.
 func (c *CreateTable) Name() string {
 	return c.name
+}
+
+// TableCopierDestinationName returns the name of the table created for a table copy operation.
+func (c *CreateTable) TableCopierDestinationName() string {
+	return c.Name()
 }
 
 // Resolved implements the Resolvable interface.

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -81,7 +81,6 @@ var _ sql.Expressioner = (*CreateTable)(nil)
 var _ sql.SchemaTarget = (*CreateTable)(nil)
 var _ sql.CheckConstraintNode = (*CreateTable)(nil)
 var _ sql.CollationCoercible = (*CreateTable)(nil)
-var _ TableCopierCreateTableDestination = (*CreateTable)(nil)
 
 // NewCreateTable creates a new CreateTable node
 func NewCreateTable(db sql.Database, name string, ifn, temp bool, tableSpec *TableSpec) *CreateTable {
@@ -142,11 +141,6 @@ func (c *CreateTable) WithIndexDefs(idxDefs sql.IndexDefs) (*CreateTable, error)
 // Name implements the Nameable interface.
 func (c *CreateTable) Name() string {
 	return c.name
-}
-
-// TableCopierDestinationName returns the name of the table created for a table copy operation.
-func (c *CreateTable) TableCopierDestinationName() string {
-	return c.Name()
 }
 
 // Resolved implements the Resolvable interface.

--- a/sql/plan/table_copier.go
+++ b/sql/plan/table_copier.go
@@ -21,6 +21,14 @@ type TableCopier struct {
 var _ sql.Databaser = (*TableCopier)(nil)
 var _ sql.Node = (*TableCopier)(nil)
 var _ sql.CollationCoercible = (*TableCopier)(nil)
+var _ DisjointedChildrenNode = (*TableCopier)(nil)
+
+// TableCopierCreateTableDestination is a create-table node that TableCopier can execute before copying rows.
+type TableCopierCreateTableDestination interface {
+	sql.Node
+	// TableCopierDestinationName returns the name of the table created for the copy destination.
+	TableCopierDestinationName() string
+}
 
 type CopierProps struct {
 	replace bool
@@ -51,14 +59,16 @@ func (tc *TableCopier) Database() sql.Database {
 }
 
 func (tc *TableCopier) ProcessCreateTable(ctx *sql.Context, b sql.NodeExecBuilder, row sql.Row) (sql.RowIter, error) {
-	ct := tc.Destination.(*CreateTable)
+	destination, ok := tc.Destination.(TableCopierCreateTableDestination)
+	if !ok {
+		return nil, fmt.Errorf("TableCopier requires a create-table destination")
+	}
 
-	_, err := b.Build(ctx, ct, row)
-	if err != nil {
+	if err := buildAndCloseTableCopierDestination(ctx, b, tc.Destination, row); err != nil {
 		return sql.RowsToRowIter(), err
 	}
 
-	table, tableExists, err := tc.db.GetTableInsensitive(ctx, ct.Name())
+	table, tableExists, err := tc.db.GetTableInsensitive(ctx, destination.TableCopierDestinationName())
 	if err != nil {
 		return sql.RowsToRowIter(), err
 	}
@@ -75,6 +85,15 @@ func (tc *TableCopier) ProcessCreateTable(ctx *sql.Context, b sql.NodeExecBuilde
 	ii := NewInsertInto(tc.db, NewResolvedTable(table, tc.db, nil), tc.Source, tc.options.replace, nil, nil, tc.options.ignore)
 
 	return b.Build(ctx, ii, row)
+}
+
+// buildAndCloseTableCopierDestination executes the create phase and releases its iterator before rows are copied.
+func buildAndCloseTableCopierDestination(ctx *sql.Context, b sql.NodeExecBuilder, destination sql.Node, row sql.Row) error {
+	iter, err := b.Build(ctx, destination, row)
+	if err != nil || iter == nil {
+		return err
+	}
+	return iter.Close(ctx)
 }
 
 // createTableSelectCanBeCopied determines whether the newly created table's data can just be copied from the Source table
@@ -135,6 +154,23 @@ func (tc *TableCopier) Children() []sql.Node {
 
 func (tc *TableCopier) WithChildren(*sql.Context, ...sql.Node) (sql.Node, error) {
 	return tc, nil
+}
+
+// DisjointedChildren exposes the independently analyzed destination and source trees.
+func (tc *TableCopier) DisjointedChildren() [][]sql.Node {
+	return [][]sql.Node{{tc.Destination}, {tc.Source}}
+}
+
+// WithDisjointedChildren returns a TableCopier with replacement destination and source trees.
+func (tc *TableCopier) WithDisjointedChildren(children [][]sql.Node) (sql.Node, error) {
+	if len(children) != 2 || len(children[0]) != 1 || len(children[1]) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(tc, len(children), 2)
+	}
+
+	ntc := *tc
+	ntc.Destination = children[0][0]
+	ntc.Source = children[1][0]
+	return &ntc, nil
 }
 
 // CollationCoercibility implements the interface sql.CollationCoercible.

--- a/sql/plan/table_copier.go
+++ b/sql/plan/table_copier.go
@@ -23,13 +23,6 @@ var _ sql.Node = (*TableCopier)(nil)
 var _ sql.CollationCoercible = (*TableCopier)(nil)
 var _ DisjointedChildrenNode = (*TableCopier)(nil)
 
-// TableCopierCreateTableDestination is a create-table node that TableCopier can execute before copying rows.
-type TableCopierCreateTableDestination interface {
-	sql.Node
-	// TableCopierDestinationName returns the name of the table created for the copy destination.
-	TableCopierDestinationName() string
-}
-
 type CopierProps struct {
 	replace bool
 	ignore  bool
@@ -59,16 +52,16 @@ func (tc *TableCopier) Database() sql.Database {
 }
 
 func (tc *TableCopier) ProcessCreateTable(ctx *sql.Context, b sql.NodeExecBuilder, row sql.Row) (sql.RowIter, error) {
-	destination, ok := tc.Destination.(TableCopierCreateTableDestination)
+	destination, ok := tc.Destination.(sql.Nameable)
 	if !ok {
-		return nil, fmt.Errorf("TableCopier requires a create-table destination")
+		return nil, fmt.Errorf("TableCopier requires a named create-table destination, found %T", tc.Destination)
 	}
 
 	if err := buildAndCloseTableCopierDestination(ctx, b, tc.Destination, row); err != nil {
 		return sql.RowsToRowIter(), err
 	}
 
-	table, tableExists, err := tc.db.GetTableInsensitive(ctx, destination.TableCopierDestinationName())
+	table, tableExists, err := tc.db.GetTableInsensitive(ctx, destination.Name())
 	if err != nil {
 		return sql.RowsToRowIter(), err
 	}

--- a/sql/plan/table_copier_test.go
+++ b/sql/plan/table_copier_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// TestBuildAndCloseTableCopierDestination verifies iterator closure and close-error propagation.
+func TestBuildAndCloseTableCopierDestination(t *testing.T) {
+	closeErr := errors.New("close failed")
+	iter := &closingRowIter{closeErr: closeErr}
+	builder := tableCopierTestBuilder{iter: iter}
+
+	err := buildAndCloseTableCopierDestination(sql.NewEmptyContext(), builder, Nothing{}, nil)
+
+	require.ErrorIs(t, err, closeErr)
+	require.True(t, iter.closed)
+}
+
+type tableCopierTestBuilder struct {
+	iter sql.RowIter
+}
+
+// Build returns the iterator used to verify the create phase's lifecycle.
+func (b tableCopierTestBuilder) Build(*sql.Context, sql.Node, sql.Row) (sql.RowIter, error) {
+	return b.iter, nil
+}
+
+type closingRowIter struct {
+	closed   bool
+	closeErr error
+}
+
+// Next reports that the test iterator has no rows.
+func (i *closingRowIter) Next(*sql.Context) (sql.Row, error) {
+	return nil, io.EOF
+}
+
+// Close records its invocation and returns the configured error.
+func (i *closingRowIter) Close(*sql.Context) error {
+	i.closed = true
+	return i.closeErr
+}

--- a/sql/rowexec/other.go
+++ b/sql/rowexec/other.go
@@ -251,16 +251,14 @@ func (b *BaseBuilder) buildNothing(ctx *sql.Context, n plan.Nothing, row sql.Row
 }
 
 func (b *BaseBuilder) buildTableCopier(ctx *sql.Context, n *plan.TableCopier, row sql.Row) (sql.RowIter, error) {
-	if _, ok := n.Destination.(*plan.CreateTable); ok {
+	switch destination := n.Destination.(type) {
+	case *plan.ResolvedTable:
+		return n.CopyTableOver(ctx, n.Source.Schema(ctx)[0].Source, destination.Name())
+	case plan.TableCopierCreateTableDestination:
 		return n.ProcessCreateTable(ctx, b, row)
+	default:
+		return nil, fmt.Errorf("TableCopier only accepts a create-table node or resolved table as the destination, found %T", destination)
 	}
-
-	drt, ok := n.Destination.(*plan.ResolvedTable)
-	if !ok {
-		return nil, fmt.Errorf("TableCopier only accepts CreateTable or TableNode as the destination")
-	}
-
-	return n.CopyTableOver(ctx, n.Source.Schema(ctx)[0].Source, drt.Name())
 }
 
 func (b *BaseBuilder) buildUnresolvedTable(ctx *sql.Context, n *plan.UnresolvedTable, row sql.Row) (sql.RowIter, error) {

--- a/sql/rowexec/other.go
+++ b/sql/rowexec/other.go
@@ -254,10 +254,8 @@ func (b *BaseBuilder) buildTableCopier(ctx *sql.Context, n *plan.TableCopier, ro
 	switch destination := n.Destination.(type) {
 	case *plan.ResolvedTable:
 		return n.CopyTableOver(ctx, n.Source.Schema(ctx)[0].Source, destination.Name())
-	case plan.TableCopierCreateTableDestination:
-		return n.ProcessCreateTable(ctx, b, row)
 	default:
-		return nil, fmt.Errorf("TableCopier only accepts a create-table node or resolved table as the destination, found %T", destination)
+		return n.ProcessCreateTable(ctx, b, row)
 	}
 }
 


### PR DESCRIPTION
Ungrouped aggregates produce one row even when their input is empty. Preserve that cardinality when simplifying EXISTS subqueries so correlated forms retain correct results without suppressing aggregate expression evaluation.

Teach TableCopier to expose its independently analyzed create and source trees, accept integrator-owned create destinations through the standard sql.Nameable contract, and close the create iterator before copying rows. Adds coverage for SELECT and write statements, including CTAS, plus HAVING / LIMIT / OFFSET boundaries.

Companion: https://github.com/dolthub/doltgresql/pull/3274

Fixes dolthub/dolt#11489
Fixes https://github.com/dolthub/dolt/issues/11477
Fixes https://github.com/dolthub/dolt/issues/11508
