### PR TITLE
[no-release-notes] Scope CHAR padding enginetest to MySQL

### DIFF
--- a/enginetest/queries/window_functions_queries.go
+++ b/enginetest/queries/window_functions_queries.go
@@ -1843,6 +1843,8 @@ ORDER BY id;`,
 	{
 		// https://github.com/dolthub/dolt/issues/11464
 		Name: "CHAR PAD SPACE values do not split a window partition",
+		// Doltgres uses its own PostgreSQL CHAR type, so this GMS StringType regression is MySQL-only.
+		Dialect: "mysql",
 		SetUpScript: []string{
 			"CREATE TABLE t (id INT PRIMARY KEY, c CHAR(3), v INT)",
 			"INSERT INTO t VALUES (1, 'a', 10), (2, 'a ', 20), (3, 'b', 30)",


### PR DESCRIPTION
Mark the `CHAR_PAD_SPACE` window script as MySQL-only. The script exercises GMS `StringType` semantics, while Doltgres owns a PostgreSQL `CHAR` type with different padding behavior.

This prevents the shared GMS suite from imposing MySQL result expectations on Doltgres.