### PR TITLE
Fix windows over grouped inputs

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -49,6 +49,64 @@ var WindowFunctionsScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "window function over grouped one-column input",
+		// PostgreSQL does not support the sql_mode setting required by this MySQL regression.
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"SET sql_mode = ''",
+			"CREATE TABLE grouped_window (id INT PRIMARY KEY, g INT, k INT, v INT)",
+			"INSERT INTO grouped_window VALUES (1,0,2,10), (2,0,1,20), (3,1,1,30)",
+			"CREATE TABLE nullable_grouped_window (id INT PRIMARY KEY, g INT)",
+			"INSERT INTO nullable_grouped_window VALUES (1,NULL), (2,NULL), (3,1), (4,1), (5,2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT g, ROW_NUMBER() OVER (ORDER BY g) AS r FROM grouped_window GROUP BY g ORDER BY g",
+				Expected: []sql.Row{{0, int64(1)}, {1, int64(2)}},
+			},
+			{
+				Query:    "SELECT g, ROW_NUMBER() OVER (PARTITION BY g ORDER BY g) AS r FROM grouped_window GROUP BY g ORDER BY g",
+				Expected: []sql.Row{{0, int64(1)}, {1, int64(1)}},
+			},
+			{
+				Query:    "SELECT g, ROW_NUMBER() OVER (ORDER BY COUNT(*)) AS r FROM grouped_window GROUP BY g ORDER BY g",
+				Expected: []sql.Row{{0, int64(2)}, {1, int64(1)}},
+			},
+			{
+				Query:    "SELECT g, ROW_NUMBER() OVER (ORDER BY g) + 10 AS r FROM grouped_window GROUP BY g ORDER BY g",
+				Expected: []sql.Row{{0, int64(11)}, {1, int64(12)}},
+			},
+			{
+				Query:    "SELECT g, ROW_NUMBER() OVER (ORDER BY g) AS r FROM grouped_window GROUP BY g HAVING g = 1 ORDER BY g",
+				Expected: []sql.Row{{1, int64(1)}},
+			},
+			{
+				Query:    "SELECT g, COUNT(*) AS n, ROW_NUMBER() OVER (PARTITION BY g ORDER BY g) AS r FROM grouped_window GROUP BY g ORDER BY g",
+				Expected: []sql.Row{{0, int64(2), int64(1)}, {1, int64(1), int64(1)}},
+			},
+			{
+				Query:    "SELECT g, ROW_NUMBER() OVER (PARTITION BY g ORDER BY g) AS r, COUNT(*) AS n FROM grouped_window GROUP BY g ORDER BY g",
+				Expected: []sql.Row{{0, int64(1), int64(2)}, {1, int64(1), int64(1)}},
+			},
+			{
+				Query:    "SELECT g, COUNT(*) AS n, ROW_NUMBER() OVER (PARTITION BY g ORDER BY g) AS r FROM nullable_grouped_window GROUP BY g ORDER BY g",
+				Expected: []sql.Row{{nil, int64(2), int64(1)}, {1, int64(2), int64(1)}, {2, int64(1), int64(1)}},
+			},
+			{
+				Query:    "SELECT ROW_NUMBER() OVER (ORDER BY g) + g AS mixed FROM grouped_window GROUP BY g ORDER BY g",
+				Expected: []sql.Row{{int64(1)}, {int64(3)}},
+			},
+			{
+				Query:    "SELECT COUNT(*) + ROW_NUMBER() OVER (ORDER BY g) AS mixed FROM grouped_window GROUP BY g",
+				Expected: []sql.Row{{int64(3)}, {int64(3)}},
+			},
+			{
+				Query:       "SELECT SUM(ROW_NUMBER() OVER (ORDER BY g)) FROM grouped_window GROUP BY g",
+				ExpectedErr: sql.ErrNonAggregatedColumnWithoutGroupBy,
+			},
+		},
+	},
+	{
 		Name: "literal window expressions over zero-width projected rows",
 		SetUpScript: []string{
 			"CREATE TABLE literal_windows (x int, g int)",

--- a/sql/expression/function/aggregation/window_iter.go
+++ b/sql/expression/function/aggregation/window_iter.go
@@ -50,7 +50,7 @@ var _ sql.Disposable = (*WindowIter)(nil)
 // Close implements sql.RowIter
 func (i *WindowIter) Close(ctx *sql.Context) error {
 	i.Dispose(ctx)
-	var err error
+	err := i.iter.Close(ctx)
 	for _, p := range i.partitionIters {
 		e := p.Close(ctx)
 		if err == nil && e != nil {

--- a/sql/expression/function/aggregation/window_iter_test.go
+++ b/sql/expression/function/aggregation/window_iter_test.go
@@ -16,6 +16,7 @@ package aggregation
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,18 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
+
+type closeTrackingIter struct {
+	sql.RowIter
+	closeCount int
+	closeErr   error
+}
+
+// Close records the call and returns the configured error.
+func (i *closeTrackingIter) Close(*sql.Context) error {
+	i.closeCount++
+	return i.closeErr
+}
 
 var (
 	partitionByX = []sql.Expression{
@@ -99,4 +112,18 @@ func TestWindowIter(t *testing.T) {
 			require.Equal(t, tt.Expected, res)
 		})
 	}
+}
+
+// TestWindowIterClose verifies that closing a window iterator releases its child and partitions.
+func TestWindowIterClose(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	closeErr := errors.New("close error")
+	child := &closeTrackingIter{closeErr: closeErr}
+	partition := NewWindowPartitionIter(&WindowPartition{})
+	partition.input = sql.WindowBuffer{{1}}
+
+	iter := NewWindowIter([]*WindowPartitionIter{partition}, [][]int{{0}}, child)
+	require.ErrorIs(t, iter.Close(ctx), closeErr)
+	require.Equal(t, 1, child.closeCount)
+	require.Nil(t, partition.input)
 }

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -185,7 +185,7 @@ func (b *Builder) buildNameConst(fromScope *scope, f *ast.FuncExpr) sql.Expressi
 	return expression.NewAlias(b.ctx, aliasStr, vLit)
 }
 
-func (b *Builder) buildAggregation(fromScope, projScope *scope, groupingCols []sql.Expression) *scope {
+func (b *Builder) buildAggregation(fromScope, projScope *scope, groupingCols []sql.Expression, having *ast.Where) *scope {
 	b.qFlags.Set(sql.QFlagAggregation)
 
 	// GROUP_BY consists of:
@@ -202,12 +202,51 @@ func (b *Builder) buildAggregation(fromScope, projScope *scope, groupingCols []s
 	var selectGfs []sql.Expression
 	selectStr := make(map[string]bool)
 	aliasDeps := make(map[string]bool)
+	windowCols := make(map[columnId]struct{}, len(fromScope.windowFuncs))
+	for _, col := range fromScope.windowFuncs {
+		windowCols[col.id] = struct{}{}
+	}
+	var inspectSelectDeps func(sql.Expression, bool) bool
+	inspectSelectDeps = func(expr sql.Expression, inAlias bool) (hasWindowDep bool) {
+		transform.InspectExpr(b.ctx, expr, func(ctx *sql.Context, e sql.Expression) bool {
+			switch e := e.(type) {
+			case *expression.GetField:
+				if _, ok := windowCols[columnId(e.Id())]; ok {
+					hasWindowDep = true
+					return true
+				}
+				colName := strings.ToLower(e.String())
+				if !selectStr[colName] {
+					selectDeps = append(selectDeps, e)
+					selectGfs = append(selectGfs, e)
+					selectStr[colName] = true
+				}
+
+				if isAliasDep, ok := aliasDeps[colName]; !ok && inAlias {
+					aliasDeps[colName] = true
+				} else if isAliasDep && !inAlias {
+					aliasDeps[colName] = false
+				}
+			case *plan.Subquery:
+				e.Correlated().ForEach(func(colId sql.ColumnId) {
+					if correlated, found := projScope.parent.getCol(colId); found {
+						hasWindowDep = inspectSelectDeps(correlated.scalarGf(), inAlias) || hasWindowDep
+					}
+				})
+			}
+			return false
+		})
+		return hasWindowDep
+	}
 	for _, e := range group.aggregations() {
 		if !selectStr[strings.ToLower(e.String())] {
 			selectDeps = append(selectDeps, e.scalar)
 			selectGfs = append(selectGfs, e.scalarGf())
 			selectStr[strings.ToLower(e.String())] = true
 		}
+	}
+	for _, col := range fromScope.windowFuncs {
+		inspectSelectDeps(col.scalar, false)
 	}
 	var aliases []sql.Expression
 	for _, col := range projScope.cols {
@@ -216,41 +255,15 @@ func (b *Builder) buildAggregation(fromScope, projScope *scope, groupingCols []s
 		switch e := col.scalar.(type) {
 		case *expression.Alias:
 			if !e.Unreferencable() {
-				aliases = append(aliases, e.WithId(sql.ColumnId(col.id)).(*expression.Alias))
 				inAlias = true
 			}
 		default:
 		}
 
-		var findSelectDeps func(*sql.Context, sql.Expression) bool
-		findSelectDeps = func(ctx *sql.Context, e sql.Expression) bool {
-			switch e := e.(type) {
-			case *expression.GetField:
-				colName := strings.ToLower(e.String())
-				if !selectStr[colName] {
-					selectDeps = append(selectDeps, e)
-					selectGfs = append(selectGfs, e)
-					selectStr[colName] = true
-				}
-
-				exprStr := strings.ToLower(e.String())
-				if isAliasDep, ok := aliasDeps[exprStr]; !ok && inAlias {
-					aliasDeps[exprStr] = true
-				} else if isAliasDep && !inAlias {
-					aliasDeps[exprStr] = false
-				}
-			case *plan.Subquery:
-				e.Correlated().ForEach(func(colId sql.ColumnId) {
-					if correlated, found := projScope.parent.getCol(colId); found {
-						findSelectDeps(ctx, correlated.scalarGf())
-					}
-				})
-			default:
-			}
-			return false
+		hasWindowDep := inspectSelectDeps(col.scalar, inAlias)
+		if inAlias && !hasWindowDep {
+			aliases = append(aliases, col.scalar.(*expression.Alias).WithId(sql.ColumnId(col.id)).(*expression.Alias))
 		}
-
-		transform.InspectExpr(b.ctx, col.scalar, findSelectDeps)
 	}
 	for _, e := range fromScope.extraCols {
 		// accessory cols used by ORDER_BY, HAVING
@@ -266,6 +279,12 @@ func (b *Builder) buildAggregation(fromScope, projScope *scope, groupingCols []s
 
 	if len(aliases) > 0 {
 		outScope.node = plan.NewProject(b.ctx, append(selectGfs, aliases...), outScope.node).WithAliasDeps(aliasDeps)
+	}
+
+	b.buildHaving(fromScope, projScope, outScope, having)
+	if len(fromScope.windowFuncs) > 0 {
+		outScope.windowFuncs = fromScope.windowFuncs
+		outScope = b.buildWindow(outScope, projScope)
 	}
 	return outScope
 }
@@ -289,11 +308,6 @@ func IsMySQLAggregateFuncName(ctx *sql.Context, name string) (bool, error) {
 // buildAggregateFunc tags aggregate functions in the correct scope
 // and makes the aggregate available for reference by other clauses.
 func (b *Builder) buildAggregateFunc(inScope *scope, name string, e *ast.FuncExpr) sql.Expression {
-	if len(inScope.windowFuncs) > 0 {
-		err := sql.ErrNonAggregatedColumnWithoutGroupBy.New()
-		b.handleErr(err)
-	}
-
 	inScope.initGroupBy()
 	gb := inScope.groupBy
 
@@ -383,7 +397,11 @@ func (b *Builder) newAggregation(e *ast.FuncExpr, name string, args []sql.Expres
 func (b *Builder) buildAggFunctionArgs(inScope *scope, e *ast.FuncExpr, gb *groupBy) []sql.Expression {
 	var args []sql.Expression
 	for _, arg := range e.Exprs {
+		windowCount := len(inScope.windowFuncs)
 		e := b.selectExprToExpression(inScope, arg)
+		if len(inScope.windowFuncs) > windowCount {
+			b.handleErr(sql.ErrNonAggregatedColumnWithoutGroupBy.New())
+		}
 		// if GetField is an alias, alias must be masking a column
 		if gf, ok := e.(*expression.GetField); ok && gf.TableId() == 0 {
 			e = b.selectExprToExpression(inScope.parent, arg)
@@ -529,11 +547,6 @@ func IsMySQLWindowFuncName(ctx *sql.Context, name string) (bool, error) {
 }
 
 func (b *Builder) buildWindowFunc(inScope *scope, name string, e *ast.FuncExpr, over *ast.WindowDef) sql.Expression {
-	if inScope.groupBy != nil {
-		err := sql.ErrNonAggregatedColumnWithoutGroupBy.New()
-		b.handleErr(err)
-	}
-
 	// internal expressions can be complex, but window can't be more than alias
 	var args []sql.Expression
 	for _, arg := range e.Exprs {

--- a/sql/planbuilder/select.go
+++ b/sql/planbuilder/select.go
@@ -92,9 +92,10 @@ func (b *Builder) buildSelect(inScope *scope, s *ast.Select) (outScope *scope) {
 
 	// At this point we've recorded dependencies for higher-level scopes,
 	// so we can build the FROM clause
-	if b.needsAggregation(fromScope, s) {
+	needsAggregation := b.needsAggregation(fromScope, s)
+	if needsAggregation {
 		groupingCols := b.buildGroupingCols(fromScope, projScope, s.GroupBy, s.SelectExprs)
-		outScope = b.buildAggregation(fromScope, projScope, groupingCols)
+		outScope = b.buildAggregation(fromScope, projScope, groupingCols, s.Having)
 	} else if fromScope.windowFuncs != nil {
 		outScope = b.buildWindow(fromScope, projScope)
 	} else {
@@ -106,7 +107,9 @@ func (b *Builder) buildSelect(inScope *scope, s *ast.Select) (outScope *scope) {
 	// expressions in higher level scopes will be replaced with GetField
 	// references.
 
-	b.buildHaving(fromScope, projScope, outScope, s.Having)
+	if !needsAggregation {
+		b.buildHaving(fromScope, projScope, outScope, s.Having)
+	}
 
 	b.buildOrderBy(outScope, orderByScope)
 


### PR DESCRIPTION
Build grouped window evaluation after aggregation and HAVING, preserving the grouped fields and aggregate results needed by window definitions and derived aliases. Allow aggregate and window expressions to coexist regardless of projection order while continuing to reject windows nested inside aggregate arguments. Also close the wrapped child iterator when a window iterator closes. Adds coverage for grouping, filtering, ordering, NULL groups, mixed aggregate/window aliases, invalid nesting, and iterator cleanup.

Fixes dolthub/dolt#11500