### PR TITLE
Return NULL for all-NULL window sums

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -25,17 +25,6 @@ import (
 // first_value, last_value, lead, lag, and the bitwise aggregate functions.
 var WindowFunctionsScriptTests = []ScriptTest{
 	{
-		Name: "window SUM over all-NULL frames",
-		SetUpScript: []string{
-			"CREATE TABLE window_sum_nulls (id INT PRIMARY KEY, v INT)",
-			"INSERT INTO window_sum_nulls VALUES (1, NULL)",
-		},
-		Query: `SELECT id, SUM(v) OVER (
-			ORDER BY id ROWS BETWEEN CURRENT ROW AND CURRENT ROW
-		) FROM window_sum_nulls ORDER BY id`,
-		Expected: []sql.Row{{1, nil}},
-	},
-	{
 		Name: "INET_NTOA round trip above signed 32-bit range",
 		SetUpScript: []string{
 			"CREATE TABLE inet_ntoa_test (ip VARCHAR(15))",
@@ -970,6 +959,17 @@ var WindowFunctionsScriptTests = []ScriptTest{
 				Expected: []sql.Row{{0}},
 			},
 		},
+	},
+	{
+		Name: "window SUM over all-NULL frames",
+		SetUpScript: []string{
+			"CREATE TABLE window_sum_nulls (id INT PRIMARY KEY, v INT)",
+			"INSERT INTO window_sum_nulls VALUES (1, NULL)",
+		},
+		Query: `SELECT id, SUM(v) OVER (
+			ORDER BY id ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+		) FROM window_sum_nulls ORDER BY id`,
+		Expected: []sql.Row{{1, nil}},
 	},
 	{
 		// https://github.com/dolthub/dolt/issues/11381

--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -988,6 +988,110 @@ var WindowFunctionsScriptTests = []ScriptTest{
 		},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/11410
+		Name: "window SUM over mixed and all-NULL intervals",
+		SetUpScript: []string{
+			"CREATE TABLE window_sum_intervals (id INT PRIMARY KEY, g INT, v INT)",
+			"INSERT INTO window_sum_intervals VALUES (1, 0, NULL), (2, 0, NULL), (3, 1, 5), (4, 1, NULL), (5, 2, NULL)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `SELECT id, SUM(v) OVER (
+					ORDER BY id ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+				) FROM window_sum_intervals ORDER BY id`,
+				Expected: []sql.Row{{1, nil}, {2, nil}, {3, float64(5)}, {4, nil}, {5, nil}},
+			},
+			{
+				Query: `SELECT id, SUM(v) OVER (
+					ORDER BY id ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+				) FROM window_sum_intervals ORDER BY id`,
+				Expected: []sql.Row{{1, nil}, {2, nil}, {3, float64(5)}, {4, float64(5)}, {5, nil}},
+			},
+			{
+				Query: `SELECT id, SUM(v) OVER (
+					ORDER BY id ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING
+				) FROM window_sum_intervals ORDER BY id`,
+				Expected: []sql.Row{{1, nil}, {2, float64(5)}, {3, float64(5)}, {4, nil}, {5, nil}},
+			},
+			{
+				Query: `SELECT id, SUM(v) OVER (
+					ORDER BY id ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING
+				) FROM window_sum_intervals ORDER BY id`,
+				Expected: []sql.Row{{1, float64(5)}, {2, float64(5)}, {3, nil}, {4, nil}, {5, nil}},
+			},
+			{
+				Query: `SELECT id, SUM(v) OVER (
+					ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+				) FROM window_sum_intervals ORDER BY id`,
+				Expected: []sql.Row{{1, float64(5)}, {2, float64(5)}, {3, float64(5)}, {4, float64(5)}, {5, float64(5)}},
+			},
+			{
+				Query: `SELECT id, SUM(v) OVER (
+					PARTITION BY g ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+				) FROM window_sum_intervals ORDER BY id`,
+				Expected: []sql.Row{{1, nil}, {2, nil}, {3, float64(5)}, {4, float64(5)}, {5, nil}},
+			},
+		},
+	},
+	{
+		// https://github.com/dolthub/dolt/issues/11410
+		Name: "nullable window aggregates over mixed and all-NULL intervals",
+		SetUpScript: []string{
+			"CREATE TABLE nullable_window_intervals (id INT PRIMARY KEY, v INT)",
+			"INSERT INTO nullable_window_intervals VALUES (1, NULL), (2, NULL), (3, 5), (4, NULL), (5, NULL)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `SELECT id,
+					AVG(v) OVER w, MIN(v) OVER w, MAX(v) OVER w,
+					STDDEV_POP(v) OVER w, STDDEV_SAMP(v) OVER w,
+					VAR_POP(v) OVER w, VAR_SAMP(v) OVER w, COUNT(v) OVER w
+					FROM nullable_window_intervals
+					WINDOW w AS (ORDER BY id ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
+					ORDER BY id`,
+				Expected: []sql.Row{
+					{1, nil, nil, nil, nil, nil, nil, nil, int64(0)},
+					{2, nil, nil, nil, nil, nil, nil, nil, int64(0)},
+					{3, float64(5), 5, 5, float64(0), nil, float64(0), nil, int64(1)},
+					{4, nil, nil, nil, nil, nil, nil, nil, int64(0)},
+					{5, nil, nil, nil, nil, nil, nil, nil, int64(0)},
+				},
+			},
+			{
+				Query: `SELECT id,
+					AVG(v) OVER w, MIN(v) OVER w, MAX(v) OVER w,
+					STDDEV_POP(v) OVER w, STDDEV_SAMP(v) OVER w,
+					VAR_POP(v) OVER w, VAR_SAMP(v) OVER w, COUNT(v) OVER w
+					FROM nullable_window_intervals
+					WINDOW w AS (ORDER BY id ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+					ORDER BY id`,
+				Expected: []sql.Row{
+					{1, nil, nil, nil, nil, nil, nil, nil, int64(0)},
+					{2, nil, nil, nil, nil, nil, nil, nil, int64(0)},
+					{3, float64(5), 5, 5, float64(0), nil, float64(0), nil, int64(1)},
+					{4, float64(5), 5, 5, float64(0), nil, float64(0), nil, int64(1)},
+					{5, nil, nil, nil, nil, nil, nil, nil, int64(0)},
+				},
+			},
+			{
+				Query: `SELECT id,
+					AVG(v) OVER w, MIN(v) OVER w, MAX(v) OVER w,
+					STDDEV_POP(v) OVER w, STDDEV_SAMP(v) OVER w,
+					VAR_POP(v) OVER w, VAR_SAMP(v) OVER w, COUNT(v) OVER w
+					FROM nullable_window_intervals
+					WINDOW w AS (ORDER BY id ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+					ORDER BY id`,
+				Expected: []sql.Row{
+					{1, nil, nil, nil, nil, nil, nil, nil, int64(0)},
+					{2, float64(5), 5, 5, float64(0), nil, float64(0), nil, int64(1)},
+					{3, float64(5), 5, 5, float64(0), nil, float64(0), nil, int64(1)},
+					{4, nil, nil, nil, nil, nil, nil, nil, int64(0)},
+					{5, nil, nil, nil, nil, nil, nil, nil, int64(0)},
+				},
+			},
+		},
+	},
+	{
 		// https://github.com/dolthub/dolt/issues/11381
 		Name: "window aggregate functions with order by col",
 		SetUpScript: []string{

--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -961,15 +961,31 @@ var WindowFunctionsScriptTests = []ScriptTest{
 		},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/11410
 		Name: "window SUM over all-NULL frames",
 		SetUpScript: []string{
-			"CREATE TABLE window_sum_nulls (id INT PRIMARY KEY, v INT)",
-			"INSERT INTO window_sum_nulls VALUES (1, NULL)",
+			"CREATE TABLE t(id INT PRIMARY KEY, v INT);",
+			"INSERT INTO t VALUES (1, NULL);",
 		},
-		Query: `SELECT id, SUM(v) OVER (
-			ORDER BY id ROWS BETWEEN CURRENT ROW AND CURRENT ROW
-		) FROM window_sum_nulls ORDER BY id`,
-		Expected: []sql.Row{{1, nil}},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `SELECT id,
+					SUM(v) OVER (
+						ORDER BY id
+						ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+					) AS wf
+				FROM t
+				ORDER BY id;`,
+				Expected: []sql.Row{{1, nil}},
+			},
+			{
+				Query: `SELECT o.id,
+					(SELECT SUM(i.v) FROM t AS i WHERE i.id = o.id) AS wf
+				FROM t AS o
+				ORDER BY o.id;`,
+				Expected: []sql.Row{{1, nil}},
+			},
+		},
 	},
 	{
 		// https://github.com/dolthub/dolt/issues/11381

--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -25,6 +25,17 @@ import (
 // first_value, last_value, lead, lag, and the bitwise aggregate functions.
 var WindowFunctionsScriptTests = []ScriptTest{
 	{
+		Name: "window SUM over all-NULL frames",
+		SetUpScript: []string{
+			"CREATE TABLE window_sum_nulls (id INT PRIMARY KEY, v INT)",
+			"INSERT INTO window_sum_nulls VALUES (1, NULL)",
+		},
+		Query: `SELECT id, SUM(v) OVER (
+			ORDER BY id ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+		) FROM window_sum_nulls ORDER BY id`,
+		Expected: []sql.Row{{1, nil}},
+	},
+	{
 		Name: "INET_NTOA round trip above signed 32-bit range",
 		SetUpScript: []string{
 			"CREATE TABLE inet_ntoa_test (ip VARCHAR(15))",

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -129,6 +129,7 @@ type SumAgg struct {
 	baseWindowFunction
 	// use prefix sums to quickly calculate arbitrary frame sum within partition
 	prefixSum      []float64
+	nullCnt        []int
 	partitionStart int
 	partitionEnd   int
 }
@@ -165,7 +166,7 @@ func (a *SumAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, b
 	a.partitionStart, a.partitionEnd = interval.Start, interval.End
 	a.Dispose(ctx)
 	var err error
-	a.prefixSum, _, err = floatPrefixSum(ctx, interval, buf, a.expr)
+	a.prefixSum, a.nullCnt, err = floatPrefixSum(ctx, interval, buf, a.expr)
 	return err
 }
 
@@ -175,6 +176,15 @@ func (a *SumAgg) NewSlidingFrameInterval(added, dropped sql.WindowInterval) {
 
 func (a *SumAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) (interface{}, error) {
 	if interval.End-interval.Start < 1 {
+		return nil, nil
+	}
+	startIdx := interval.Start - a.partitionStart - 1
+	endIdx := interval.End - a.partitionStart - 1
+	nullCnt := a.nullCnt[endIdx]
+	if startIdx >= 0 {
+		nullCnt -= a.nullCnt[startIdx]
+	}
+	if nullCnt == interval.End-interval.Start {
 		return nil, nil
 	}
 	return computePrefixSum(interval, a.partitionStart, a.prefixSum), nil

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -184,6 +184,7 @@ func (a *SumAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.
 	if startIdx >= 0 {
 		nullCnt -= a.nullCnt[startIdx]
 	}
+	// SUM returns NULL when the frame has no non-NULL values.
 	if nullCnt == interval.End-interval.Start {
 		return nil, nil
 	}
@@ -291,6 +292,10 @@ func (a *AvgAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.
 	if startIdx >= 0 {
 		nonNullCnt -= startIdx + 1
 		nonNullCnt += a.nullCnt[startIdx]
+	}
+	// AVG returns NULL when the frame has no non-NULL values.
+	if nonNullCnt == 0 {
+		return nil, nil
 	}
 	return computePrefixSum(interval, a.partitionStart, a.prefixSum) / float64(nonNullCnt), nil
 }


### PR DESCRIPTION
Returns NULL when a window SUM frame contains no non-NULL values.

Fixes https://github.com/dolthub/dolt/issues/11410