### PR TITLE
Reject unsupported DISTINCT window aggregates

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -1875,6 +1875,8 @@ ORDER BY id;`,
 	{
 		// https://github.com/dolthub/dolt/issues/11464
 		Name: "CHAR PAD SPACE values do not split a window partition",
+		// Doltgres uses its own PostgreSQL CHAR type, so this GMS StringType regression is MySQL-only.
+		Dialect: "mysql",
 		SetUpScript: []string{
 			"CREATE TABLE t (id INT PRIMARY KEY, c CHAR(3), v INT)",
 			"INSERT INTO t VALUES (1, 'a', 10), (2, 'a ', 20), (3, 'b', 30)",

--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -1039,6 +1039,38 @@ ORDER BY id;`,
 		Expected: []sql.Row{{1, float64(10)}, {2, float64(30)}},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/11392
+		Name: "customer reproduction: MySQL distinct aggregate window behavior",
+		// PostgreSQL uses a different error and SQLSTATE for DISTINCT aggregate windows.
+		Dialect: "mysql",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:          "SELECT COUNT(DISTINCT v) OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM (SELECT 1 AS id, 1 AS v UNION ALL SELECT 2, 1 UNION ALL SELECT 3, 2) t",
+				ExpectedErrStr: "This version of MySQL doesn't yet support '<window function>(DISTINCT ..)' (errno 1235) (sqlstate 42000)",
+			},
+			{
+				Query:          "SELECT COUNT(DISTINCT v, id) OVER () FROM (SELECT 1 AS id, 1 AS v UNION ALL SELECT 2, 1) t",
+				ExpectedErrStr: "This version of MySQL doesn't yet support '<window function>(DISTINCT ..)' (errno 1235) (sqlstate 42000)",
+			},
+			{
+				Query:          "SELECT SUM(DISTINCT v) OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM (SELECT 1 AS id, 1 AS v UNION ALL SELECT 2, 1 UNION ALL SELECT 3, 2) t",
+				ExpectedErrStr: "This version of MySQL doesn't yet support '<window function>(DISTINCT ..)' (errno 1235) (sqlstate 42000)",
+			},
+			{
+				Query:          "SELECT AVG(DISTINCT v) OVER () FROM (SELECT 1.00 AS v UNION ALL SELECT 1.00 UNION ALL SELECT 4.00) t",
+				ExpectedErrStr: "This version of MySQL doesn't yet support '<window function>(DISTINCT ..)' (errno 1235) (sqlstate 42000)",
+			},
+			{
+				Query:    "SELECT MIN(DISTINCT v) OVER () FROM (SELECT 1 AS v UNION ALL SELECT 2) t",
+				Expected: []sql.Row{{1}, {1}},
+			},
+			{
+				Query:    "SELECT MAX(DISTINCT v) OVER () FROM (SELECT 1 AS v UNION ALL SELECT 2) t",
+				Expected: []sql.Row{{2}, {2}},
+			},
+		},
+	},
+	{
 		// https://github.com/dolthub/dolt/issues/11395
 		Name: "customer reproduction: sibling window aggregates with different frames",
 		SetUpScript: []string{

--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -1041,9 +1041,13 @@ ORDER BY id;`,
 	{
 		// https://github.com/dolthub/dolt/issues/11392
 		Name: "customer reproduction: MySQL distinct aggregate window behavior",
-		// PostgreSQL uses a different error and SQLSTATE for DISTINCT aggregate windows.
+		// PostgreSQL rejects these forms with different errors and SQLSTATEs.
 		Dialect: "mysql",
 		Assertions: []ScriptTestAssertion{
+			{
+				Query:          "SELECT COUNT(DISTINCT *) OVER () FROM (SELECT 1 AS v) t",
+				ExpectedErrStr: "You have an error in your SQL syntax (errno 1064) (sqlstate 42000)",
+			},
 			{
 				Query:          "SELECT COUNT(DISTINCT v) OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM (SELECT 1 AS id, 1 AS v UNION ALL SELECT 2, 1 UNION ALL SELECT 3, 2) t",
 				ExpectedErrStr: "This version of MySQL doesn't yet support '<window function>(DISTINCT ..)' (errno 1235) (sqlstate 42000)",

--- a/sql/overrides.go
+++ b/sql/overrides.go
@@ -67,6 +67,9 @@ type BuilderOverrides struct {
 	Parser Parser
 	// InsertIgnoreMode controls the error-handling semantics for ignored inserts.
 	InsertIgnoreMode InsertIgnoreMode
+	// ValidateDistinctWindow validates DISTINCT window calls that use built-in expressions without their own
+	// DistinctWindowFunctionValidator. When nil, the call is rejected using MySQL-compatible behavior.
+	ValidateDistinctWindow func(schema, name string, expr Expression) error
 }
 
 // InsertIgnoreMode controls which compatibility semantics an ignored insert uses.

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dolthub/vitess/go/mysql"
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -558,6 +557,9 @@ func (b *Builder) buildWindowFunc(inScope *scope, name string, e *ast.FuncExpr, 
 	var win sql.WindowAdaptableExpression
 	if name == "count" {
 		if _, ok := e.Exprs[0].(*ast.StarExpr); ok {
+			if e.Distinct {
+				b.handleErr(errMySQLDistinctStarWindow)
+			}
 			win = aggregation.NewCount(expression.NewLiteral(1, types.Int64))
 			b.qFlags.Set(sql.QFlagCountStar)
 		}
@@ -620,16 +622,11 @@ func (b *Builder) validateDistinctWindow(e *ast.FuncExpr, name string, expr sql.
 		}
 		return
 	}
-	if name == "min" || name == "max" {
+	switch expr.(type) {
+	case *aggregation.Min, *aggregation.Max:
 		return
 	}
-	b.handleErr(mysqlDistinctWindowError())
-}
-
-// mysqlDistinctWindowError returns MySQL's error for unsupported DISTINCT aggregate windows.
-func mysqlDistinctWindowError() error {
-	return mysql.NewSQLError(mysql.ERNotSupportedYet, mysql.SSClientError,
-		"This version of MySQL doesn't yet support '<window function>(DISTINCT ..)'")
+	b.handleErr(errMySQLDistinctWindow)
 }
 
 func (b *Builder) buildWindow(fromScope, projScope *scope) *scope {

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/dolthub/vitess/go/mysql"
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -571,6 +572,10 @@ func (b *Builder) buildWindowFunc(inScope *scope, name string, e *ast.FuncExpr, 
 
 		newInst, err := f.NewInstance(b.ctx, args)
 		if err != nil {
+			// MySQL reports unsupported DISTINCT window syntax before validating COUNT's argument count.
+			if e.Distinct && name == "count" && len(args) > 1 {
+				b.validateDistinctWindow(e, name, aggregation.NewCountDistinct(args...))
+			}
 			b.handleErr(err)
 		}
 		b.validateDistinctWindow(e, name, newInst)
@@ -607,7 +612,24 @@ func (b *Builder) validateDistinctWindow(e *ast.FuncExpr, name string, expr sql.
 		if err := validator.ValidateDistinctWindow(e.Qualifier.String(), name); err != nil {
 			b.handleErr(err)
 		}
+		return
 	}
+	if b.overrides.ValidateDistinctWindow != nil {
+		if err := b.overrides.ValidateDistinctWindow(e.Qualifier.String(), name, expr); err != nil {
+			b.handleErr(err)
+		}
+		return
+	}
+	if name == "min" || name == "max" {
+		return
+	}
+	b.handleErr(mysqlDistinctWindowError())
+}
+
+// mysqlDistinctWindowError returns MySQL's error for unsupported DISTINCT aggregate windows.
+func mysqlDistinctWindowError() error {
+	return mysql.NewSQLError(mysql.ERNotSupportedYet, mysql.SSClientError,
+		"This version of MySQL doesn't yet support '<window function>(DISTINCT ..)'")
 }
 
 func (b *Builder) buildWindow(fromScope, projScope *scope) *scope {

--- a/sql/planbuilder/errors.go
+++ b/sql/planbuilder/errors.go
@@ -15,6 +15,7 @@
 package planbuilder
 
 import (
+	"github.com/dolthub/vitess/go/mysql"
 	"gopkg.in/src-d/go-errors.v1"
 )
 
@@ -36,4 +37,12 @@ var (
 	ErrOrderByBinding = errors.NewKind("bindings in sort clauses not supported yet")
 
 	ErrFailedToParseStats = errors.NewKind("failed to parse data: %s\n%s")
+
+	// errMySQLDistinctWindow is returned for DISTINCT aggregate windows unsupported by MySQL.
+	errMySQLDistinctWindow = mysql.NewSQLError(mysql.ERNotSupportedYet, mysql.SSClientError,
+		"This version of MySQL doesn't yet support '<window function>(DISTINCT ..)'")
+
+	// errMySQLDistinctStarWindow is returned for COUNT(DISTINCT *) windows, which are invalid MySQL syntax.
+	errMySQLDistinctStarWindow = mysql.NewSQLError(mysql.ERParseError, mysql.SSClientError,
+		"You have an error in your SQL syntax")
 )


### PR DESCRIPTION
Rejects `DISTINCT` window aggregates with MySQL 8.4-compatible error 1235 / SQLSTATE 42000 for `COUNT`, `SUM`, and `AVG`, including multi-argument `COUNT`, while preserving accepted `MIN` and `MAX` behavior.

Adds engine coverage for the exact customer reproduction and adjacent aggregate behavior.

Fixes dolthub/dolt#11392