### PR TITLE
Reset REGEXP_* functions on Dispose so they work across window partitions

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -25,6 +25,47 @@ import (
 // first_value, last_value, lead, lag, and the bitwise aggregate functions.
 var WindowFunctionsScriptTests = []ScriptTest{
 	{
+		Name: "regexp functions inside window aggregates are evaluated in every partition",
+		SetUpScript: []string{
+			"CREATE TABLE regexp_windows (g int primary key, v int not null, s varchar(8) not null)",
+			"INSERT INTO regexp_windows VALUES (0, 10, 'a'), (1, 50, 'a'), (2, 7, 'b')",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT g, SUM(CASE WHEN REGEXP_LIKE(s, 'a') THEN v ELSE 0 END) OVER (PARTITION BY g) AS total FROM regexp_windows ORDER BY g",
+				Expected: []sql.Row{
+					{0, float64(10)},
+					{1, float64(50)},
+					{2, float64(0)},
+				},
+			},
+			{
+				Query: "SELECT g, SUM(REGEXP_INSTR(s, 'a')) OVER (PARTITION BY g) AS pos FROM regexp_windows ORDER BY g",
+				Expected: []sql.Row{
+					{0, float64(1)},
+					{1, float64(1)},
+					{2, float64(0)},
+				},
+			},
+			{
+				Query: "SELECT g, MAX(REGEXP_SUBSTR(s, 'a')) OVER (PARTITION BY g) AS m FROM regexp_windows ORDER BY g",
+				Expected: []sql.Row{
+					{0, "a"},
+					{1, "a"},
+					{2, nil},
+				},
+			},
+			{
+				Query: "SELECT g, MAX(REGEXP_REPLACE(s, 'a', 'x')) OVER (PARTITION BY g) AS m FROM regexp_windows ORDER BY g",
+				Expected: []sql.Row{
+					{0, "x"},
+					{1, "x"},
+					{2, "b"},
+				},
+			},
+		},
+	},
+	{
 		Name: "nondeterministic window expressions are evaluated independently",
 		SetUpScript: []string{
 			"CREATE TABLE nondeterministic_windows (id int primary key)",

--- a/sql/expression/function/regexp_instr.go
+++ b/sql/expression/function/regexp_instr.go
@@ -270,5 +270,8 @@ func (r *RegexpInstr) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 func (r *RegexpInstr) Dispose(ctx *sql.Context) {
 	if r.re != nil {
 		_ = r.re.Close()
+		r.re = nil
 	}
+	r.compileOnce = sync.Once{}
+	r.compileErr = nil
 }

--- a/sql/expression/function/regexp_like.go
+++ b/sql/expression/function/regexp_like.go
@@ -214,7 +214,10 @@ func (r *RegexpLike) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 func (r *RegexpLike) Dispose(ctx *sql.Context) {
 	if r.re != nil {
 		_ = r.re.Close()
+		r.re = nil
 	}
+	r.compileOnce = sync.Once{}
+	r.compileErr = nil
 }
 
 func compileRegex(ctx *sql.Context, pattern, text, flags sql.Expression, funcName string, row sql.Row) (regex.Regex, error) {

--- a/sql/expression/function/regexp_replace.go
+++ b/sql/expression/function/regexp_replace.go
@@ -288,5 +288,8 @@ func (r *RegexpReplace) Eval(ctx *sql.Context, row sql.Row) (val interface{}, er
 func (r *RegexpReplace) Dispose(ctx *sql.Context) {
 	if r.re != nil {
 		_ = r.re.Close()
+		r.re = nil
 	}
+	r.compileOnce = sync.Once{}
+	r.compileErr = nil
 }

--- a/sql/expression/function/regexp_substr.go
+++ b/sql/expression/function/regexp_substr.go
@@ -247,5 +247,8 @@ func (r *RegexpSubstr) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 func (r *RegexpSubstr) Dispose(ctx *sql.Context) {
 	if r.re != nil {
 		_ = r.re.Close()
+		r.re = nil
 	}
+	r.compileOnce = sync.Once{}
+	r.compileErr = nil
 }


### PR DESCRIPTION
Fixes dolthub/dolt#11550

## What

`REGEXP_LIKE` (and the other `REGEXP_*` functions) return wrong results when used inside a window aggregate with more than one partition:

```sql
SELECT g, SUM(CASE WHEN REGEXP_LIKE(s,'a') THEN v ELSE 0 END) OVER (PARTITION BY g) FROM t ORDER BY g;
-- expected 10 / 50, got 10 / 0
```

`REGEXP_SUBSTR` / `REGEXP_REPLACE` in the same position fail outright with `SetRegexString must be called before any other function`.

## Why

`SumAgg.StartPartition` (and every other window agg) calls `expression.Dispose` on its child expression when a new partition starts. The `REGEXP_*` functions close their compiled regex in `Dispose`, but keep the `sync.Once` and the closed handle, so on the next partition `compile` is a no-op and `Eval` runs against a dead regex. With the pure-Go engine the closed regex simply never matches (→ `0`); the ICU path errors.

## Fix

`Dispose` now also clears `re`, resets `compileOnce` and `compileErr`, so the next `Eval` after a `Dispose` recompiles. Applied to `RegexpLike`, `RegexpInstr`, `RegexpSubstr`, `RegexpReplace` (all four had the identical shape).

## Tests

Added a script test in `WindowFunctionsScriptTests` covering all four functions across three partitions.

RED on `main` (before the fix):
```
expected: []sql.Row{{0, 10}, {1, 50}, {2, 0}}
actual  : []sql.Row{{0, 10}, {1, 0},  {2, 0}}
...REGEXP_SUBSTR/REGEXP_REPLACE: SetRegexString must be called before any other function
```

GREEN with the fix:
```
go test -tags gms_pure_go ./enginetest/ -run 'TestWindow|TestQueries$|TestScripts$|TestQueryPlans$' -count=1
ok  github.com/dolthub/go-mysql-server/enginetest 13.595s
go test -tags gms_pure_go ./internal/regex/ -count=1   → ok
```

Note: `go test -tags gms_pure_go ./sql/expression/function/` shows 4 failing `TestRegexpReplaceWithFlags/*multiline*` subtests — those fail identically on a clean `main` checkout under the pure-Go tag and are unrelated to this change. I couldn't run the ICU/cgo path locally.
