### PR TITLE
fix: clamp MEDIUMINT UNSIGNED wire values to 16777215, not 16777216

### DIFF
--- a/enginetest/queries/type_wire_queries.go
+++ b/enginetest/queries/type_wire_queries.go
@@ -194,6 +194,22 @@ var TypeWireTests = []TypeWireTest{
 		},
 	},
 	{
+		Name: "MEDIUMINT UNSIGNED boundary",
+		SetUpScript: []string{
+			`CREATE TABLE test (pk MEDIUMINT UNSIGNED PRIMARY KEY, v1 MEDIUMINT UNSIGNED);`,
+			`INSERT INTO test VALUES (1, 16777215), (16777214, 8388608), (16777215, 0);`,
+			`UPDATE test SET v1 = v1 + 1 WHERE pk = 16777214;`,
+		},
+		Queries: []string{
+			`SELECT * FROM test ORDER BY pk;`,
+			`SELECT v1, pk FROM test ORDER BY pk DESC;`,
+		},
+		Results: [][]sql.Row{
+			{{"1", "16777215"}, {"16777214", "8388609"}, {"16777215", "0"}},
+			{{"0", "16777215"}, {"8388609", "16777214"}, {"16777215", "1"}},
+		},
+	},
+	{
 		Name: "INT UNSIGNED",
 		SetUpScript: []string{
 			`CREATE TABLE test (pk INT UNSIGNED PRIMARY KEY, v1 INT UNSIGNED);`,

--- a/sql/types/number.go
+++ b/sql/types/number.go
@@ -678,8 +678,8 @@ func (t NumberTypeImpl_) SQLUint24(ctx *sql.Context, dest []byte, v interface{})
 	if err != nil {
 		return nil, err
 	}
-	if num > (1 << 24) {
-		num = uint64((1 << 24))
+	if num > (1<<24 - 1) {
+		num = uint64(1<<24 - 1)
 	}
 	dest = strconv.AppendUint(dest, num, 10)
 

--- a/sql/types/number_test.go
+++ b/sql/types/number_test.go
@@ -2177,3 +2177,27 @@ func TestConvertValueToFloat64(t *testing.T) {
 		})
 	}
 }
+
+func TestNumberSQLUnsignedClamp(t *testing.T) {
+	tests := []struct {
+		typ sql.Type
+		val interface{}
+		exp string
+	}{
+		{Uint8, uint64(math.MaxUint8), "255"},
+		{Uint8, uint64(math.MaxUint8 + 1), "255"},
+		{Uint16, uint64(math.MaxUint16 + 1), "65535"},
+		{Uint24, uint64(1<<24 - 1), "16777215"},
+		{Uint24, uint64(1 << 24), "16777215"},
+		{Uint24, uint64(99999999), "16777215"},
+		{Uint32, uint64(math.MaxUint32 + 1), "4294967295"},
+		{Int24, int64(1 << 23), "8388607"},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s %v", test.typ.String(), test.val), func(t *testing.T) {
+			val, err := test.typ.SQL(sql.NewEmptyContext(), nil, test.val)
+			require.NoError(t, err)
+			assert.Equal(t, test.exp, val.ToString())
+		})
+	}
+}


### PR DESCRIPTION
### Problem

`NumberTypeImpl_.SQLUint24` clamps an over-range value to `16777216`, which is one past the largest value a `MEDIUMINT UNSIGNED` column can hold (`16777215`, `2^24 - 1`).

`sql/types/number.go:681-683`:

```go
	if num > (1 << 24) {
		num = uint64((1 << 24))
	}
```

Both the predicate and the assigned value are off by one: the predicate lets `1 << 24` itself through untouched, and the assignment writes `1 << 24` rather than the type maximum. Every value at or above `16777216` serializes onto the wire as `16777216`.

### Why this is a bug and not a design choice

Your own code already answers this four times over, in the same file:

- your own `SQLInt24` at `sql/types/number.go:618` clamps to `1<<23 - 1`,
- your own `SQLUint8` at `:655` clamps to `math.MaxUint8`,
- your own `SQLUint16` at `:668` clamps to `math.MaxUint16`,
- your own `SQLUint32` at `:694` clamps to `math.MaxUint32`,
- and your own `Convert` at `sql/types/number.go:366-367` already clamps `sqltypes.Uint24` to `uint32(1<<24 - 1)`.

Only `SQLUint24` dropped the `- 1`. Every sibling in the family uses the inclusive maximum.

