### PR TITLE
Return error for standalone interval expressions

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10086,6 +10086,10 @@ type QueryErrorTest struct {
 
 var ErrorQueries = []QueryErrorTest{
 	{
+		Query:       "SELECT INTERVAL 1 DAY",
+		ExpectedErr: sql.ErrIntervalInvalidUse,
+	},
+	{
 		Query:       "analyze table mytable update histogram on i using data 'unknown'",
 		ExpectedErr: planbuilder.ErrFailedToParseStats,
 	},

--- a/sql/analyzer/analyzererrors/errors.go
+++ b/sql/analyzer/analyzererrors/errors.go
@@ -55,13 +55,6 @@ var (
 			"but found value %q of type %s on %s",
 	)
 
-	// ErrIntervalInvalidUse is returned when an interval expression is not
-	// correctly used.
-	ErrIntervalInvalidUse = errors.NewKind(
-		"invalid use of an interval, which can only be used with DATE_ADD, " +
-			"DATE_SUB and +/- operators to subtract from or add to a date",
-	)
-
 	// ErrExplodeInvalidUse is returned when an EXPLODE function is used
 	// outside a Project node.
 	ErrExplodeInvalidUse = errors.NewKind(

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -586,7 +586,7 @@ func validateIntervalUsage(ctx *sql.Context, a *Analyzer, n sql.Node, scope *pla
 	})
 
 	if invalid {
-		return nil, transform.SameTree, analyzererrors.ErrIntervalInvalidUse.New()
+		return nil, transform.SameTree, sql.ErrIntervalInvalidUse.New()
 	}
 
 	return n, transform.SameTree, nil

--- a/sql/analyzer/validation_rules_test.go
+++ b/sql/analyzer/validation_rules_test.go
@@ -708,7 +708,7 @@ func TestValidateIntervalUsage(t *testing.T) {
 				require.NoError(err)
 			} else {
 				require.Error(err)
-				require.True(analyzererrors.ErrIntervalInvalidUse.Is(err))
+				require.True(sql.ErrIntervalInvalidUse.Is(err))
 			}
 		})
 	}

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -29,6 +29,12 @@ var (
 	// ErrUnsupportedFeature is thrown when a feature is not already supported
 	ErrUnsupportedFeature = errors.NewKind("unsupported feature: %s")
 
+	// ErrIntervalInvalidUse is returned when an interval expression is evaluated outside date arithmetic.
+	ErrIntervalInvalidUse = errors.NewKind(
+		"invalid use of an interval, which can only be used with DATE_ADD, " +
+			"DATE_SUB and +/- operators to subtract from or add to a date",
+	)
+
 	// ErrReadOnly is returned when the engine has been set to Read Only but a write operation was attempted.
 	ErrReadOnly = errors.NewKind("database server is set to read only mode")
 

--- a/sql/expression/interval.go
+++ b/sql/expression/interval.go
@@ -67,7 +67,7 @@ func (i *Interval) IsNullable(ctx *sql.Context) bool { return i.Child.IsNullable
 
 // Eval implements the sql.Expression interface.
 func (i *Interval) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	panic("Interval.Eval is just a placeholder method and should not be called directly")
+	return nil, sql.ErrIntervalInvalidUse.New()
 }
 
 var (


### PR DESCRIPTION
Standalone `INTERVAL` expressions can reach `Interval.Eval`, whose placeholder implementation panics. Return the shared invalid-use error instead, centralize that error in the `sql` package, and cover the public query behavior with an engine regression.

Fixes dolthub/dolt#11452