### PR TITLE
Fix empty inserts with generated columns

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4019,6 +4019,32 @@ func TestPreparedInsert(t *testing.T, harness Harness) {
 	for _, tt := range tests {
 		TestScript(t, harness, tt)
 	}
+	TestScriptPrepared(t, harness, queries.ScriptTest{
+		Name:    "multi-row empty insert",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"create table prepared_empty (a int default 1, b int generated always as (a + 1))",
+			"create table prepared_mixed (a int default 1, b int default 2)",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "insert into prepared_empty values (), ()",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "select * from prepared_empty",
+				Expected: []sql.Row{{1, 2}, {1, 2}},
+			},
+			{
+				Query:       "insert into prepared_mixed values (), (3, 4)",
+				ExpectedErr: sql.ErrInsertIntoMismatchValueCount,
+			},
+			{
+				Query:    "select * from prepared_mixed",
+				Expected: []sql.Row{},
+			},
+		},
+	})
 }
 
 // TODO: find better way to do this

--- a/enginetest/queries/generated_columns.go
+++ b/enginetest/queries/generated_columns.go
@@ -32,6 +32,7 @@ var GeneratedColumnTests = []ScriptTest{
 			"create table later_t (b int generated always as (a + 1), a int default 1)",
 			"create table invisible_base_t (a int default 1 invisible, b int generated always as (a + 1))",
 			"create table invisible_generated_t (a int default 1, b int generated always as (a + 1) invisible)",
+			"create table select_empty_t (a int default 1, b int generated always as (a + 1))",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -105,6 +106,18 @@ var GeneratedColumnTests = []ScriptTest{
 			{
 				Query:    "select a, b from invisible_generated_t",
 				Expected: []sql.Row{{1, 2}},
+			},
+			{
+				Query:       "insert into select_empty_t select 9, 10 where 1 = 0",
+				ExpectedErr: sql.ErrGeneratedColumnValue,
+			},
+			{
+				Query:    "insert into select_empty_t (a) select 9 where 1 = 0",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "select a, b from select_empty_t",
+				Expected: []sql.Row{},
 			},
 		},
 	},

