### PR TITLE
Count nonnumeric strings as non-null in window AVG and SUM

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -92,6 +92,49 @@ var WindowFunctionsScriptTests = []ScriptTest{
 		Expected: []sql.Row{{13}},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/11470
+		Name:    "Window AVG drops a non-NULL nonnumeric VARCHAR",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"CREATE TABLE t(id INT PRIMARY KEY, v VARCHAR(8));",
+			"INSERT INTO t VALUES (1, 'aa'), (2, NULL), (3, '10');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `SELECT id,
+       AVG(v) OVER (
+         ORDER BY id
+         ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+       ) AS wf
+FROM t
+ORDER BY id;`,
+				Expected: []sql.Row{
+					{1, float64(0)},
+					{2, nil},
+					{3, float64(10)},
+				},
+			},
+			{
+				Query: `SELECT id,
+       AVG(v) OVER (
+         ORDER BY id
+         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+       ) AS wf_avg,
+       SUM(v) OVER (
+         ORDER BY id
+         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+       ) AS wf_sum
+FROM t
+ORDER BY id;`,
+				Expected: []sql.Row{
+					{1, float64(0), float64(0)},
+					{2, float64(0), float64(0)},
+					{3, float64(5), float64(10)},
+				},
+			},
+		},
+	},
+	{
 		Name: "window functions preserve correlated subquery columns",
 		SetUpScript: []string{
 			"CREATE TABLE window_correlated (id INT PRIMARY KEY, c0 INT, c1 INT)",

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -202,10 +202,15 @@ func floatPrefixSum(ctx *sql.Context, interval sql.WindowInterval, buf sql.Windo
 		if err != nil {
 			continue
 		}
+		if v == nil {
+			nullCnt += 1
+			sums[i] = last
+			nulls[i] = nullCnt
+			continue
+		}
 		val, _, err := types.Float64.Convert(ctx, v)
 		if err != nil || val == nil {
 			val = float64(0)
-			nullCnt += 1
 		}
 		last += val.(float64)
 		sums[i] = last

--- a/sql/expression/function/aggregation/window_functions_test.go
+++ b/sql/expression/function/aggregation/window_functions_test.go
@@ -413,5 +413,24 @@ func TestWindowedAggFuncs(t *testing.T) {
 			require.Equal(t, tt.Expected, res)
 		})
 	}
+}
 
+func TestAvgAgg_NonNumericVarchar(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	buf := []sql.Row{{"aa"}, {nil}, {"10"}}
+	p := sql.WindowInterval{Start: 0, End: len(buf)}
+
+	avg := NewAvgAgg(expression.NewGetField(0, types.LongText, "x", true))
+	require.NoError(t, avg.StartPartition(ctx, p, buf))
+	res, err := avg.Compute(ctx, sql.WindowInterval{Start: 0, End: 1}, buf)
+	require.NoError(t, err)
+	require.Equal(t, float64(0), res)
+
+	res, err = avg.Compute(ctx, sql.WindowInterval{Start: 1, End: 2}, buf)
+	require.NoError(t, err)
+	require.Nil(t, res)
+
+	res, err = avg.Compute(ctx, sql.WindowInterval{Start: 0, End: 3}, buf)
+	require.NoError(t, err)
+	require.Equal(t, float64(5), res)
 }


### PR DESCRIPTION
Fix dolthub/dolt#11470