### Reachability - stated honestly

I could not reach this through SQL, and I want to be explicit about that rather than overstate the impact.

`Convert` rejects out-of-range values before they can be stored, so `INSERT`, `UPDATE`, `ALTER ... MODIFY`, generated columns (`STORED` and `VIRTUAL`), column `DEFAULT`, and stored-procedure locals all clamp correctly at `16777215` on the current `main`. I probed all of those and none of them delivers an over-range value at type `Uint24`.

The path that does reach it is an **integrator's own `sql.Table`**. `SQL()` at `sql/types/number.go:739` dispatches at `:769-770`:

```go
	case sqltypes.Uint24:
		dest, err = t.SQLUint24(ctx, dest, v)
```

on the raw value, without converting first. So for a row that arrives from an integrator's storage layer already in the type's Go representation (`uint32`), this clamp is the last line of defense.

Reproduced with a `memory.NewTable` whose schema declares `mu MEDIUMINT UNSIGNED` (`types.Uint24`) alongside a `types.Uint32` control column, fed raw `uint32` values, queried through `Engine.Query` and serialized with `schema[c].Type.SQL(ctx, nil, row[c])`:

before

```
go=[0 16777215 4294967295]  wire:  mu="16777215"  u32="4294967295"
go=[1 16777216 4294967295]  wire:  mu="16777216"  u32="4294967295"
go=[2 99999999 4294967295]  wire:  mu="16777216"  u32="4294967295"
```

after

```
go=[0 16777215 4294967295]  wire:  mu="16777215"  u32="4294967295"
go=[1 16777216 4294967295]  wire:  mu="16777215"  u32="4294967295"
go=[2 99999999 4294967295]  wire:  mu="16777215"  u32="4294967295"
```

The `u32` control column is unchanged in both runs, which isolates the difference to the `Uint24` branch.

### Fix

```diff
-	if num > (1 << 24) {
-		num = uint64((1 << 24))
+	if num > (1<<24 - 1) {
+		num = uint64(1<<24 - 1)
 	}
```

### Tests

**`sql/types/number_test.go` - `TestNumberSQLUnsignedClamp`** covers the whole unsigned clamp family plus `Int24`, so the four correct siblings pin the behaviour the fixed one now matches. It is red before the change and green after.

**`enginetest/queries/type_wire_queries.go` - `MEDIUMINT UNSIGNED boundary`** is a coverage extension, not a red-green. The existing `MEDIUMINT UNSIGNED` entry tops out at `999999`, roughly sixteen times below the type maximum, and its `DELETE FROM test WHERE pk > "99999";` step makes extending it in place impossible - hence a separate self-contained entry that exercises `16777215`, `16777214`, and an `UPDATE` that lands on `8388609`. Consistent with the reachability note above, this entry passes both before and after the fix.

### Verification

| gate | result |
| --- | --- |
| `./check_repo.sh` (the format gate from `.github/workflows/format.yml`) | pass, worktree unchanged |
| `gofmt -l` on all three changed files | clean |
| `go build -tags=gms_pure_go ./...` | pass |
| `go test -tags=gms_pure_go ./sql/types/ -run TestNumberSQLUnsignedClamp` | pass, 8/8 subtests |
| same test against the unpatched `number.go` | fails on `mediumint_unsigned_16777216` and `mediumint_unsigned_99999999` |
| same test with the clamp over-corrected to `1<<24 - 2` | fails on `16777215`, `16777216`, `99999999` |
| `go test -race -tags=gms_pure_go ./sql/types/` | pass |
| `go test -tags=gms_pure_go ./sql/... -count=1` | 25 packages ok |
| `TestTypesOverWire` (full suite, and the new entry with `-v`) | pass |

Mutation-checked in both directions, so the test brackets the fix rather than merely following it.

Two notes on my local environment, in the interest of full disclosure: I ran the suite with `-tags=gms_pure_go` because `libicu-dev` is not installed here, and under that tag `TestRegexpReplaceWithFlags` fails - it fails identically on an unmodified checkout, and the README says some tests do not pass with that tag. Separately, `TestTypesOverWire` cannot start a listener on this WSL2 host because `server.PortInUse` treats a spuriously successful `net.DialTimeout` to a just-released port as "in use"; I confirmed that on an unmodified checkout too, and ran the wire suite with that probe locally stubbed. Neither observation is touched by this PR.

---

Disclosure: this patch was prepared with AI assistance. I have reviewed and tested it myself, and I am responsible for its correctness.
