### PR TITLE
Remove schema length check when analyzing subquery aliases

### DIFF
--- a/enginetest/queries/view_queries.go
+++ b/enginetest/queries/view_queries.go
@@ -666,6 +666,21 @@ CREATE TABLE tab1 (
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/11501
+		Name: "nested view with self EXISTS subquery",
+		SetUpScript: []string{
+			"CREATE TABLE t__base (c_pk BIGINT NOT NULL, c1 BIGINT);",
+			"INSERT INTO t__base VALUES (1, 10), (2, 20);",
+			"CREATE VIEW t1 AS SELECT c_pk, c1 FROM (SELECT c_pk, c1 FROM t__base) AS eq_ns_1;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT * FROM t1 a WHERE EXISTS (SELECT 1 FROM t1 b WHERE b.c_pk = a.c_pk);",
+				Expected: []sql.Row{{1, 10}, {2, 20}},
+			},
+		},
+	},
 }
 
 var ViewCreateInSubroutineTests = []ScriptTest{

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -313,12 +313,6 @@ func analyzeSubqueryAlias(ctx *sql.Context, a *Analyzer, sqa *plan.SubqueryAlias
 		return nil, same, err
 	}
 
-	if len(sqa.ColumnNames) > 0 {
-		schemaLen := schemaLength(ctx, child)
-		if schemaLen != len(sqa.ColumnNames) {
-			return nil, transform.SameTree, sql.ErrColumnCountMismatch.New()
-		}
-	}
 	if same {
 		return sqa, transform.SameTree, nil
 	}


### PR DESCRIPTION
Fixes dolthub/dolt#11501

When analyzing subquery aliases, checking if the child schema length matched the `ColumnNames` length was too strict. In nested subqueries, it's possible the child schema length was already reduced due to table pruning when the child subquery was analyzed. This check was removed altogether because we don't have any tests that actually rely on this check happening.