### PR TITLE
Fix BIGINT arithmetic overflow handling

### DIFF
--- a/enginetest/queries/prepared_statement_queries.go
+++ b/enginetest/queries/prepared_statement_queries.go
@@ -1,6 +1,7 @@
 package queries
 
 import (
+	"math"
 	"time"
 
 	"github.com/dolthub/vitess/go/vt/sqlparser"
@@ -225,6 +226,28 @@ var PreparedScriptTests = []ScriptTest{
 					{nil, time.Date(2001, time.February, 3, 12, 34, 56, 0, time.UTC), nil},
 					{nil, nil, time.Date(2001, time.February, 3, 12, 34, 56, 0, time.UTC)},
 				},
+			},
+		},
+	},
+	{
+		// https://github.com/dolthub/dolt/issues/11411
+		Name: "prepared unsigned BIGINT arithmetic rejects overflow",
+		// MySQL-only: PostgreSQL does not support unsigned integer types.
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"CREATE TABLE prepared_integer_bounds (id INT PRIMARY KEY, u BIGINT UNSIGNED)",
+			"INSERT INTO prepared_integer_bounds VALUES (1, 18446744073709551615)",
+			"SET @zero = 0, @one = 1",
+			"PREPARE add_to_unsigned FROM 'SELECT u + ? FROM prepared_integer_bounds'",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "EXECUTE add_to_unsigned USING @zero",
+				Expected: []sql.Row{{uint64(math.MaxUint64)}},
+			},
+			{
+				Query:       "EXECUTE add_to_unsigned USING @one",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
 			},
 		},
 	},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -6258,6 +6258,104 @@ CREATE TABLE tab3 (
 		},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/11411
