### PR TITLE
Automate dependency bump approval and merge

### DIFF
--- a/.github/workflows/bump-dependency.yaml
+++ b/.github/workflows/bump-dependency.yaml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: [ bump-dependency ]
 
+concurrency:
+  group: bump-dependency-${{ github.event.client_payload.dependency }}
+  cancel-in-progress: false
+
 jobs:
   sanitize-payload:
     name: Sanitize Payload
@@ -91,6 +95,9 @@ jobs:
     needs: [sanitize-payload, stale-bump-prs]
     name: Open Bump PR
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       latest-pr: ${{ steps.latest-pr.outputs.pr_url }}
     steps:
@@ -113,19 +120,8 @@ jobs:
           echo "Installing ${SAFE_MODULE}@${SAFE_HEAD}"
           GOOS=linux go get "${SAFE_MODULE}@${SAFE_HEAD}"
 
-      - name: Get Assignee and Reviewer (safe)
-        id: get_reviewer
-        env:
-          ASSIGNEE: ${{ needs.sanitize-payload.outputs.safe_assignee }}
-        run: |
-          set -euo pipefail
-          if [ "${ASSIGNEE}" = "zachmu" ]; then
-            echo "reviewer=Hydrocharged" >> "$GITHUB_OUTPUT"
-          else
-            echo "reviewer=zachmu" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create and Push new branch (safe)
+        id: bump-commit
         env:
           GIT_USER:  ${{ needs.sanitize-payload.outputs.safe_assignee }}
           GIT_MAIL:  ${{ needs.sanitize-payload.outputs.safe_email }}
@@ -143,6 +139,7 @@ jobs:
 
           # Commit message uses sanitized assignee only
           git commit -m "[ga-bump-dep] Bump dependency in GMS by ${COMMIT_BY}"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           git push origin "${BRANCH}"
 
       - name: pull-request
@@ -154,9 +151,92 @@ jobs:
           github_token: ${{ secrets.REPO_ACCESS_TOKEN }}
           pr_title: "[auto-bump] [no-release-notes] dependency by ${{ needs.sanitize-payload.outputs.safe_assignee }}"
           pr_template: ".github/markdown-templates/dep-bump.md"
-          pr_reviewer: ${{ steps.get_reviewer.outputs.reviewer }}
           pr_assignee: ${{ needs.sanitize-payload.outputs.safe_assignee }}
           pr_label: ${{ needs.sanitize-payload.outputs.label }}
+      - name: Validate and approve pull request
+        uses: actions/github-script@v7
+        env:
+          EXPECTED_BRANCH: ${{ needs.sanitize-payload.outputs.safe_branch }}
+          EXPECTED_LABEL: ${{ needs.sanitize-payload.outputs.label }}
+          EXPECTED_SHA: ${{ steps.bump-commit.outputs.sha }}
+          PR_URL: ${{ steps.latest-pr.outputs.pr_url }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { EXPECTED_BRANCH, EXPECTED_LABEL, EXPECTED_SHA, PR_URL } = process.env;
+            const match = PR_URL.match(/\/pull\/(\d+)$/);
+            if (!match) throw new Error(`Unable to determine pull request number from ${PR_URL}`);
+
+            const pull_number = Number(match[1]);
+            const { owner, repo } = context.repo;
+            const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number });
+
+            if (pull.state !== "open") throw new Error("Pull request is not open");
+            if (pull.base.ref !== "main") throw new Error(`Unexpected base branch: ${pull.base.ref}`);
+            if (pull.head.repo?.full_name !== `${owner}/${repo}`) throw new Error("Pull request head is from a fork");
+            if (pull.head.ref !== EXPECTED_BRANCH) throw new Error(`Unexpected head branch: ${pull.head.ref}`);
+            if (pull.head.sha !== EXPECTED_SHA) throw new Error(`Unexpected head SHA: ${pull.head.sha}`);
+            if (!pull.labels.some(({ name }) => name === EXPECTED_LABEL)) {
+              throw new Error(`Pull request is missing expected label: ${EXPECTED_LABEL}`);
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            });
+            const allowed = new Set(["go.mod", "go.sum"]);
+            const unexpected = files.filter(({ filename }) => !allowed.has(filename));
+            if (!files.some(({ filename }) => filename === "go.mod")) {
+              throw new Error("Dependency bump did not change go.mod");
+            }
+            if (unexpected.length > 0) {
+              throw new Error(`Unexpected changed files: ${unexpected.map(({ filename }) => filename).join(", ")}`);
+            }
+
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number,
+              commit_id: EXPECTED_SHA,
+              event: "APPROVE",
+              body: "Automated approval: validated dependency-only update.",
+            });
+      - name: Disable auto-merge on superseded pull requests
+        if: ${{ needs.stale-bump-prs.outputs.stale-pulls != '' }}
+        uses: actions/github-script@v7
+        env:
+          STALE_PULLS: ${{ needs.stale-bump-prs.outputs.stale-pulls }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pulls = JSON.parse(process.env.STALE_PULLS);
+
+            for (const { number, keepAlive } of pulls) {
+              if (keepAlive) continue;
+              const { data: pull } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: number,
+              });
+              if (!pull.auto_merge) continue;
+
+              await github.graphql(`
+                mutation($pullRequestId: ID!) {
+                  disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) {
+                    pullRequest { number }
+                  }
+                }
+              `, { pullRequestId: pull.node_id });
+            }
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.bump-commit.outputs.sha }}
+          PR_URL: ${{ steps.latest-pr.outputs.pr_url }}
+        run: gh pr merge "$PR_URL" --auto --squash --match-head-commit "$HEAD_SHA"
 
   comment-on-stale-prs:
     needs: [open-bump-pr, stale-bump-prs]
@@ -183,41 +263,20 @@ jobs:
 
               if (pull.keepAlive) process.exit(0);
 
-              const checkSuiteRes = await github.rest.checks.listSuitesForRef({
+              console.log(`Closing open pr ${pull.number}`);
+              await github.rest.issues.createComment({
+                issue_number: pull.number,
                 owner,
                 repo,
-                ref: pull.headRef,
+                body: `This PR has been superseded by ${SUPERSEDED_BY}`
               });
 
-              if (checkSuiteRes.data) {
-                for (const suite of checkSuiteRes.data.check_suites) {
-                  console.log("suite id:", suite.id);
-                  console.log("suite app slug:", suite.app.slug);
-                  console.log("suite status:", suite.status);
-                  console.log("suite conclusion:", suite.conclusion);
-                  if (suite.app.slug === "github-actions") {
-                     if (suite.status !== "completed" || suite.conclusion !== "success") {
-                       console.log(`Leaving pr open due to status:${suite.status} conclusion${suite.conclusion}`);
-                       process.exit(0);
-                     }
-                  }
-                }
-
-                console.log(`Closing open pr ${pull.number}`);
-                await github.rest.issues.createComment({
-                  issue_number: pull.number,
-                  owner,
-                  repo,
-                  body: `This PR has been superseded by ${SUPERSEDED_BY}`
-                });
-
-                await github.rest.pulls.update({
-                  owner,
-                  repo,
-                  pull_number: pull.number,
-                  state: 'closed',
-                });
-              }
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pull.number,
+                state: 'closed',
+              });
 
               process.exit(0);
             } catch(err) {


### PR DESCRIPTION
Validate generated dependency bump PRs, approve the exact dependency-only commit, and enable squash auto-merge with a head-SHA guard. Disable auto-merge on superseded bumps before closing them, and standardize stale bump cleanup to close immediately unless marked `keep-alive`.