### PR TITLE
Fix correlated subqueries in window sorting

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -919,6 +919,25 @@ var WindowFunctionsScriptTests = []ScriptTest{
 		},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/11419
+		Name: "customer reproduction: correlated scalar subquery in window ordering",
+		SetUpScript: []string{
+			"CREATE TABLE window_correlated_order (id INT PRIMARY KEY, g INT, v INT NOT NULL)",
+			"CREATE TABLE window_correlated_delta (g INT PRIMARY KEY, delta INT NOT NULL)",
+			"INSERT INTO window_correlated_order VALUES (1, 0, 10), (2, 0, 20)",
+			"INSERT INTO window_correlated_delta VALUES (0, 7)",
+		},
+		Query: `SELECT t.id,
+			SUM(t.v) OVER (
+				PARTITION BY t.g
+				ORDER BY (SELECT d.delta FROM window_correlated_delta d WHERE d.g = t.g), t.id
+				ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+			) AS wf
+			FROM window_correlated_order t
+			ORDER BY t.id`,
+		Expected: []sql.Row{{1, float64(10)}, {2, float64(30)}},
+	},
+	{
 		// https://github.com/dolthub/dolt/issues/11395
 		Name: "customer reproduction: sibling window aggregates with different frames",
 		SetUpScript: []string{

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -156,7 +156,6 @@ func (i *WindowPartitionIter) Next(ctx *sql.Context) (sql.Row, error) {
 // a sorted sql.WindowBuffer and a list of original row indices for resorting.
 func (i *WindowPartitionIter) materializeInput(ctx *sql.Context) (sql.WindowBuffer, []int, error) {
 	input := make(sql.WindowBuffer, 0)
-	j := 0
 	for {
 		row, err := i.child.Next(ctx)
 		if err != nil {
@@ -165,30 +164,27 @@ func (i *WindowPartitionIter) materializeInput(ctx *sql.Context) (sql.WindowBuff
 			}
 			return nil, nil, err
 		}
-		// TODO: Appending the row number to the end of the row can likely cause indexing issues
-		//  https://github.com/dolthub/dolt/issues/11328
-		input = append(input, append(row, j))
-		j++
+		input = append(input, row)
 	}
 
 	if len(input) == 0 {
 		return nil, nil, nil
 	}
 
-	// sort all rows by partition
-	sorter := sorters.NewRowSorterWithRows(ctx, append(partitionsToSortConditions(i.w.PartitionBy), i.w.SortBy...), input)
+	// Sort all rows by partition while tracking their original positions separately. Adding
+	// positions to the rows would expose them to expressions evaluated by the sorter.
+	outputOrdering := make([]int, len(input))
+	for idx := range outputOrdering {
+		outputOrdering[idx] = idx
+	}
+	sorter := &windowSorter{
+		RowSorter:      sorters.NewRowSorterWithRows(ctx, append(partitionsToSortConditions(i.w.PartitionBy), i.w.SortBy...), input),
+		outputOrdering: outputOrdering,
+	}
 	sort.Stable(sorter)
 	err := sorter.GetError()
 	if err != nil {
 		return nil, nil, err
-	}
-
-	// maintain output sort ordering
-	// TODO: push sort above aggregation, makes this code unnecessarily complex
-	outputOrdering := make([]int, len(input))
-	outputIdx := len(input[0]) - 1
-	for k, row := range input {
-		outputOrdering[k], input[k] = row[outputIdx].(int), row[:outputIdx]
 	}
 
 	return input, outputOrdering, nil
@@ -315,6 +311,18 @@ func (i *WindowPartitionIter) nextPartition(ctx *sql.Context) error {
 	}
 
 	return nil
+}
+
+// windowSorter keeps original row positions aligned with rows during window sorting.
+type windowSorter struct {
+	*sorters.RowSorter
+	outputOrdering []int
+}
+
+// Swap keeps original row positions aligned with rows as the window input is sorted.
+func (s *windowSorter) Swap(i, j int) {
+	s.RowSorter.Swap(i, j)
+	s.outputOrdering[i], s.outputOrdering[j] = s.outputOrdering[j], s.outputOrdering[i]
 }
 
 func partitionsToSortConditions(partitionExprs []sql.Expression) sql.SortConditions {

--- a/sql/expression/function/aggregation/window_partition_test.go
+++ b/sql/expression/function/aggregation/window_partition_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
@@ -141,20 +142,53 @@ func TestWindowPartition_MaterializeInput(t *testing.T) {
 
 	buf, ordering, err := i.materializeInput(ctx)
 	require.NoError(t, err)
-	expBuf := []sql.Row{
+	expBuf := sql.WindowBuffer{
+		{int64(6), "desert", "sand", int32(4)},
+		{int64(7), "desert", "cactus", int32(6)},
+		{int64(8), "desert", "scorpion", int32(8)},
+		{int64(9), "desert", "mummy", int32(5)},
 		{int64(1), "forest", "leaf", int32(4)},
 		{int64(2), "forest", "bark", int32(4)},
 		{int64(3), "forest", "canopy", int32(6)},
 		{int64(4), "forest", "bug", int32(3)},
 		{int64(5), "forest", "wildflower", int32(10)},
-		{int64(6), "desert", "sand", int32(4)},
-		{int64(7), "desert", "cactus", int32(6)},
-		{int64(8), "desert", "scorpion", int32(8)},
-		{int64(9), "desert", "mummy", int32(5)},
 	}
-	require.ElementsMatch(t, expBuf, buf)
-	expOrd := []int{0, 1, 2, 3, 4, 5, 6, 7, 8}
-	require.ElementsMatch(t, expOrd, ordering)
+	require.Equal(t, expBuf, buf)
+	expOrd := []int{5, 6, 7, 8, 0, 1, 2, 3, 4}
+	require.Equal(t, expOrd, ordering)
+}
+
+// TestWindowPartition_MaterializeInputTracksOriginalOrder verifies sorted rows stay paired with their source positions.
+func TestWindowPartition_MaterializeInputTracksOriginalOrder(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	input := []sql.Row{
+		{"b", 2, "b2"},
+		{"a", nil, "a-null"},
+		{"b", 1, "b1"},
+		{"a", 1, "a1-first"},
+		{"a", 1, "a1-second"},
+	}
+	iter := WindowPartitionIter{
+		w: &WindowPartition{
+			PartitionBy: []sql.Expression{expression.NewGetField(0, types.Text, "partition_key", false)},
+			SortBy: sql.SortConditions{{
+				Expr:         expression.NewGetField(1, types.Int64, "sort_key", true),
+				NullOrdering: sql.NullsFirst,
+			}},
+		},
+		child: sql.RowsToRowIter(input...),
+	}
+
+	buf, ordering, err := iter.materializeInput(ctx)
+	require.NoError(t, err)
+	require.Equal(t, sql.WindowBuffer{
+		{"a", nil, "a-null"},
+		{"a", 1, "a1-first"},
+		{"a", 1, "a1-second"},
+		{"b", 1, "b1"},
+		{"b", 2, "b2"},
+	}, buf)
+	require.Equal(t, []int{1, 3, 4, 2, 0}, ordering)
 }
 
 func TestWindowPartition_InitializePartitions(t *testing.T) {


### PR DESCRIPTION
Window execution appended each row's original position directly to the SQL row before evaluating partition and ordering expressions. Correlated scalar subqueries could observe that synthetic field and produce incorrect window sort keys.

Track original positions in a parallel slice that is swapped alongside rows and cached sort keys, keeping bookkeeping outside the SQL-visible row. Add the reported regression and exact row-to-position invariants for reordered partitions, NULL keys, and stable duplicate keys.

Fixes dolthub/dolt#11419
Fixes dolthub/dolt#11460