+		Name: "integer arithmetic rejects signed and unsigned BIGINT overflow",
+		// MySQL-only: PostgreSQL does not support unsigned integer types.
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"CREATE TABLE integer_bounds (id INT PRIMARY KEY, u BIGINT UNSIGNED, s BIGINT)",
+			"INSERT INTO integer_bounds VALUES (1, 18446744073709551615, 9223372036854775807)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT u, u + 0, u + -1, u - 1 FROM integer_bounds",
+				Expected: []sql.Row{{uint64(math.MaxUint64), uint64(math.MaxUint64), uint64(math.MaxUint64 - 1), uint64(math.MaxUint64 - 1)}},
+			},
+			{
+				Query:       "SELECT u + 1 FROM integer_bounds",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
+			},
+			{
+				Query:       "SELECT CAST(18446744073709551615 AS UNSIGNED) * 2",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
+			},
+			{
+				Query:       "SELECT CAST(0 AS UNSIGNED) - 1",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
+			},
+			{
+				Query:    "SELECT -1 + CAST(1 AS UNSIGNED)",
+				Expected: []sql.Row{{uint64(0)}},
+			},
+			{
+				Query:    "SELECT CAST(-1 AS SIGNED) * CAST(0 AS UNSIGNED), CAST(0 AS UNSIGNED) * CAST(-1 AS SIGNED)",
+				Expected: []sql.Row{{uint64(0), uint64(0)}},
+			},
+			{
+				Query:    "SELECT CAST(1 AS UNSIGNED) - -1, 2 - CAST(1 AS UNSIGNED)",
+				Expected: []sql.Row{{uint64(2), uint64(1)}},
+			},
+			{
+				Query:       "SELECT -2 + CAST(1 AS UNSIGNED)",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
+			},
+			{
+				Query:       "SELECT 1 - CAST(2 AS UNSIGNED)",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
+			},
+			{
+				Query:       "SELECT CAST(1 AS UNSIGNED) * -1",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
+			},
+			{
+				Query:       "SELECT s + 1 FROM integer_bounds",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
+			},
+			{
+				Query:       "SELECT CAST(-9223372036854775807 AS SIGNED) - 2",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
+			},
+			{
+				Query:       "SELECT CAST(3037000500 AS SIGNED) * CAST(3037000500 AS SIGNED)",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
+			},
+		},
+	},
+	{
+		Name: "NO_UNSIGNED_SUBTRACTION returns signed BIGINT arithmetic results",
+		// MySQL-only: NO_UNSIGNED_SUBTRACTION is a MySQL SQL mode.
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"SET SESSION sql_mode = 'NO_UNSIGNED_SUBTRACTION'",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT CAST(0 AS UNSIGNED) - 1",
+				Expected: []sql.Row{{-1}},
+			},
+			{
+				Query:    "SELECT 1 - CAST(2 AS UNSIGNED)",
+				Expected: []sql.Row{{-1}},
+			},
+			{
+				Query:    "SELECT CAST(9223372036854775808 AS UNSIGNED) - 1",
+				Expected: []sql.Row{{math.MaxInt64}},
+			},
+			{
+				Query:    "SELECT CAST(9223372036854775807 AS SIGNED) - CAST(18446744073709551615 AS UNSIGNED)",
+				Expected: []sql.Row{{math.MinInt64}},
+			},
+			{
+				Query:       "SELECT CAST(18446744073709551615 AS UNSIGNED) - 1",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
+			},
+			{
+				Query:       "SELECT CAST(-9223372036854775808 AS SIGNED) - CAST(1 AS UNSIGNED)",
+				ExpectedErr: sql.ErrIntegerOutOfRange,
+			},
+		},
+	},
+	{
 		Name: "arithmetic bit operations on int, float and decimal types",
 		SetUpScript: []string{
 			"CREATE TABLE num_types (pk int primary key, a int, b float, c decimal(5,3));",

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -902,6 +902,9 @@ var (
 	// ErrValueOutOfRange is returned when a value is out of range for a type.
 	ErrValueOutOfRange = errors.NewKind("%v out of range for %v")
 
+	// ErrIntegerOutOfRange is returned when integer arithmetic exceeds the result type's range.
+	ErrIntegerOutOfRange = newMySQLKind("%s value is out of range in '%s'", mysql.ERDataOutOfRange, mysql.SSDataOutOfRange)
+
 	ErrConvertingToSet   = errors.NewKind("value %v is not valid for this set")
 	ErrDuplicateEntrySet = errors.NewKind("duplicate entry: %v")
 	ErrInvalidSetValue   = errors.NewKind("value %v was not found in the set")

--- a/sql/errors_test.go
+++ b/sql/errors_test.go
@@ -11,14 +11,19 @@ import (
 )
 
 func TestSQLErrorCast(t *testing.T) {
+	integerRangeErr := ErrIntegerOutOfRange.New("BIGINT UNSIGNED", "(value + 1)")
+	assert.Equal(t, "BIGINT UNSIGNED value is out of range in '(value + 1)'", integerRangeErr.Error())
+
 	tests := []struct {
-		err  error
-		code int
+		err      error
+		code     int
+		sqlState string
 	}{
-		{ErrTableNotFound.New("table not found err"), mysql.ERNoSuchTable},
-		{ErrInvalidType.New("unhandled mysql error"), mysql.ERUnknownError},
-		{fmt.Errorf("generic error"), mysql.ERUnknownError},
-		{nil, mysql.ERUnknownError},
+		{ErrTableNotFound.New("table not found err"), mysql.ERNoSuchTable, ""},
+		{integerRangeErr, mysql.ERDataOutOfRange, mysql.SSDataOutOfRange},
+		{ErrInvalidType.New("unhandled mysql error"), mysql.ERUnknownError, ""},
+		{fmt.Errorf("generic error"), mysql.ERUnknownError, ""},
+		{nil, mysql.ERUnknownError, ""},
 	}
 
 	for _, test := range tests {
@@ -28,6 +33,9 @@ func TestSQLErrorCast(t *testing.T) {
 			if err != nil {
 				require.Error(t, err)
 				assert.Equal(t, err.Number(), test.code)
+				if test.sqlState != "" {
+					assert.Equal(t, test.sqlState, err.SQLState())
+				}
 			} else {
 				assert.Equal(t, err, nilErr)
 			}

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -203,11 +203,13 @@ func (a *Arithmetic) getReturnType(ctx *sql.Context) sql.Type {
 		}
 	}
 
-	if types.IsUnsigned(lTyp) && types.IsUnsigned(rTyp) {
-		return types.Uint64
-	}
-
 	if types.IsInteger(lTyp) && types.IsInteger(rTyp) {
+		if types.IsUnsigned(lTyp) || types.IsUnsigned(rTyp) {
+			if a.Op == sqlparser.MinusStr && sql.LoadSqlMode(ctx).ModeEnabled(sql.NO_UNSIGNED_SUBTRACTION) {
+				return types.Int64
+			}
+			return types.Uint64
+		}
 		return types.Int64
 	}
 
@@ -299,6 +301,9 @@ func (a *Arithmetic) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	if lVal == nil || rVal == nil {
 		return nil, nil
 	}
+	if types.IsInteger(a.Type(ctx)) {
+		return a.evalInteger(ctx, lVal, rVal)
+	}
 
 	lVal, rVal, err = a.convertLeftRight(ctx, lVal, rVal)
 	if err != nil {
@@ -331,6 +336,250 @@ func (a *Arithmetic) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	return result, nil
+}
+
+// evalInteger evaluates integer arithmetic exactly and rejects results outside the signed or unsigned BIGINT range.
+func (a *Arithmetic) evalInteger(ctx *sql.Context, lval, rval interface{}) (interface{}, error) {
+	typ := a.Type(ctx)
+	leftUnsigned := types.IsUnsigned(a.LeftChild.Type(ctx))
+	rightUnsigned := types.IsUnsigned(a.RightChild.Type(ctx))
+	if leftUnsigned != rightUnsigned || (!types.IsUnsigned(typ) && (leftUnsigned || rightUnsigned)) {
+		return a.evalMixedInteger(ctx, typ, lval, rval)
+	}
+
+	lval, rval, err := a.convertLeftRight(ctx, lval, rval)
+	if err != nil {
+		return nil, err
+	}
+
+	switch left := lval.(type) {
+	case uint64:
+		right, ok := rval.(uint64)
+		if !ok {
+			return nil, errUnableToCast.New(lval, rval)
+		}
+		var result uint64
+		switch strings.ToLower(a.Op) {
+		case sqlparser.PlusStr:
+			if right > math.MaxUint64-left {
+				return nil, a.integerOutOfRange(typ)
+			}
+			result = left + right
+		case sqlparser.MinusStr:
+			if left < right {
+				return nil, a.integerOutOfRange(typ)
+			}
+			result = left - right
+		case sqlparser.MultStr:
+			if right != 0 && left > math.MaxUint64/right {
+				return nil, a.integerOutOfRange(typ)
+			}
+			result = left * right
+		default:
+			return nil, errUnableToEval.New(lval, a.Op, rval)
+		}
+		return result, nil
+	case int64:
+		right, ok := rval.(int64)
+		if !ok {
+			return nil, errUnableToCast.New(lval, rval)
+		}
+		var result int64
+		switch strings.ToLower(a.Op) {
+		case sqlparser.PlusStr:
+			if (right > 0 && left > math.MaxInt64-right) || (right < 0 && left < math.MinInt64-right) {
+				return nil, a.integerOutOfRange(typ)
+			}
+			result = left + right
+		case sqlparser.MinusStr:
+			if (right > 0 && left < math.MinInt64+right) || (right < 0 && left > math.MaxInt64+right) {
+				return nil, a.integerOutOfRange(typ)
+			}
+			result = left - right
+		case sqlparser.MultStr:
+			if (left == math.MinInt64 && right == -1) || (right == math.MinInt64 && left == -1) ||
+				(right != 0 && (left*right)/right != left) {
+				return nil, a.integerOutOfRange(typ)
+			}
+			result = left * right
+		default:
+			return nil, errUnableToEval.New(lval, a.Op, rval)
+		}
+		return result, nil
+	default:
+		return nil, errUnableToCast.New(lval, rval)
+	}
+}
+
+// integerMagnitude stores an integer as a sign and an unsigned magnitude.
+type integerMagnitude struct {
+	magnitude uint64
+	negative  bool
+}
+
+// evalMixedInteger evaluates mixed signed and unsigned operands without decimal conversion.
+func (a *Arithmetic) evalMixedInteger(ctx *sql.Context, typ sql.Type, lval, rval interface{}) (interface{}, error) {
+	if types.IsUnsigned(typ) {
+		return a.evalMixedUnsignedInteger(ctx, lval, rval)
+	}
+
+	left := integerMagnitudeFromValue(ctx, a.LeftChild.Type(ctx), lval)
+	right := integerMagnitudeFromValue(ctx, a.RightChild.Type(ctx), rval)
+	if strings.ToLower(a.Op) != sqlparser.MinusStr {
+		return nil, errUnableToEval.New(lval, a.Op, rval)
+	}
+	if right.magnitude != 0 {
+		right.negative = !right.negative
+	}
+	result, overflow := addIntegerMagnitudes(left, right)
+	if overflow {
+		return nil, a.integerOutOfRange(typ)
+	}
+
+	if result.negative {
+		const minInt64Magnitude = uint64(math.MaxInt64) + 1
+		if result.magnitude > minInt64Magnitude {
+			return nil, a.integerOutOfRange(typ)
+		}
+		if result.magnitude == minInt64Magnitude {
+			return int64(math.MinInt64), nil
+		}
+		return -int64(result.magnitude), nil
+	}
+	if result.magnitude > math.MaxInt64 {
+		return nil, a.integerOutOfRange(typ)
+	}
+	return int64(result.magnitude), nil
+}
+
+// evalMixedUnsignedInteger evaluates an unsigned result without constructing intermediate signed magnitudes.
+func (a *Arithmetic) evalMixedUnsignedInteger(ctx *sql.Context, lval, rval interface{}) (interface{}, error) {
+	leftUnsigned := types.IsUnsigned(a.LeftChild.Type(ctx))
+	var unsignedValue uint64
+	var signedValue int64
+	if leftUnsigned {
+		if converted := convertValueToType(ctx, a.LeftChild.Type(ctx), types.Uint64, lval); converted != nil {
+			unsignedValue = converted.(uint64)
+		}
+		if converted := convertValueToType(ctx, a.RightChild.Type(ctx), types.Int64, rval); converted != nil {
+			signedValue = converted.(int64)
+		}
+	} else {
+		if converted := convertValueToType(ctx, a.LeftChild.Type(ctx), types.Int64, lval); converted != nil {
+			signedValue = converted.(int64)
+		}
+		if converted := convertValueToType(ctx, a.RightChild.Type(ctx), types.Uint64, rval); converted != nil {
+			unsignedValue = converted.(uint64)
+		}
+	}
+
+	negativeMagnitude := uint64(0)
+	if signedValue < 0 {
+		negativeMagnitude = uint64(-(signedValue + 1)) + 1
+	}
+
+	switch strings.ToLower(a.Op) {
+	case sqlparser.PlusStr:
+		if signedValue < 0 {
+			if unsignedValue < negativeMagnitude {
+				return nil, a.integerOutOfRange(types.Uint64)
+			}
+			return unsignedValue - negativeMagnitude, nil
+		}
+		positive := uint64(signedValue)
+		if unsignedValue > math.MaxUint64-positive {
+			return nil, a.integerOutOfRange(types.Uint64)
+		}
+		return unsignedValue + positive, nil
+	case sqlparser.MinusStr:
+		if leftUnsigned {
+			if signedValue < 0 {
+				if unsignedValue > math.MaxUint64-negativeMagnitude {
+					return nil, a.integerOutOfRange(types.Uint64)
+				}
+				return unsignedValue + negativeMagnitude, nil
+			}
+			positive := uint64(signedValue)
+			if unsignedValue < positive {
+				return nil, a.integerOutOfRange(types.Uint64)
+			}
+			return unsignedValue - positive, nil
+		}
+		if signedValue < 0 || uint64(signedValue) < unsignedValue {
+			return nil, a.integerOutOfRange(types.Uint64)
+		}
+		return uint64(signedValue) - unsignedValue, nil
+	case sqlparser.MultStr:
+		if signedValue == 0 || unsignedValue == 0 {
+			return uint64(0), nil
+		}
+		if signedValue < 0 {
+			return nil, a.integerOutOfRange(types.Uint64)
+		}
+		positive := uint64(signedValue)
+		if unsignedValue > math.MaxUint64/positive {
+			return nil, a.integerOutOfRange(types.Uint64)
+		}
+		return unsignedValue * positive, nil
+	default:
+		return nil, errUnableToEval.New(lval, a.Op, rval)
+	}
+}
+
+// integerMagnitudeFromValue converts an integer operand without losing a signed value's sign.
+func integerMagnitudeFromValue(ctx *sql.Context, typ sql.Type, val interface{}) integerMagnitude {
+	if types.IsUnsigned(typ) {
+		converted := convertValueToType(ctx, typ, types.Uint64, val)
+		if converted == nil {
+			return integerMagnitude{}
+		}
+		return integerMagnitude{magnitude: converted.(uint64)}
+	}
+
+	converted := convertValueToType(ctx, typ, types.Int64, val)
+	if converted == nil {
+		return integerMagnitude{}
+	}
+	signed := converted.(int64)
+	if signed >= 0 {
+		return integerMagnitude{magnitude: uint64(signed)}
+	}
+	return integerMagnitude{
+		magnitude: uint64(-(signed + 1)) + 1,
+		negative:  true,
+	}
+}
+
+// addIntegerMagnitudes adds two signed magnitudes and reports uint64 magnitude overflow.
+func addIntegerMagnitudes(left, right integerMagnitude) (integerMagnitude, bool) {
+	if left.negative == right.negative {
+		if left.magnitude > math.MaxUint64-right.magnitude {
+			return integerMagnitude{}, true
+		}
+		return integerMagnitude{
+			magnitude: left.magnitude + right.magnitude,
+			negative:  left.negative,
+		}, false
+	}
+	if left.magnitude >= right.magnitude {
+		return integerMagnitude{
+			magnitude: left.magnitude - right.magnitude,
+			negative:  left.negative && left.magnitude != right.magnitude,
+		}, false
+	}
+	return integerMagnitude{
+		magnitude: right.magnitude - left.magnitude,
+		negative:  right.negative,
+	}, false
+}
+
+// integerOutOfRange returns MySQL's BIGINT range error for this arithmetic expression.
+func (a *Arithmetic) integerOutOfRange(typ sql.Type) error {
+	typeName := "BIGINT"
+	if types.IsUnsigned(typ) {
+		typeName = "BIGINT UNSIGNED"
+	}
+	return sql.ErrIntegerOutOfRange.New(typeName, a.String())
 }
 
 func (a *Arithmetic) evalLeftRight(ctx *sql.Context, row sql.Row) (interface{}, interface{}, error) {


### PR DESCRIPTION
Dolt currently allows BIGINT arithmetic to wrap at signed and unsigned boundaries. This applies MySQL integer result typing, performs checked native addition, subtraction, and multiplication, and honors NO_UNSIGNED_SUBTRACTION. MySQL-only engine scripts cover literal, stored-column, mixed-sign, SQL mode, and prepared execution paths, while protocol errors preserve MySQL error 1690 and SQLSTATE 22003.

Fixes dolthub/dolt#11411