### PR TITLE
Fix `SELECT` list alias resolution in window clauses

### DIFF
--- a/enginetest/queries/column_alias_queries.go
+++ b/enginetest/queries/column_alias_queries.go
@@ -264,6 +264,75 @@ var ColumnAliasQueries = []ScriptTest{
 		},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/11502
+		Name: "column aliases in window definitions",
+		SetUpScript: []string{
+			"create table t (id int primary key, g int, k int, v int);",
+			"insert into t values (1,1,1,25),(2,0,0,-37),(3,1,-2,85);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `select id, g, k as order_alias,
+					lag(v) over (partition by g order by order_alias, id) as prev_v,
+					lead(v) over (partition by g order by order_alias, id) as next_v
+					from t order by id;`,
+				ExpectedErrStr: "Unknown column 'order_alias' in 'window order by'",
+			},
+			{
+				Query:          "select k as order_alias, lag(v) over (order by order_alias) as p from t;",
+				ExpectedErrStr: "Unknown column 'order_alias' in 'window order by'",
+			},
+			{
+				Query:          "select k as order_key, lag(v) over (order by ORDER_KEY) as p from t;",
+				ExpectedErrStr: "Unknown column 'order_key' in 'window order by'",
+			},
+			{
+				Query:          "select g as part_alias, lag(v) over (partition by part_alias order by id) as p from t;",
+				ExpectedErrStr: "Unknown column 'part_alias' in 'window partition by'",
+			},
+			{
+				Query:          "select k as order_alias, lag(v) over (order by nosuchcol) as p from t;",
+				ExpectedErrStr: "Unknown column 'nosuchcol' in 'window order by'",
+			},
+			{
+				Query:          "select k as order_alias, lag(v) over w as p from t window w as (order by order_alias);",
+				ExpectedErrStr: "Unknown column 'order_alias' in 'window order by'",
+			},
+			{
+				Query:    "select id, k as order_alias, lag(v) over (order by order_alias + 0) as p from t order by id;",
+				Expected: []sql.Row{{1, 1, -37}, {2, 0, 85}, {3, -2, nil}},
+			},
+			{
+				Query:    "select id, g as part_alias, lag(v) over (partition by part_alias + 0 order by id) as p from t order by id;",
+				Expected: []sql.Row{{1, 1, nil}, {2, 0, nil}, {3, 1, 25}},
+			},
+			{
+				Query:    "select id, k + 10 as ke, lag(v) over (order by ke + 0) as p from t order by id;",
+				Expected: []sql.Row{{1, 11, -37}, {2, 10, 85}, {3, 8, nil}},
+			},
+			{
+				Query:    "select id, k as ka, lag(v) over (order by abs(ka)) as p from t order by id;",
+				Expected: []sql.Row{{1, 1, -37}, {2, 0, nil}, {3, -2, 25}},
+			},
+			{
+				Query:    "select id, v as k, lag(v) over (order by k) as p from t order by id;",
+				Expected: []sql.Row{{1, 25, -37}, {2, -37, 85}, {3, 85, nil}},
+			},
+			{
+				Query:    "select id, k as order_alias, lag(v) over (order by k, id) as p from t order by id;",
+				Expected: []sql.Row{{1, 1, -37}, {2, 0, 85}, {3, -2, nil}},
+			},
+			{
+				Query:    "select id, g, k as order_alias, lag(v) over (partition by g order by k, id) as prev_v from t order by order_alias;",
+				Expected: []sql.Row{{3, 1, -2, nil}, {2, 0, 0, nil}, {1, 1, 1, 85}},
+			},
+			{
+				Query:    "select id, k as ORDER_ALIAS, lag(v) over (order by order_alias + 0) as p from t order by id;",
+				Expected: []sql.Row{{1, 1, -37}, {2, 0, 85}, {3, -2, nil}},
+			},
+		},
+	},
+	{
 		Name: "various broken alias queries",
 		Skip: true,
 		Assertions: []ScriptTestAssertion{

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -741,7 +741,7 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 	sortConditions := make(sql.SortConditions, len(def.OrderBy))
 	for i, c := range def.OrderBy {
 		// resolve col in fromScope
-		e := b.buildScalar(fromScope, c.Expr)
+		e := b.buildWindowClauseScalar(fromScope, c.Expr, "window order by")
 		so := sql.Ascending
 		if c.Direction == ast.DescScr {
 			so = sql.Descending
@@ -755,7 +755,7 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 
 	partitions := make([]sql.Expression, len(def.PartitionBy))
 	for i, expr := range def.PartitionBy {
-		partitions[i] = b.buildScalar(fromScope, expr)
+		partitions[i] = b.buildWindowClauseScalar(fromScope, expr, "window partition by")
 	}
 
 	frame := b.NewFrame(fromScope, def.Frame)
@@ -781,6 +781,22 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 	}
 
 	return windowDef
+}
+
+// buildWindowClauseScalar builds an expression inside a window
+// PARTITION BY or ORDER BY clause.
+//
+// In window clauses, a plain alias reference (e.g. "ORDER BY my_alias")
+// is not allowed, but an expression using an alias (e.g. "ORDER BY
+// my_alias + 1") is allowed and resolves to the underlying expression.
+// See [window functions], [column aliases].
+//
+// [window functions]: https://dev.mysql.com/doc/refman/8.4/en/window-functions-usage.html
+// [column aliases]: https://dev.mysql.com/doc/refman/8.4/en/problems-with-alias.html
+func (b *Builder) buildWindowClauseScalar(inScope *scope, e ast.Expr, clause string) sql.Expression {
+	_, isColRef := e.(*ast.ColName)
+	defer b.withWindowState(clause, isColRef)()
+	return b.buildScalar(inScope, e)
 }
 
 // windowDisplayName returns a human-readable label for a window definition, for use in error

--- a/sql/planbuilder/builder.go
+++ b/sql/planbuilder/builder.go
@@ -49,6 +49,14 @@ type Builder struct {
 	tabId sql.TableId
 	colId columnId
 
+	// windowClause tracks whether we are currently building an expression
+	// inside a window clause (e.g. "window order by") or empty otherwise.
+	windowClause string
+
+	// windowClauseColRef is true if the window clause is a single column
+	// name (not a composite expression like a + 1).
+	windowClauseColRef bool
+
 	authEnabled  bool
 	multiDDL     bool
 	insertActive bool
@@ -190,6 +198,12 @@ func (b *Builder) TriggerCtx() *TriggerContext {
 
 func (b *Builder) newScope() *scope {
 	return &scope{b: b}
+}
+
+func (b *Builder) withWindowState(clause string, isColRef bool) func() {
+	outerClause, outerColRef := b.windowClause, b.windowClauseColRef
+	b.windowClause, b.windowClauseColRef = clause, isColRef
+	return func() { b.windowClause, b.windowClauseColRef = outerClause, outerColRef }
 }
 
 func (b *Builder) Reset() {

--- a/sql/planbuilder/project.go
+++ b/sql/planbuilder/project.go
@@ -37,7 +37,12 @@ func (b *Builder) analyzeSelectList(inScope, outScope *scope, selectExprs ast.Se
 	// interleave tempScope between inScope and parent, namespace for
 	// alias accumulation within SELECT
 	tempScope := inScope.replace()
+	tempScope.selectAliasScope = true
 	inScope.parent = tempScope
+
+	// Reset window state so nested subqueries in the SELECT list
+	// do not inherit this outer query's window context.
+	defer b.withWindowState("", false)()
 
 	// need to transfer aggregation state from out -> in
 	var exprs []sql.Expression
@@ -168,9 +173,9 @@ func (b *Builder) analyzeSelectList(inScope, outScope *scope, selectExprs ast.Se
 				tempScope.addColumn(col)
 			}
 			if inScope.selectAliases == nil {
-				inScope.selectAliases = make(map[string]sql.Expression)
+				inScope.selectAliases = make(map[string]*expression.Alias)
 			}
-			inScope.selectAliases[e.Name()] = e
+			inScope.selectAliases[strings.ToLower(e.Name())] = e
 			exprs = append(exprs, e)
 		case *expression.Literal:
 			exprs = append(exprs, e)

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -138,7 +138,15 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 		c, ok := inScope.resolveColumn(dbName, tblName, colName, true, false)
 		if !ok {
 			if aliasedExpr, ok := inScope.selectAliases[colName]; ok {
-				return aliasedExpr
+				switch {
+				case b.windowClause == "":
+					return aliasedExpr
+				case b.windowClauseColRef:
+					b.handleErr(sql.ErrUnknownColumn.New(colName, b.windowClause))
+				default:
+					// Use the expression that the alias stands for.
+					return aliasedExpr.Child
+				}
 			}
 			// Only try system variable lookup if there's no table qualifier.
 			// Qualified names like "A.timestamp" are always column references, never system variables.
@@ -207,6 +215,9 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 				}
 				return tableExpr
 			} else {
+				if b.windowClause != "" {
+					b.handleErr(sql.ErrUnknownColumn.New(colName, b.windowClause))
+				}
 				err := sql.ErrColumnNotFound.New(v)
 				b.handleErr(err)
 			}

--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -40,7 +40,7 @@ type scope struct {
 	tables              map[string]sql.TableId
 	oldTables           map[sql.TableId]string
 	windowDefs          map[string]*sql.WindowDefinition
-	selectAliases       map[string]sql.Expression
+	selectAliases       map[string]*expression.Alias
 	insertColumnAliases map[string]string
 
 	// redirectCol is used for using and natural joins right-table
@@ -68,6 +68,9 @@ type scope struct {
 	// windowFuncs is a list of window functions in the current scope
 	windowFuncs []scopeColumn
 
+	// selectAliasScope marks the temporary SELECT list alias scope.
+	selectAliasScope bool
+
 	refsSubquery bool
 
 	schemaName string
@@ -94,7 +97,13 @@ func (s *scope) resolveColumn(db, table, col string, checkParent, chooseFirst bo
 
 	var found scopeColumn
 	var foundCand bool
+	// In window clauses (PARTITION BY, ORDER BY), column names must match
+	// table columns, not same-level SELECT aliases with the same name.
+	hideAliases := s.selectAliasScope && s.b.windowClause != ""
 	for _, c := range s.cols {
+		if hideAliases {
+			break
+		}
 		if strings.EqualFold(c.col, col) && (strings.EqualFold(c.table, table) || table == "") && (strings.EqualFold(c.db, db) || db == "") {
 			if foundCand {
 				if found.equals(c) {
@@ -501,7 +510,7 @@ func (s *scope) copy(ctx *sql.Context) *scope {
 		ret.colset = s.colset.Copy()
 	}
 	if s.selectAliases != nil {
-		ret.selectAliases = make(map[string]sql.Expression, len(s.selectAliases))
+		ret.selectAliases = make(map[string]*expression.Alias, len(s.selectAliases))
 		for k, v := range s.selectAliases {
 			ret.selectAliases[k] = v
 		}


### PR DESCRIPTION
Fixes an issue where window function clauses could incorrectly resolve or shadow column references using SELECT list aliases.
- Allow expressions in window clauses to reference `SELECT` list aliases while preserving resolution to underlying table columns.
- Normalizes `SELECT` list alias lookup keys to lower case for consistent case-insensitive matching.
Fix dolthub/dolt#11502