### PR TITLE
Recompute stored generated columns when modifying their definitions

### DIFF
--- a/enginetest/queries/generated_columns.go
+++ b/enginetest/queries/generated_columns.go
@@ -22,6 +22,49 @@ import (
 
 var GeneratedColumnTests = []ScriptTest{
 	{
+		Name: "modify stored generated enum evaluates new expression",
+		SetUpScript: []string{
+			"create table t (id int primary key, z enum('a', 'b') as ('a') stored, w varchar(10) as (concat(z)) stored)",
+			"insert into t (id) values (1)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{Query: "alter table t modify column z enum('b', 'a') as ('a') stored", Expected: []sql.Row{{types.NewOkResult(0)}}},
+			{Query: "select id, z, w from t", Expected: []sql.Row{{1, "a", "a"}}},
+			{Query: "alter table t modify column z enum('b') as ('b') stored", Expected: []sql.Row{{types.NewOkResult(0)}}},
+			{Query: "select id, z, w from t", Expected: []sql.Row{{1, "b", "b"}}},
+		},
+	},
+	{
+		Name: "modify stored generated expression rebuilds rows and indexes",
+		SetUpScript: []string{
+			"create table t (id int primary key, x int, y int, z int as (x + y) stored, index iz (z))",
+			"insert into t (id, x, y) values (1, 2, 3), (2, 10, 20), (3, null, 4)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{Query: "alter table t modify column z int as (x * y) stored", Expected: []sql.Row{{types.NewOkResult(0)}}},
+			{Query: "select id, z, x * y from t order by id", Expected: []sql.Row{{1, 6, 6}, {2, 200, 200}, {3, nil, nil}}},
+			{Query: "select id from t where z = 6", Expected: []sql.Row{{1}}, ExpectedIndexes: []string{"iz"}},
+			{Query: "select id from t where z = 5", Expected: []sql.Row{}, ExpectedIndexes: []string{"iz"}},
+			{Query: "select id from t where z = 200", Expected: []sql.Row{{2}}, ExpectedIndexes: []string{"iz"}},
+			{Query: "select id from t where z = 30", Expected: []sql.Row{}, ExpectedIndexes: []string{"iz"}},
+		},
+	},
+	{
+		Name: "change stored generated expression rebuilds dependent columns",
+		SetUpScript: []string{
+			"create table t (id int primary key, x int, y int, z int as (x + y) stored, w int as (z + 1) stored, v int as (w + 1) virtual, index iz (z), index iw (w))",
+			"insert into t (id, x, y) values (1, 2, 3), (2, 10, 20)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{Query: "alter table t change column z z int as (x * y) stored", Expected: []sql.Row{{types.NewOkResult(0)}}},
+			{Query: "select id, z, w, v from t order by id", Expected: []sql.Row{{1, 6, 7, 8}, {2, 200, 201, 202}}},
+			{Query: "select id from t where z = 6", Expected: []sql.Row{{1}}, ExpectedIndexes: []string{"iz"}},
+			{Query: "select id from t where z = 5", Expected: []sql.Row{}, ExpectedIndexes: []string{"iz"}},
+			{Query: "select id from t where w = 7", Expected: []sql.Row{{1}}, ExpectedIndexes: []string{"iw"}},
+			{Query: "select id from t where w = 6", Expected: []sql.Row{}, ExpectedIndexes: []string{"iw"}},
+		},
+	},
+	{
 		// https://github.com/dolthub/dolt/issues/11388
 		Name:    "empty insert with default and generated columns",
 		Dialect: "mysql",

--- a/sql/rowexec/alter_table_test.go
+++ b/sql/rowexec/alter_table_test.go
@@ -403,6 +403,38 @@ func TestModifyColumnInSchema(t *testing.T) {
 	}
 }
 
+func TestModifyStoredGeneratedColumnProjection(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	field := func(index int, name string) sql.Expression {
+		return expression.NewGetField(index, types.Int64, name, false)
+	}
+	generated := func(left sql.Expression, op string, right sql.Expression) *sql.ColumnDefaultValue {
+		return mustDefault(expression.NewArithmetic(left, right, op), types.Int64, false, true, false)
+	}
+	for _, name := range []string{"resolved", "persisted"} {
+		t.Run(name, func(t *testing.T) {
+			sch := sql.Schema{
+				{Name: "x", Type: types.Int64},
+				{Name: "y", Type: types.Int64},
+				{Name: "z", Type: types.Int64, Generated: generated(field(0, "x"), "+", field(1, "y"))},
+				{Name: "w", Type: types.Int64, Generated: generated(field(2, "z"), "+", expression.NewLiteral(int64(1), types.Int64))},
+			}
+			if name == "persisted" {
+				sch[2].Generated = sql.NewUnresolvedColumnDefaultValue("(x + y)")
+				sch[3].Generated = sql.NewUnresolvedColumnDefaultValue("(z + 1)")
+				sch = resolveGeneratedColumns(ctx, sql.EngineOverrides{}, "mydb", "t", sch)
+				require.True(t, sch[3].Generated.Resolved())
+			}
+			newCol := &sql.Column{Name: "product", Type: types.Int64, Generated: generated(field(0, "x"), "*", field(1, "y"))}
+			_, projections, err := modifyColumnInSchema(ctx, sch, "z", newCol, &sql.ColumnOrder{First: true})
+			require.NoError(t, err)
+			row, err := ProjectRow(ctx, projections, sql.Row{int64(2), int64(3), int64(5), int64(6)})
+			require.NoError(t, err)
+			require.Equal(t, sql.Row{int64(6), int64(2), int64(3), int64(7)}, row)
+		})
+	}
+}
+
 // mustDefault enforces that no error occurred when constructing the column default value.
 func mustDefault(expr sql.Expression, outType sql.Type, representsLiteral bool, parenthesized bool, mayReturnNil bool) *sql.ColumnDefaultValue {
 	colDef, err := sql.NewColumnDefaultValue(expr, outType, representsLiteral, parenthesized, mayReturnNil)

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -645,7 +645,11 @@ func (i *modifyColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTabl
 	oldPkSchema := sql.SchemaToPrimaryKeySchema(ctx, rwt, rwt.Schema(ctx))
 	newPkSchema := sql.SchemaToPrimaryKeySchema(ctx, rwt, newSch, renames...)
 
-	rewriteRequired := false
+	// Modifying a stored generated column can change its expression without changing
+	// its type. Recompute its values and rebuild indexes even if the storage engine
+	// would otherwise consider this a schema-only change.
+	recomputeGenerated := oldCol.Generated != nil && !oldCol.Virtual && newCol.Generated != nil && !newCol.Virtual
+	rewriteRequired := recomputeGenerated
 	if oldCol.Nullable && !newCol.Nullable {
 		rewriteRequired = true
 	}
@@ -685,7 +689,7 @@ func (i *modifyColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTabl
 		}
 
 		// remap old enum values to new enum values
-		if isOldEnum && isNewEnum && r[oldColIdx] != nil {
+		if isOldEnum && isNewEnum && !recomputeGenerated && r[oldColIdx] != nil {
 			oldIdx := int(r[oldColIdx].(uint16))
 			// 0 values in enums are error values. They are preserved during remapping.
 			if oldIdx != 0 {
@@ -738,6 +742,7 @@ func modifyColumnInSchema(ctx *sql.Context, schema sql.Schema, name string, colu
 		// Should be checked in the analyzer already
 		return nil, nil, sql.ErrTableColumnNotFound.New(column.Source, name)
 	}
+	recomputeGenerated := schema[currIdx].Generated != nil && !schema[currIdx].Virtual && column.Generated != nil && !column.Virtual
 
 	// Primary key-ness isn't included in the column description as part of the ALTER statement, preserve it
 	if schema[currIdx].PrimaryKey {
@@ -809,7 +814,12 @@ func modifyColumnInSchema(ctx *sql.Context, schema sql.Schema, name string, colu
 		if newSchemaIdx == -1 {
 			return nil, transform.SameTree, sql.ErrColumnNotFound.New(colName)
 		}
-		return expression.NewGetFieldWithTable(newSchemaIdx, int(gf.TableId()), gf.Type(ctx), gf.Database(), gf.Table(), colName, gf.IsNullable(ctx)), transform.NewTree, nil
+		fieldType, nullable := gf.Type(ctx), gf.IsNullable(ctx)
+		if recomputeGenerated {
+			// Regenerated values have the new type, including any new ENUM ordinals.
+			fieldType, nullable = newSch[newSchemaIdx].Type, newSch[newSchemaIdx].Nullable
+		}
+		return expression.NewGetFieldWithTable(newSchemaIdx, int(gf.TableId()), fieldType, gf.Database(), gf.Table(), colName, nullable), transform.NewTree, nil
 	}
 	for i := range newSch {
 		newCol := newSch[oldToNewIdxMapping[i]]
@@ -838,6 +848,10 @@ func modifyColumnInSchema(ctx *sql.Context, schema sql.Schema, name string, colu
 			}
 
 			newCol.Generated = newGenerated.(*sql.ColumnDefaultValue)
+			if recomputeGenerated {
+				// Dependent generated columns must use the newly computed values too.
+				projections[oldToNewIdxMapping[i]] = newCol.Generated
+			}
 		}
 	}
 
@@ -1709,13 +1723,13 @@ func (i *addColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) 
 }
 
 // resolveGeneratedColumns resolves any not-yet-resolved generated column expressions for
-// virtual columns in |schema|, so that a table rewrite (see getColumnExpression) can evaluate
-// them. A virtual column's expression may still be an *sql.UnresolvedColumnDefault placeholder
+// columns in |schema|, so that a table rewrite can evaluate them. A generated
+// column's expression may still be an *sql.UnresolvedColumnDefault placeholder
 // (parsed from persisted metadata rather than a bound expression tree) at this point. Returns
 // |schema| unmodified if nothing needs resolving.
 func resolveGeneratedColumns(ctx *sql.Context, overrides sql.EngineOverrides, dbName, tableName string, schema sql.Schema) sql.Schema {
 	for _, col := range schema {
-		if col.Virtual && col.Generated != nil && !col.Generated.Resolved() {
+		if col.Generated != nil && !col.Generated.Resolved() {
 			b := planbuilder.NewBuilderForColumnDefaultResolution(ctx, overrides)
 			return b.ResolveSchemaDefaults(dbName, tableName, schema)
 		}


### PR DESCRIPTION
Fixes dolthub/dolt#11781.

Changing a STORED generated column's expression through `MODIFY COLUMN` or `CHANGE COLUMN` could update the schema while leaving existing values and secondary indexes computed from the old expression. Require a table rewrite for STORED-to-STORED modifications and project the new generated expressions, including dependent generated columns, instead of copying their stored values.

Resolve persisted generated expressions before rewriting. When an ENUM definition changes, evaluate the new expression without remapping the obsolete stored value, and bind dependent expressions to the new field types. This preserves the meaning of ENUM values when their ordinals change.

Regression coverage includes MODIFY and CHANGE, old/new index lookups, NULL inputs, dependent stored/virtual columns, renamed/reordered projections, persisted expressions, and ENUM label reordering/removal. The new regressions failed before their corresponding fixes.

Validation on macOS arm64 with ICU:
- `go test ./sql/rowexec -count=1`
- `go test ./enginetest -run '^Test(ModifyColumn|AddColumn|DropColumn|RenameColumn|ColumnDefaults|GeneratedColumns)$' -count=1`
- Dolt `go test ./libraries/doltcore/sqle/enginetest -run '^TestGeneratedColumns/(modify_stored_generated|change_stored_generated)' -count=1`: all three new scripts pass with this checkout supplied through a temporary Go workspace (no committed dependency changes).

STORED-to-STORED modifications conservatively rewrite even when their definitions are equivalent. Dolt will need a dependency update to consume this engine fix.

Implemented and independently reviewed with OpenAI Codex (GPT-6 Astra, high reasoning).