--- a/enginetest/queries/generated_columns.go
+++ b/enginetest/queries/generated_columns.go
@@ -22,6 +22,93 @@ import (
 
 var GeneratedColumnTests = []ScriptTest{
 	{
+		// https://github.com/dolthub/dolt/issues/11388
+		Name:    "empty insert with default and generated columns",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"create table t (a int default 1, b int generated always as (a + 1))",
+			"create table mixed_generated_t (a int default 1, b int generated always as (a + 1))",
+			"create table stored_t (a int default 1, b int generated always as (a + 1) stored)",
+			"create table later_t (b int generated always as (a + 1), a int default 1)",
+			"create table invisible_base_t (a int default 1 invisible, b int generated always as (a + 1))",
+			"create table invisible_generated_t (a int default 1, b int generated always as (a + 1) invisible)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "insert into t values ()",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "insert into t () values ()",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "select a, b from t",
+				Expected: []sql.Row{{1, 2}, {1, 2}},
+			},
+			{
+				Query:    "insert into t (b, a) values (default, default)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "select a, b from t",
+				Expected: []sql.Row{{1, 2}, {1, 2}, {1, 2}},
+			},
+			{
+				Query:       "insert into mixed_generated_t values (), (3, default)",
+				ExpectedErr: sql.ErrInsertIntoMismatchValueCount,
+			},
+			{
+				Query:       "insert into mixed_generated_t values (3, default), ()",
+				ExpectedErr: sql.ErrInsertIntoMismatchValueCount,
+			},
+			{
+				Query:    "select a, b from mixed_generated_t",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "insert into mixed_generated_t values (default, default), (3, default)",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "select a, b from mixed_generated_t",
+				Expected: []sql.Row{{1, 2}, {3, 4}},
+			},
+			{
+				Query:    "insert into stored_t values (), ()",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "select a, b from stored_t",
+				Expected: []sql.Row{{1, 2}, {1, 2}},
+			},
+			{
+				Query:    "insert into later_t values ()",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "select b, a from later_t",
+				Expected: []sql.Row{{2, 1}},
+			},
+			{
+				Query:    "insert into invisible_base_t values (), ()",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "select a, b from invisible_base_t",
+				Expected: []sql.Row{{1, 2}, {1, 2}},
+			},
+			{
+				Query:    "insert into invisible_generated_t values ()",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "select a, b from invisible_generated_t",
+				Expected: []sql.Row{{1, 2}},
+			},
+		},
+	},
+	{
 		Name: "stored generated column",
 		SetUpScript: []string{
 			"create table t1 (a int primary key, b int as (a + 1) stored)",

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -929,6 +929,90 @@ var SpatialInsertQueries = []WriteQueryTest{
 
 var InsertScripts = []ScriptTest{
 	{
+		// https://github.com/dolthub/dolt/issues/11388
+		Name:    "multi-row empty insert compatibility",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"create table empty_defaults (a int default 1, b int default 2)",
+			"create table empty_column_list (a int default 1, b int default 2)",
+			"create table mixed_defaults (a int default 1, b int default 2)",
+			"create table empty_named (a int default 1, b int default 2)",
+			"create table empty_auto (id int auto_increment primary key, v int default 5)",
+			"create table empty_nullable (a int, b int)",
+			"create table empty_required (a int not null, b int default 2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "insert into empty_defaults values (), ()",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "select * from empty_defaults",
+				Expected: []sql.Row{{1, 2}, {1, 2}},
+			},
+			{
+				Query:    "insert into empty_column_list () values (), ()",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "select * from empty_column_list",
+				Expected: []sql.Row{{1, 2}, {1, 2}},
+			},
+			{
+				Query:       "insert into mixed_defaults values (), (3, 4)",
+				ExpectedErr: sql.ErrInsertIntoMismatchValueCount,
+			},
+			{
+				Query:       "insert into mixed_defaults values (3, 4), ()",
+				ExpectedErr: sql.ErrInsertIntoMismatchValueCount,
+			},
+			{
+				Query:    "select * from mixed_defaults",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "insert into mixed_defaults values (default, default), (3, default)",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "select * from mixed_defaults",
+				Expected: []sql.Row{{1, 2}, {3, 2}},
+			},
+			{
+				Query:       "insert into empty_named (a) values (), ()",
+				ExpectedErr: sql.ErrInsertIntoMismatchValueCount,
+			},
+			{
+				Query:    "select * from empty_named",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "insert into empty_auto values (), ()",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 1}}},
+			},
+			{
+				Query:    "select * from empty_auto order by id",
+				Expected: []sql.Row{{1, 5}, {2, 5}},
+			},
+			{
+				Query:    "insert into empty_nullable values (), ()",
+				Expected: []sql.Row{{types.NewOkResult(2)}},
+			},
+			{
+				Query:    "select * from empty_nullable",
+				Expected: []sql.Row{{nil, nil}, {nil, nil}},
+			},
+			{
+				Query:       "insert into empty_required values (), ()",
+				ExpectedErr: sql.ErrFieldNoDefaultValue,
+			},
+			{
+				Query:    "select * from empty_required",
+				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
 		// https://github.com/dolthub/dolt/issues/7322
 		Name: "issue 7322: values expression is subquery",
 		SetUpScript: []string{
@@ -1408,24 +1492,17 @@ var InsertScripts = []ScriptTest{
 				},
 			},
 			{
-				Query: "insert into auto_pk values (0), (1), (NULL), ()",
-				Expected: []sql.Row{
-					{types.OkResult{RowsAffected: 4}},
-				},
+				Query:       "insert into auto_pk values (0), (1), (NULL), ()",
+				ExpectedErr: sql.ErrInsertIntoMismatchValueCount,
 			},
 			{
-				Query: "select * from auto_pk",
-				Expected: []sql.Row{
-					{0},
-					{1},
-					{2},
-					{3},
-				},
+				Query:    "select * from auto_pk",
+				Expected: []sql.Row{},
 			},
 			{
 				Query: "select auto_increment from information_schema.tables where table_name='auto_pk' and table_schema=database()",
 				Expected: []sql.Row{
-					{uint64(4)},
+					{nil},
 				},
 			},
 

--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -1843,6 +1843,8 @@ ORDER BY id;`,
 	{
 		// https://github.com/dolthub/dolt/issues/11464
 		Name: "CHAR PAD SPACE values do not split a window partition",
+		// Doltgres uses its own PostgreSQL CHAR type, so this GMS StringType regression is MySQL-only.
+		Dialect: "mysql",
 		SetUpScript: []string{
 			"CREATE TABLE t (id INT PRIMARY KEY, c CHAR(3), v INT)",
 			"INSERT INTO t VALUES (1, 'a', 10), (2, 'a ', 20), (3, 'b', 30)",

--- a/sql/analyzer/inserts.go
+++ b/sql/analyzer/inserts.go
@@ -76,8 +76,11 @@ func resolveInsertRows(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sc
 			columnNames[i] = strings.ToLower(name)
 		}
 
-		// If no columns are given and value tuples are not all empty, use the full schema
-		if len(columnNames) == 0 && existsNonZeroValueCount(source) {
+		// Empty value tuples implicitly target no columns so that every destination column is populated from its default.
+		// Keep the insert node's inferred column names intact because external row sources may replace a placeholder Values node.
+		if !existsNonZeroValueCount(source) {
+			columnNames = nil
+		} else if len(columnNames) == 0 {
 			columnNames = make([]string, len(dstSchema))
 			for i, f := range dstSchema {
 				columnNames[i] = f.Name
@@ -105,7 +108,7 @@ func resolveInsertRows(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sc
 	})
 }
 
-// Ensures that the number of elements in each Value tuple is empty
+// existsNonZeroValueCount reports whether a row source contains values rather than only empty tuples.
 func existsNonZeroValueCount(values sql.Node) bool {
 	switch node := values.(type) {
 	case *plan.Values:

--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -90,6 +90,20 @@ func (b *Builder) buildInsert(inScope *scope, i *ast.Insert) (outScope *scope) {
 	}
 
 	insertRows := i.Rows
+	sourceColumns := columns
+	// Leave implicit empty rows unshaped so the analyzer can materialize defaults for the complete destination schema.
+	if values, ok := insertRows.(*ast.AliasedValues); ok && len(i.Columns) == 0 {
+		allRowsEmpty := true
+		for _, tuple := range values.Values {
+			if len(tuple) > 0 {
+				allRowsEmpty = false
+				break
+			}
+		}
+		if allRowsEmpty {
+			sourceColumns = nil
+		}
+	}
 
 	// We need to give a table name to the scope of the values being inserted. We use the row alias if provided, otherwise go with a default.
 	// If the row alias also provided column names, we create a map from the destination names to the aliases. This will allow us to
@@ -112,7 +126,7 @@ func (b *Builder) buildInsert(inScope *scope, i *ast.Insert) (outScope *scope) {
 		}
 	}
 
-	srcScope, srcLiteralOnly := b.insertRowsToNode(inScope, insertRows, columns, i.Table.Name.String(), sch)
+	srcScope, srcLiteralOnly := b.insertRowsToNode(inScope, insertRows, sourceColumns, i.Table.Name.String(), sch)
 
 	var onDupUpdateExprs *plan.UpdateExprs
 	var onDupWhere sql.Expression
@@ -304,7 +318,7 @@ func (b *Builder) buildInsertValues(inScope *scope, v *ast.AliasedValues, column
 		// table error and do not have a schema for resolving defaults
 		triggerUnknownTable := (len(columnNames) == 0 && len(vt) > 0) && (len(b.TriggerCtx().UnresolvedTables) > 0)
 
-		if len(vt) != len(columnNames) && !noExprs && !triggerUnknownTable {
+		if len(vt) != len(columnNames) && !triggerUnknownTable {
 			err := sql.ErrInsertIntoMismatchValueCount.New()
 			b.handleErr(err)
 		}

--- a/sql/planbuilder/dml_validate.go
+++ b/sql/planbuilder/dml_validate.go
@@ -59,15 +59,17 @@ func (b *Builder) validateInsert(ins *plan.InsertInto) {
 		columnNames[i] = strings.ToLower(name)
 	}
 
-	// If no columns are given and value tuples are not all empty, use the full schema
-	if len(columnNames) == 0 && existsNonZeroValueCount(ins.Source) {
+	// Empty value tuples implicitly target no columns so that every destination column is populated from its default.
+	if !existsNonZeroValueCount(ins.Source) {
+		columnNames = nil
+	} else if len(columnNames) == 0 {
 		columnNames = make([]string, len(dstSchema))
 		for i, f := range dstSchema {
 			columnNames[i] = f.Name
 		}
 	}
 
-	if len(ins.ColumnNames) > 0 {
+	if len(columnNames) > 0 {
 		err := validateInsertColumns(table.Name(), columnNames, dstSchema, ins.Source)
 		if err != nil {
 			b.handleErr(err)
@@ -80,7 +82,7 @@ func (b *Builder) validateInsert(ins *plan.InsertInto) {
 	}
 }
 
-// Ensures that the number of elements in each Value tuple is empty
+// existsNonZeroValueCount reports whether a row source contains values rather than only empty tuples.
 func existsNonZeroValueCount(values sql.Node) bool {
 	switch node := values.(type) {
 	case *plan.Values:


### PR DESCRIPTION
Preserve implicit all-empty `VALUES` rows as zero-width sources so insert analysis materializes defaults and generated expressions against the complete destination schema. Reject mixed empty and non-empty tuple widths to match MySQL, with coverage for generated, invisible, auto-increment, atomic, and prepared cases.

Fixes dolthub/dolt#11388