### PR TITLE
Include bucket count in NTILE identity

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -25,23 +25,6 @@ import (
 // first_value, last_value, lead, lag, and the bitwise aggregate functions.
 var WindowFunctionsScriptTests = []ScriptTest{
 	{
-		Name: "sibling NTILE expressions with different bucket counts",
-		SetUpScript: []string{
-			"CREATE TABLE ntile_counts (id INT PRIMARY KEY, g INT)",
-			"INSERT INTO ntile_counts VALUES (1, 0), (2, 0), (3, 0), (4, 0)",
-		},
-		Query: `SELECT id,
-			NTILE(2) OVER (PARTITION BY g ORDER BY id),
-			NTILE(3) OVER (PARTITION BY g ORDER BY id)
-			FROM ntile_counts ORDER BY id`,
-		Expected: []sql.Row{
-			{1, uint64(1), uint64(1)},
-			{2, uint64(1), uint64(1)},
-			{3, uint64(2), uint64(2)},
-			{4, uint64(2), uint64(3)},
-		},
-	},
-	{
 		Name: "INET_NTOA round trip above signed 32-bit range",
 		SetUpScript: []string{
 			"CREATE TABLE inet_ntoa_test (ip VARCHAR(15))",
@@ -715,6 +698,23 @@ var WindowFunctionsScriptTests = []ScriptTest{
 					{float64(15), float64(21)},
 				},
 			},
+		},
+	},
+	{
+		Name: "sibling NTILE expressions with different bucket counts",
+		SetUpScript: []string{
+			"CREATE TABLE ntile_counts (id INT PRIMARY KEY, g INT)",
+			"INSERT INTO ntile_counts VALUES (1, 0), (2, 0), (3, 0), (4, 0)",
+		},
+		Query: `SELECT id,
+			NTILE(2) OVER (PARTITION BY g ORDER BY id),
+			NTILE(3) OVER (PARTITION BY g ORDER BY id)
+			FROM ntile_counts ORDER BY id`,
+		Expected: []sql.Row{
+			{1, uint64(1), uint64(1)},
+			{2, uint64(1), uint64(1)},
+			{3, uint64(2), uint64(2)},
+			{4, uint64(2), uint64(3)},
 		},
 	},
 	{

--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -25,6 +25,23 @@ import (
 // first_value, last_value, lead, lag, and the bitwise aggregate functions.
 var WindowFunctionsScriptTests = []ScriptTest{
 	{
+		Name: "sibling NTILE expressions with different bucket counts",
+		SetUpScript: []string{
+			"CREATE TABLE ntile_counts (id INT PRIMARY KEY, g INT)",
+			"INSERT INTO ntile_counts VALUES (1, 0), (2, 0), (3, 0), (4, 0)",
+		},
+		Query: `SELECT id,
+			NTILE(2) OVER (PARTITION BY g ORDER BY id),
+			NTILE(3) OVER (PARTITION BY g ORDER BY id)
+			FROM ntile_counts ORDER BY id`,
+		Expected: []sql.Row{
+			{1, uint64(1), uint64(1)},
+			{2, uint64(1), uint64(1)},
+			{3, uint64(2), uint64(2)},
+			{4, uint64(2), uint64(3)},
+		},
+	},
+	{
 		Name: "INET_NTOA round trip above signed 32-bit range",
 		SetUpScript: []string{
 			"CREATE TABLE inet_ntoa_test (ip VARCHAR(15))",

--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -718,6 +718,25 @@ var WindowFunctionsScriptTests = []ScriptTest{
 		},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/11466
+		Name: "customer reproduction: sibling NTILE expressions with different bucket counts",
+		SetUpScript: []string{
+			"CREATE TABLE t(id INT PRIMARY KEY, g INT, v INT NOT NULL)",
+			"INSERT INTO t VALUES (1,0,10),(2,0,20),(3,0,30),(4,0,40)",
+		},
+		Query: `SELECT id,
+			NTILE(2) OVER (PARTITION BY g ORDER BY id) AS n2,
+			NTILE(3) OVER (PARTITION BY g ORDER BY id) AS n3
+			FROM t
+			ORDER BY id`,
+		Expected: []sql.Row{
+			{1, uint64(1), uint64(1)},
+			{2, uint64(1), uint64(1)},
+			{3, uint64(2), uint64(2)},
+			{4, uint64(2), uint64(3)},
+		},
+	},
+	{
 		Name:    "ntile tests",
 		Dialect: "mysql",
 		SetUpScript: []string{

--- a/sql/expression/function/aggregation/window/ntile.go
+++ b/sql/expression/function/aggregation/window/ntile.go
@@ -70,7 +70,9 @@ func (n *NTile) Resolved() bool {
 
 func (n *NTile) String() string {
 	sb := strings.Builder{}
-	sb.WriteString("ntile()")
+	sb.WriteString("ntile(")
+	sb.WriteString(n.bucketExpr.String())
+	sb.WriteString(")")
 	if n.window != nil {
 		sb.WriteString(" ")
 		sb.WriteString(n.window.String())
@@ -80,7 +82,9 @@ func (n *NTile) String() string {
 
 func (n *NTile) DebugString(ctx *sql.Context) string {
 	sb := strings.Builder{}
-	sb.WriteString("ntile()")
+	sb.WriteString("ntile(")
+	sb.WriteString(sql.DebugString(ctx, n.bucketExpr))
+	sb.WriteString(")")
 	if n.window != nil {
 		sb.WriteString(" ")
 		sb.WriteString(sql.DebugString(ctx, n.window))


### PR DESCRIPTION
Keeps sibling NTILE expressions with different bucket counts distinct.

Fixes https://github.com/dolthub/dolt/issues/11466