### PR TITLE
Fix constant window expression partitions

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -25,6 +25,43 @@ import (
 // first_value, last_value, lead, lag, and the bitwise aggregate functions.
 var WindowFunctionsScriptTests = []ScriptTest{
 	{
+		Name: "literal window expressions over zero-width projected rows",
+		SetUpScript: []string{
+			"CREATE TABLE literal_windows (x int, g int)",
+			"INSERT INTO literal_windows VALUES (1, 1), (2, 1), (3, 2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT COUNT(*) OVER () FROM literal_windows",
+				Expected: []sql.Row{{int64(3)}, {int64(3)}, {int64(3)}},
+			},
+			{
+				Query:    "SELECT SUM(1) OVER () FROM literal_windows",
+				Expected: []sql.Row{{float64(3)}, {float64(3)}, {float64(3)}},
+			},
+			{
+				Query:    "SELECT COUNT(0) OVER (PARTITION BY 1 + 0) FROM literal_windows",
+				Expected: []sql.Row{{int64(3)}, {int64(3)}, {int64(3)}},
+			},
+			{
+				Query:    "SELECT RANK() OVER () FROM literal_windows",
+				Expected: []sql.Row{{uint64(1)}, {uint64(1)}, {uint64(1)}},
+			},
+			{
+				Query:    "SELECT RANK() OVER (ORDER BY 1 + 0) FROM literal_windows",
+				Expected: []sql.Row{{uint64(1)}, {uint64(1)}, {uint64(1)}},
+			},
+			{
+				Query:    "SELECT DENSE_RANK() OVER () FROM literal_windows",
+				Expected: []sql.Row{{uint64(1)}, {uint64(1)}, {uint64(1)}},
+			},
+			{
+				Query:    "SELECT PERCENT_RANK() OVER () FROM literal_windows",
+				Expected: []sql.Row{{float64(0)}, {float64(0)}, {float64(0)}},
+			},
+		},
+	},
+	{
 		Name: "INET_NTOA round trip above signed 32-bit range",
 		SetUpScript: []string{
 			"CREATE TABLE inet_ntoa_test (ip VARCHAR(15))",

--- a/sql/expression/function/aggregation/window_framer.go
+++ b/sql/expression/function/aggregation/window_framer.go
@@ -582,10 +582,16 @@ func nextPeerGroup(ctx *sql.Context, pos, partitionEnd int, orderBy []sql.Expres
 	return sql.WindowInterval{Start: pos, End: i}, nil
 }
 
-// isNewOrderByValue compares the order by columns between two rows, returning true when the last row is null or
-// when the next row's orderBy columns are unique
+// isNewOrderByValue reports whether row begins a new ORDER BY peer group after last.
 func isNewOrderByValue(ctx *sql.Context, orderByExprs []sql.Expression, last sql.Row, row sql.Row) (bool, error) {
-	if len(last) == 0 {
+	// Without ORDER BY, every row in the partition belongs to the same peer group.
+	if len(orderByExprs) == 0 {
+		return false, nil
+	}
+
+	// A non-nil zero-width row is still a row. This occurs when projection pushdown
+	// removes every source column used by a window expression.
+	if last == nil {
 		return true, nil
 	}
 

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -329,7 +329,9 @@ func partitionsToSortConditions(partitionExprs []sql.Expression) sql.SortConditi
 }
 
 func isNewPartition(ctx *sql.Context, partitionBy []sql.Expression, last sql.Row, row sql.Row) (bool, error) {
-	if len(last) == 0 {
+	// A non-nil zero-width row is still a row. This occurs when projection pushdown
+	// removes every source column used by a window expression.
+	if last == nil {
 		return true, nil
 	}
 


### PR DESCRIPTION
Constant-only window expressions can leave zero-width projected rows. Partition and peer-group detection treated those rows as uninitialized, splitting every input row into its own partition or peer group.

Use nil as the uninitialized-row sentinel and treat an absent `ORDER BY` as one peer group. Add current script-suite coverage for constant aggregate, partition, and ordering expressions, validated against MySQL 8.0.45 and PostgreSQL 15.17.

This adapts and supersedes the core fix contributed by @vishnujayvel in #3684. Credit also goes to @wanteatfruit for the report.

Fixes dolthub/dolt#11409