### PR TITLE
Fix merging nondeterministic window expressions

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -25,6 +25,30 @@ import (
 // first_value, last_value, lead, lag, and the bitwise aggregate functions.
 var WindowFunctionsScriptTests = []ScriptTest{
 	{
+		Name: "nondeterministic window expressions are evaluated independently",
+		SetUpScript: []string{
+			"CREATE TABLE nondeterministic_windows (id int primary key)",
+			"INSERT INTO nondeterministic_windows VALUES (1), (2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT id, a = b AS same FROM (SELECT id, FIRST_VALUE(UUID()) OVER (ORDER BY id) AS a, FIRST_VALUE(UUID()) OVER (ORDER BY id) AS b FROM nondeterministic_windows) q ORDER BY id",
+				Expected: []sql.Row{
+					{1, false},
+					{2, false},
+				},
+			},
+			{
+				Query:    "SELECT COUNT(DISTINCT a), COUNT(DISTINCT b), MIN(a <> b) FROM (SELECT FIRST_VALUE(UUID()) OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS a, FIRST_VALUE(UUID()) OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS b FROM nondeterministic_windows) q",
+				Expected: []sql.Row{{int64(1), int64(1), true}},
+			},
+			{
+				Query:    "SELECT COUNT(DISTINCT a), COUNT(DISTINCT b), MIN(a <> b) FROM (SELECT LAST_VALUE(UUID()) OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS a, LAST_VALUE(UUID()) OVER (ORDER BY id ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS b FROM nondeterministic_windows) q",
+				Expected: []sql.Row{{int64(1), int64(1), true}},
+			},
+		},
+	},
+	{
 		Name: "literal window expressions over zero-width projected rows",
 		SetUpScript: []string{
 			"CREATE TABLE literal_windows (x int, g int)",

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -639,6 +639,7 @@ func (a *MinAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.
 type LastAgg struct {
 	expr   sql.Expression
 	framer sql.WindowFramer
+	values map[int]interface{}
 }
 
 func NewLastAgg(e sql.Expression) *LastAgg {
@@ -673,6 +674,7 @@ func (a *LastAgg) DefaultFramer() sql.WindowFramer {
 
 func (a *LastAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) error {
 	a.Dispose(ctx)
+	clear(a.values)
 	return nil
 }
 
@@ -684,11 +686,19 @@ func (a *LastAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buffer 
 	if interval.End-interval.Start < 1 {
 		return nil, nil
 	}
-	row := buffer[interval.End-1]
+	rowIdx := interval.End - 1
+	if v, ok := a.values[rowIdx]; ok {
+		return v, nil
+	}
+	row := buffer[rowIdx]
 	v, err := a.expr.Eval(ctx, row)
 	if err != nil {
 		return nil, err
 	}
+	if a.values == nil {
+		a.values = make(map[int]interface{})
+	}
+	a.values[rowIdx] = v
 	return v, nil
 }
 
@@ -697,6 +707,7 @@ type FirstAgg struct {
 	framer         sql.WindowFramer
 	partitionStart int
 	partitionEnd   int
+	values         map[int]interface{}
 }
 
 func NewFirstAgg(e sql.Expression) *FirstAgg {
@@ -732,6 +743,7 @@ func (a *FirstAgg) DefaultFramer() sql.WindowFramer {
 func (a *FirstAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) error {
 	a.Dispose(ctx)
 	a.partitionStart, a.partitionEnd = interval.Start, interval.End
+	clear(a.values)
 	return nil
 }
 
@@ -743,11 +755,18 @@ func (a *FirstAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buffer
 	if interval.End-interval.Start < 1 {
 		return nil, nil
 	}
+	if v, ok := a.values[interval.Start]; ok {
+		return v, nil
+	}
 	row := buffer[interval.Start]
 	v, err := a.expr.Eval(ctx, row)
 	if err != nil {
 		return nil, err
 	}
+	if a.values == nil {
+		a.values = make(map[int]interface{})
+	}
+	a.values[interval.Start] = v
 	return v, nil
 }
 

--- a/sql/expression/function/aggregation/window_functions_test.go
+++ b/sql/expression/function/aggregation/window_functions_test.go
@@ -26,6 +26,76 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
+// windowCountingExpr counts evaluations while returning the selected row value.
+type windowCountingExpr struct {
+	sql.Expression
+	count *int
+}
+
+// Eval implements sql.Expression and records each underlying evaluation.
+func (e *windowCountingExpr) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	*e.count++
+	return e.Expression.Eval(ctx, row)
+}
+
+// TestFirstAndLastValueCacheSourceRows verifies that source-row values are evaluated once per partition.
+func TestFirstAndLastValueCacheSourceRows(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	buffer := sql.WindowBuffer{{nil}, {1}, {2}}
+
+	firstCount := 0
+	first := NewFirstAgg(&windowCountingExpr{
+		Expression: expression.NewGetField(0, types.Int64, "value", true),
+		count:      &firstCount,
+	})
+	require.NoError(t, first.StartPartition(ctx, sql.WindowInterval{Start: 0, End: 3}, buffer))
+	for _, test := range []struct {
+		interval sql.WindowInterval
+		expected interface{}
+	}{
+		{sql.WindowInterval{Start: 0, End: 1}, nil},
+		{sql.WindowInterval{Start: 0, End: 2}, nil},
+		{sql.WindowInterval{Start: 1, End: 2}, 1},
+		{sql.WindowInterval{Start: 1, End: 3}, 1},
+	} {
+		actual, err := first.Compute(ctx, test.interval, buffer)
+		require.NoError(t, err)
+		require.Equal(t, test.expected, actual)
+	}
+	require.Equal(t, 2, firstCount)
+	require.NoError(t, first.StartPartition(ctx, sql.WindowInterval{Start: 0, End: 3}, buffer))
+	_, err := first.Compute(ctx, sql.WindowInterval{Start: 0, End: 1}, buffer)
+	require.NoError(t, err)
+	require.Equal(t, 3, firstCount)
+
+	lastCount := 0
+	last := NewLastAgg(&windowCountingExpr{
+		Expression: expression.NewGetField(0, types.Int64, "value", true),
+		count:      &lastCount,
+	})
+	require.NoError(t, last.StartPartition(ctx, sql.WindowInterval{Start: 0, End: 3}, buffer))
+	for _, test := range []struct {
+		interval sql.WindowInterval
+		expected interface{}
+	}{
+		{sql.WindowInterval{Start: 0, End: 3}, 2},
+		{sql.WindowInterval{Start: 1, End: 3}, 2},
+		{sql.WindowInterval{Start: 0, End: 2}, 1},
+		{sql.WindowInterval{Start: 1, End: 2}, 1},
+		{sql.WindowInterval{Start: 0, End: 1}, nil},
+		{sql.WindowInterval{Start: 0, End: 1}, nil},
+	} {
+		actual, err := last.Compute(ctx, test.interval, buffer)
+		require.NoError(t, err)
+		require.Equal(t, test.expected, actual)
+	}
+	require.Equal(t, 3, lastCount)
+	require.NoError(t, last.StartPartition(ctx, sql.WindowInterval{Start: 0, End: 3}, buffer))
+	_, err = last.Compute(ctx, sql.WindowInterval{Start: 0, End: 3}, buffer)
+	require.NoError(t, err)
+	require.Equal(t, 4, lastCount)
+}
+
 func TestGroupedAggFuncs(t *testing.T) {
 	tests := []struct {
 		Name     string

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -608,7 +608,7 @@ func (b *Builder) buildWindow(fromScope, projScope *scope) *scope {
 	windowStr := make(map[string]bool)
 	for _, col := range fromScope.windowFuncs {
 		e := col.scalar
-		if !windowStr[e.String()] {
+		if !windowStr[e.String()] || expressionIsNonDeterministic(b.ctx, e) {
 			switch e.(type) {
 			case sql.WindowAdaptableExpression:
 				windowStr[e.String()] = true
@@ -673,6 +673,14 @@ func (b *Builder) buildWindow(fromScope, projScope *scope) *scope {
 	}
 
 	return outScope
+}
+
+// expressionIsNonDeterministic reports whether an expression tree contains a nondeterministic expression.
+func expressionIsNonDeterministic(ctx *sql.Context, expr sql.Expression) bool {
+	return transform.InspectExpr(ctx, expr, func(_ *sql.Context, child sql.Expression) bool {
+		nondeterministic, ok := child.(sql.NonDeterministicExpression)
+		return ok && nondeterministic.IsNonDeterministic()
+	})
 }
 
 func (b *Builder) buildNamedWindows(fromScope *scope, window ast.Window) {


### PR DESCRIPTION
The window planner currently deduplicates identical expressions by their rendered SQL. Preserve that optimization for deterministic expressions, but emit separate window outputs when an expression tree contains a nondeterministic function.

Evaluate each source-row value once per partition for `FIRST_VALUE` and `LAST_VALUE`, including NULL values and changing frame boundaries. Adds engine and focused unit regressions for both planner and executor behavior.

Fixes dolthub/dolt#11499