### PR TITLE
Fix COUNT(DISTINCT ...) collision for multi-column comma values

### DIFF
--- a/sql/expression/function/aggregation/count_test.go
+++ b/sql/expression/function/aggregation/count_test.go
@@ -137,6 +137,21 @@ func TestCountDistinctEvalString(t *testing.T) {
 	require.Equal(int64(2), evalBuffer(t, b))
 }
 
+func TestCountDistinctEvalMultiColumn(t *testing.T) {
+	require := require.New(t)
+	ctx := sql.NewEmptyContext()
+
+	c := NewCountDistinct(
+		expression.NewGetField(0, types.Text, "", true),
+		expression.NewGetField(1, types.Text, "", true),
+	)
+	b, _ := c.NewBuffer(ctx)
+
+	require.NoError(b.Update(ctx, sql.NewRow("a,", "b")))
+	require.NoError(b.Update(ctx, sql.NewRow("a", ",b")))
+	require.Equal(int64(2), evalBuffer(t, b))
+}
+
 func TestCountDistinctEvalExtendedType(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()

--- a/sql/expression/function/aggregation/unary_agg_buffers.go
+++ b/sql/expression/function/aggregation/unary_agg_buffers.go
@@ -486,7 +486,7 @@ func (c *countDistinctBuffer) Update(ctx *sql.Context, row sql.Row) error {
 		}
 	}
 
-	var str string
+	hash := xxhash.New()
 	for _, val := range value.(sql.Row) {
 		// skip nil values
 		if val == nil {
@@ -500,16 +500,11 @@ func (c *countDistinctBuffer) Update(ctx *sql.Context, row sql.Row) error {
 		if !ok {
 			return fmt.Errorf("count distinct unable to hash value: %s", err)
 		}
-		str += vv + ","
+		if _, err = fmt.Fprintf(hash, "%d:%s", len(vv), vv); err != nil {
+			return err
+		}
 	}
-
-	hash := xxhash.New()
-	_, err := hash.WriteString(str)
-	if err != nil {
-		return err
-	}
-	h := hash.Sum64()
-	c.seen[h] = struct{}{}
+	c.seen[hash.Sum64()] = struct{}{}
 
 	return nil
 }


### PR DESCRIPTION
## What

Fixes a `COUNT(DISTINCT a, b)` correctness bug where distinct multi-column tuples are counted as one. Reported downstream at dolthub/dolt#11562.

```sql
CREATE TABLE t(id INT PRIMARY KEY, a VARCHAR(16), b VARCHAR(16));
INSERT INTO t VALUES (1, 'a,', 'b'), (2, 'a', ',b');
SELECT COUNT(DISTINCT a, b) FROM t;   -- MySQL: 2, was returning 1
```

## Fix

The multi-column path in `countDistinctBuffer.Update` built its hash key by joining each converted value with a `,` separator (`str += vv + ","`). That encoding is not injective: `('a,','b')` and `('a',',b')` both produce `"a,,b,"`, so distinct tuples collide into one hash bucket. Length-prefixing each value (`"%d:%s"`) makes the encoding self-delimiting, so different tuples always produce different keys.

## Tests

Added `TestCountDistinctEvalMultiColumn` in `count_test.go` using the reporter's exact tuples.

## Validation

```
go test -tags gms_pure_go ./sql/expression/function/aggregation/
```

- New test: RED on `main` (returns 1, expected 2), GREEN with the fix.
- Full `aggregation` package suite passes.
- `gofmt`/`goimports -local github.com/dolthub/go-mysql-server` clean.

Happy to adjust.
