### PR TITLE
Fix correlated subqueries alongside window functions

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -36,6 +36,31 @@ var WindowFunctionsScriptTests = []ScriptTest{
 		Expected: []sql.Row{{"192.0.2.1"}},
 	},
 	{
+		Name: "window functions preserve correlated subquery columns",
+		SetUpScript: []string{
+			"CREATE TABLE window_correlated (id INT PRIMARY KEY, c0 INT, c1 INT)",
+			"INSERT INTO window_correlated VALUES (1, 10, 100), (2, 10, 200), (3, 20, 300)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT id, COUNT(*) OVER (PARTITION BY c0) AS w, (SELECT COUNT(*) FROM window_correlated t2 WHERE t2.c0 = t.c0) AS r FROM window_correlated t ORDER BY id",
+				Expected: []sql.Row{
+					{1, int64(2), int64(2)},
+					{2, int64(2), int64(2)},
+					{3, int64(1), int64(1)},
+				},
+			},
+			{
+				Query: "SELECT id, ROW_NUMBER() OVER (ORDER BY id) AS rn, (SELECT SUM(t2.c1) FROM window_correlated t2 WHERE t2.c0 = t.c0) AS s FROM window_correlated t ORDER BY id",
+				Expected: []sql.Row{
+					{1, int64(1), float64(300)},
+					{2, int64(2), float64(300)},
+					{3, int64(3), float64(300)},
+				},
+			},
+		},
+	},
+	{
 		Name: "ceil and floor do not mutate shared decimal window results",
 		SetUpScript: []string{
 			"CREATE TABLE decimal_window_values (id BIGINT, d DECIMAL(10,2))",

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -631,7 +631,8 @@ func (b *Builder) buildWindow(fromScope, projScope *scope) *scope {
 		}
 
 		// projection dependencies -> table cols needed above
-		transform.InspectExpr(b.ctx, col.scalar, func(ctx *sql.Context, e sql.Expression) bool {
+		var findSelectDeps func(*sql.Context, sql.Expression) bool
+		findSelectDeps = func(ctx *sql.Context, e sql.Expression) bool {
 			switch e := e.(type) {
 			case *expression.GetField:
 				colName := strings.ToLower(e.String())
@@ -640,10 +641,17 @@ func (b *Builder) buildWindow(fromScope, projScope *scope) *scope {
 					selectGfs = append(selectGfs, e)
 					selectStr[colName] = true
 				}
+			case *plan.Subquery:
+				e.Correlated().ForEach(func(colId sql.ColumnId) {
+					if correlated, found := projScope.parent.getCol(colId); found {
+						findSelectDeps(ctx, correlated.scalarGf())
+					}
+				})
 			default:
 			}
 			return false
-		})
+		}
+		transform.InspectExpr(b.ctx, col.scalar, findSelectDeps)
 	}
 	for _, e := range fromScope.extraCols {
 		// accessory cols used by ORDER_BY, HAVING


### PR DESCRIPTION
Window planning preserves ordinary projection dependencies, but did not preserve outer columns referenced only through a correlated scalar subquery. This left the subquery reading a stale post-window ordinal and silently producing empty-match results.

Carry correlated outer columns through the window node using the same column-ID dependency handling already used by aggregation planning. Add engine regressions for correlated `COUNT` and `SUM` alongside two different window functions.

Fixes dolthub/dolt#11478