### PR TITLE
Decorrelate inner join subqueries in `EXISTS` subqueries

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4975,7 +4975,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query: `CREATE TABLE test SELECT * FROM t1`,
-				Expected: []sql.Row{sql.Row{types.OkResult{
+				Expected: []sql.Row{{types.OkResult{
 					RowsAffected: 3,
 					InsertID:     0,
 					Info:         nil,
@@ -14838,6 +14838,104 @@ select * from t1 except (
 			{
 				Query:    "SELECT id FROM c ORDER BY id",
 				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		// https://github.com/dolthub/dolt/issues/11771
+		Name: "EXISTS and NOT EXISTS with join and correlated ON clause",
+		SetUpScript: []string{
+			"CREATE TABLE a (id INT PRIMARY KEY)",
+			"CREATE TABLE b (a_id INT, c_id INT)",
+			"CREATE TABLE c (id INT PRIMARY KEY)",
+			"INSERT INTO a VALUES (1), (2)",
+			"INSERT INTO c VALUES (9)",
+			"INSERT INTO b VALUES (1, 9)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT b.a_id, b.c_id FROM b JOIN c ON c.id = b.c_id",
+				Expected: []sql.Row{{1, 9}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE EXISTS (SELECT 1 FROM b JOIN c ON c.id = b.c_id WHERE b.a_id = a.id)",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE EXISTS (SELECT 1 FROM b JOIN c ON c.id = b.c_id AND b.a_id = a.id)",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE NOT EXISTS (SELECT 1 FROM b JOIN c ON c.id = b.c_id WHERE b.a_id = a.id)",
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE NOT EXISTS (SELECT 1 FROM b JOIN c ON c.id = b.c_id AND b.a_id = a.id)",
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE EXISTS (SELECT 1 FROM b LEFT JOIN c ON c.id = b.c_id AND b.a_id = a.id) ORDER BY a.id",
+				Expected: []sql.Row{{1}, {2}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE EXISTS (SELECT 1 FROM b WHERE b.a_id = a.id)",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE EXISTS (SELECT 1 FROM b JOIN c ON b.a_id = a.id) ORDER BY a.id",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE NOT EXISTS (SELECT 1 FROM b JOIN c ON b.a_id = a.id) ORDER BY a.id",
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE EXISTS (SELECT 1 FROM b JOIN c ON c.id = b.c_id AND (b.a_id = a.id OR a.id = 99)) ORDER BY a.id",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE NOT EXISTS (SELECT 1 FROM b JOIN c ON c.id = b.c_id AND (b.a_id = a.id OR a.id = 99)) ORDER BY a.id",
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE EXISTS (SELECT 1 FROM b JOIN c ON c.id = b.c_id AND b.a_id = a.id - 0) ORDER BY a.id",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE EXISTS (SELECT 1 FROM b JOIN c ON c.id = b.c_id AND b.a_id = a.id WHERE a.id > 0) ORDER BY a.id",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE EXISTS (SELECT 1 FROM b JOIN c ON c.id = b.c_id AND b.a_id = a.id WHERE b.c_id = 9) ORDER BY a.id",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE EXISTS (SELECT 1 FROM b JOIN c ON c.id = b.c_id AND b.a_id = a.id WHERE b.c_id = 999) ORDER BY a.id",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT a.id FROM a WHERE EXISTS (SELECT 1 FROM b AS a JOIN c ON c.id = a.c_id AND a.a_id = mydb.a.id) ORDER BY a.id",
+				Expected: []sql.Row{{1}},
+			},
+		},
+	},
+	{
+		Name: "EXISTS with nested inner join on null-supplying side of outer join",
+		SetUpScript: []string{
+			"CREATE TABLE outer_rows (id INT PRIMARY KEY)",
+			"CREATE TABLE left_rows (owner_id INT)",
+			"CREATE TABLE middle (id INT)",
+			"CREATE TABLE right_rows (middle_id INT)",
+			"INSERT INTO outer_rows VALUES (1)",
+			"INSERT INTO left_rows VALUES (1)",
+			"INSERT INTO middle VALUES (7)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT o.id FROM outer_rows o WHERE EXISTS (" +
+					"SELECT 1 FROM left_rows l LEFT JOIN (middle m JOIN right_rows r ON r.middle_id = m.id AND m.id = o.id) ON l.owner_id = o.id" +
+					") ORDER BY o.id",
+				Expected: []sql.Row{{1}},
 			},
 		},
 	},

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -189,7 +189,7 @@ func filterPushdownSelector(ctx *sql.Context, c transform.Context) bool {
 	case *plan.TableAlias:
 		return false
 	case *plan.JoinNode:
-		if (n.Op.IsLeftOuter() || n.Op.IsAnti()) && c.ChildNum != 0 {
+		if !n.Op.IsPreservedTable(c.ChildNum) {
 			return false
 		}
 	}

--- a/sql/analyzer/unnest_exists_subqueries.go
+++ b/sql/analyzer/unnest_exists_subqueries.go
@@ -272,57 +272,55 @@ type hoistSubquery struct {
 	emptyScope  bool
 }
 
-// decorrelateOuterCols returns an optionally modified subquery and extracted filters referencing an outer scope.
-// If the subquery has aliases that conflict with outside aliases, the internal aliases will be renamed to avoid
-// name collisions.
+// decorrelateOuterCols extracts correlated JOIN and WHERE predicates
+// from |sqChild| referencing outer columns in |corr|, returning the
+// rewritten subquery child and extracted filters.
+//
+// If |sqChild| contains aliases conflicting with outside aliases,
+// conflicting aliases in the returned subtree and filters are renamed
+// via |aliasDisambig|.
+//
+// It returns nil and a nil error if decorrelation cannot proceed
+// safely, such as when an offset is encountered.
 func decorrelateOuterCols(ctx *sql.Context, sqChild sql.Node, aliasDisambig *aliasDisambiguator, corr sql.ColSet) (*hoistSubquery, error) {
 	var joinFilters []sql.Expression
 	var filtersToKeep []sql.Expression
 	var emptyScope bool
 	var cantDecorrelate bool
-	n, _, _ := transform.Node(ctx, sqChild, func(ctx *sql.Context, n sql.Node) (sql.Node, transform.TreeIdentity, error) {
+	n, _, _ := transform.NodeWithCtx(ctx, sqChild, decorrelateSelector, func(ctx *sql.Context, c transform.Context) (sql.Node, transform.TreeIdentity, error) {
 		if emptyScope {
-			return n, transform.SameTree, nil
+			return c.Node, transform.SameTree, nil
 		}
-		switch f := n.(type) {
+		switch f := c.Node.(type) {
 		case *plan.Offset:
 			cantDecorrelate = true
-			return n, transform.SameTree, nil
+			return c.Node, transform.SameTree, nil
 		case *plan.EmptyTable:
 			emptyScope = true
-			return n, transform.SameTree, nil
+			return c.Node, transform.SameTree, nil
 		case *plan.Filter:
-			filters := expression.SplitConjunction(ctx, f.Expression)
-			for _, f := range filters {
-				outerRef := transform.InspectExpr(ctx, f, func(ctx *sql.Context, e sql.Expression) bool {
-					if gf, ok := e.(*expression.GetField); ok && corr.Contains(gf.Id()) {
-						return true
-					}
-					if sq, ok := e.(*plan.Subquery); ok {
-						if !sq.Correlated().Intersection(corr).Empty() {
-							return true
-						}
-					}
-					return false
-				})
-
-				// based on the GetField analysis, decide where to put the filter
-				if outerRef {
-					joinFilters = append(joinFilters, f)
-				} else {
-					filtersToKeep = append(filtersToKeep, f)
-				}
-			}
-
-			// avoid updating the tree if we don't move any filters
-			if len(filtersToKeep) == len(filters) {
-				filtersToKeep = nil
+			extracted, keep := decorrelateCondition(ctx, f.Expression, corr)
+			if len(extracted) == 0 {
 				return f, transform.SameTree, nil
 			}
-
+			joinFilters = append(joinFilters, extracted...)
+			filtersToKeep = append(filtersToKeep, keep...)
 			return f.Child, transform.NewTree, nil
+		case *plan.JoinNode:
+			// Outer join conditions cannot be hoisted: hoisting them
+			// turns an optional match into a mandatory filter on
+			// preserved rows, dropping rows that should survive.
+			if !f.JoinType().IsInner() || f.Filter == nil {
+				return c.Node, transform.SameTree, nil
+			}
+			extracted, keep := decorrelateCondition(ctx, f.Filter, corr)
+			if len(extracted) == 0 {
+				return c.Node, transform.SameTree, nil
+			}
+			joinFilters = append(joinFilters, extracted...)
+			return f.WithFilter(expression.JoinAnd(keep...)), transform.NewTree, nil
 		default:
-			return n, transform.SameTree, nil
+			return c.Node, transform.SameTree, nil
 		}
 	})
 
@@ -424,4 +422,51 @@ func decorrelateOuterCols(ctx *sql.Context, sqChild sql.Node, aliasDisambig *ali
 		inner:       n,
 		joinFilters: joinFilters,
 	}, nil
+}
+
+// decorrelateCondition splits |cond| into correlated predicates
+// referencing outer columns in |corr| and uncorrelated predicates that
+// remain in scope.
+//
+// Predicates referencing any column in |corr| or a subquery correlated
+// with |corr| are returned in |correlated|. All remaining predicates
+// are returned in |inScope|.
+func decorrelateCondition(ctx *sql.Context, cond sql.Expression, corr sql.ColSet) (correlated, inScope []sql.Expression) {
+	preds := expression.SplitConjunction(ctx, cond)
+	if corr.Empty() {
+		return nil, preds
+	}
+	correlated = make([]sql.Expression, 0, len(preds))
+	inScope = make([]sql.Expression, 0, len(preds))
+	for _, pred := range preds {
+		// A condition is correlated if it refers to any column from an
+		// outer query outside this subquery.
+		isCorrelated := transform.InspectExpr(ctx, pred, func(ctx *sql.Context, e sql.Expression) bool {
+			if gf, ok := e.(*expression.GetField); ok && corr.Contains(gf.Id()) {
+				return true
+			}
+			if sq, ok := e.(*plan.Subquery); ok {
+				if !sq.Correlated().Intersection(corr).Empty() {
+					return true
+				}
+			}
+			return false
+		})
+		if isCorrelated {
+			correlated = append(correlated, pred)
+		} else {
+			inScope = append(inScope, pred)
+		}
+	}
+	return correlated, inScope
+}
+
+// decorrelateSelector reports whether traversal in |c| should enter
+// child nodes to extract decorrelated join conditions.
+func decorrelateSelector(_ *sql.Context, c transform.Context) bool {
+	jn, ok := c.Parent.(*plan.JoinNode)
+	if !ok {
+		return true
+	}
+	return jn.JoinType().IsPreservedTable(c.ChildNum)
 }

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -100,6 +100,26 @@ func (i JoinType) IsFullOuter() bool {
 	return i == JoinTypeFullOuter
 }
 
+// IsPreservedTable reports whether the table or nest at child index
+// |childNum| is on the preserved side of this join operation.
+// In an outer join, rows from the preserved table are returned even when
+// there is no match in the inner (null-supplied) table, as described in
+// [MySQL Outer Join Simplification].
+//
+// [MySQL Outer Join Simplification]: https://dev.mysql.com/doc/refman/8.4/en/outer-join-simplification.html
+func (i JoinType) IsPreservedTable(childNum int) bool {
+	switch {
+	case i.IsLeftOuter():
+		return childNum == 0
+	case i.IsRightOuter():
+		return childNum == 1
+	case !i.IsInner():
+		return false
+	default:
+		return true
+	}
+}
+
 func (i JoinType) IsPhysical() bool {
 	switch i {
 	case JoinTypeLookup, JoinTypeLeftOuterLookup,


### PR DESCRIPTION
Fix `EXISTS` subqueries containing inner joins nested inside outer joins incorrectly dropped matching rows. Correlated conditions on null-supplying side of an outer join are now preserved in place rather than hoisted.
- Add `(JoinType) IsPreservedTable(childNum int) bool` and unified usage with `filterPushdownSelector`.
- Add `decorrelateSelector` to stop decorrelation traversal from entering null-supplied join branches.
- Add `decorrelateCondition` to decorralate inner join filters alongside `WHERE` filters.
Fix dolthub/dolt#11771